### PR TITLE
Added Endpoints For External Identity Providers

### DIFF
--- a/EshopApp.AuthLibrary/UserLogic/AuthenticationProcedures.cs
+++ b/EshopApp.AuthLibrary/UserLogic/AuthenticationProcedures.cs
@@ -60,13 +60,13 @@ public class AuthenticationProcedures : IAuthenticationProcedures
         }
         catch (Exception ex)
         {
-            _logger.LogError(new EventId(4201, "CurrentUserCouldNotBeRetrieved"), ex, "An error occurred while retrieving logged in user. " +
+            _logger.LogError(new EventId(4200, "CurrentUserCouldNotBeRetrieved"), ex, "An error occurred while retrieving logged in user. " +
                 "ExceptionMessage: {ExceptionMessage}. StackTrace: {StackTrace}.", ex.Message, ex.StackTrace);
             throw;
         }
     }
 
-    public async Task<AppUser?> FindByUserIdAsync(string userId)
+    private async Task<AppUser?> FindByUserIdAsync(string userId)
     {
         try
         {
@@ -75,13 +75,13 @@ public class AuthenticationProcedures : IAuthenticationProcedures
         catch (Exception ex)
         {
 
-            _logger.LogError(new EventId(4202, "UserRetrievalByIdFailure"), ex, "An error occurred while retrieving user with id: {UserId}. " +
+            _logger.LogError(new EventId(4201, "UserRetrievalByIdFailure"), ex, "An error occurred while retrieving user with id: {UserId}. " +
                 "ExceptionMessage: {ExceptionMessage}. StackTrace: {StackTrace}.", userId, ex.Message, ex.StackTrace);
             throw;
         }
     }
 
-    public async Task<AppUser?> FindByEmailAsync(string email)
+    private async Task<AppUser?> FindByEmailAsync(string email)
     {
         try
         {
@@ -89,7 +89,7 @@ public class AuthenticationProcedures : IAuthenticationProcedures
         }
         catch (Exception ex)
         {
-            _logger.LogError(new EventId(4203, "UserRetrievalByEmailFailure"), ex, "An error occurred while retrieving user with email: {Email}. " +
+            _logger.LogError(new EventId(4202, "UserRetrievalByEmailFailure"), ex, "An error occurred while retrieving user with email: {Email}. " +
                 "ExceptionMessage {ExceptionMessage}. StackTrace: {StackTrace}.", email, ex.Message, ex.StackTrace);
             throw;
         }
@@ -102,7 +102,7 @@ public class AuthenticationProcedures : IAuthenticationProcedures
             AppUser? appUser = await FindByEmailAsync(email);
             if (appUser is not null)
             {
-                _logger.LogWarning(new EventId(2208, "SignUpFailureDueToDuplicateEmail"), "Another user has the given email and thus the signup process can not proceed. Email={Email}.", email);
+                _logger.LogWarning(new EventId(3200, "SignUpFailureDueToDuplicateEmail"), "Another user has the given email and thus the signup process can not proceed. Email={Email}.", email);
                 return new LibSignUpResponseModel(null!, null!, LibraryReturnedCodes.DuplicateEmail);
             }
 
@@ -121,7 +121,7 @@ public class AuthenticationProcedures : IAuthenticationProcedures
             var result = await _userManager.CreateAsync(appUser, password);
             if (!result.Succeeded)
             {
-                _logger.LogWarning(new EventId(2200, "UserRegistrationFailureUnkownError"), "An error occurred while creating user account, but an exception was not thrown. Email: {Email}, Errors: {Errors}.", 
+                _logger.LogWarning(new EventId(3201, "UserRegistrationFailureUnkownError"), "An error occurred while creating user account, but an exception was not thrown. Email: {Email}, Errors: {Errors}.", 
                     appUser.Email, result.Errors);
                 return new LibSignUpResponseModel(null!, null!, LibraryReturnedCodes.UnknownError);
             }
@@ -147,7 +147,7 @@ public class AuthenticationProcedures : IAuthenticationProcedures
             var user = await _userManager.FindByIdAsync(userId);
             if (user is null)
             {
-                _logger.LogWarning(new EventId(3200, "EmailConfirmationFailureDueToNullUser"), "Tried to confirm email of null user: " +
+                _logger.LogWarning(new EventId(3202, "EmailConfirmationFailureDueToNullUser"), "Tried to confirm email of null user: " +
                     "UserId={UserId}, ConfirmationToken={ConfirmationToken}.", userId, confirmationToken);
                 return new ReturnCodeAndTokenResponseModel(null!, LibraryReturnedCodes.UserNotFoundWithGivenId);
             }
@@ -155,7 +155,7 @@ public class AuthenticationProcedures : IAuthenticationProcedures
             var result = await _userManager.ConfirmEmailAsync(user, confirmationToken);
             if (!result.Succeeded)
             {
-                _logger.LogWarning(new EventId(3201, "EmailConfirmationFailureNoException"), "Email of user could not be confirmed: " +
+                _logger.LogWarning(new EventId(3203, "EmailConfirmationFailureNoException"), "Email of user could not be confirmed: " +
                     "UserId={UserId}, ConfirmationToken={ConfirmationToken}. Errors={Errors}.", userId, confirmationToken, result.Errors);
                 return new ReturnCodeAndTokenResponseModel(null!, LibraryReturnedCodes.UnknownError);
             }
@@ -184,7 +184,7 @@ public class AuthenticationProcedures : IAuthenticationProcedures
             AppUser? appUser = await GetCurrentUserByToken(accessToken);
             if (appUser is null)
             {
-                _logger.LogWarning(new EventId(2208, "EmailChangeTokenCreationFailureDueToValidTokenButUserNotInSystem"), "The token was valid, but it does not correspond to any user in the system and thus the process of changing" +
+                _logger.LogWarning(new EventId(3204, "EmailChangeTokenCreationFailureDueToValidTokenButUserNotInSystem"), "The token was valid, but it does not correspond to any user in the system and thus the process of changing" +
                     " password could not proceed. AccessToken={AccessToken}", accessToken);
                 return LibraryReturnedCodes.ValidTokenButUserNotInSystem;
             }
@@ -200,7 +200,7 @@ public class AuthenticationProcedures : IAuthenticationProcedures
                 return LibraryReturnedCodes.PasswordMissmatch;
             else if (!result.Succeeded)
             {
-                _logger.LogWarning(new EventId(3202, "PasswordChangeFailureNoException"), "Password could not be changed: " +
+                _logger.LogWarning(new EventId(3205, "PasswordChangeFailureNoException"), "Password could not be changed: " +
                     "UserId={UserId}, Email={Email}, Username={Username}. Errors={Errors}.", appUser.Id, appUser.Email, appUser.UserName, result.Errors);
                 return LibraryReturnedCodes.UnknownError;
             }
@@ -224,27 +224,27 @@ public class AuthenticationProcedures : IAuthenticationProcedures
             AppUser? user = await FindByEmailAsync(email);
             if (user is null)
             {
-                _logger.LogWarning(new EventId(3200, "SignInFailureDueToNullUser"), "Tried to sign in null user: Email={Email}.", email);
+                _logger.LogWarning(new EventId(3206, "SignInFailureDueToNullUser"), "Tried to sign in null user: Email={Email}.", email);
                 return new ReturnCodeAndTokenResponseModel(null!, LibraryReturnedCodes.UserNotFoundWithGivenEmail);
             }
 
             bool isLockedOut = await _userManager.IsLockedOutAsync(user);
             if (isLockedOut)
             {
-                _logger.LogWarning(new EventId(3200, "SignInFailureDueToAccountLock"), "User with locked account tried to sign in: Email={Email}.", email);
+                _logger.LogWarning(new EventId(3207, "SignInFailureDueToAccountLock"), "User with locked account tried to sign in: Email={Email}.", email);
                 return new ReturnCodeAndTokenResponseModel(null!, LibraryReturnedCodes.UserAccountLocked);
             }
 
             if (!user.EmailConfirmed)
             {
-                _logger.LogWarning(new EventId(3200, "SignInFailureDueToUnconfirmedEmail"), "User with unconfirmed email tried to sign in: Email={Email}.", email);
+                _logger.LogWarning(new EventId(3208, "SignInFailureDueToUnconfirmedEmail"), "User with unconfirmed email tried to sign in: Email={Email}.", email);
                 return new ReturnCodeAndTokenResponseModel(null!, LibraryReturnedCodes.UserAccountNotActivated);
             }
 
             var result = await _userManager.CheckPasswordAsync(user!, password)!;
             if (!result)
             {
-                _logger.LogWarning(new EventId(3203, "UserSignInFailureDueToInvalidCredentials"), "User could not be signed in, because of invalid credentials. Email={Email}.", email);
+                _logger.LogWarning(new EventId(3209, "UserSignInFailureDueToInvalidCredentials"), "User could not be signed in, because of invalid credentials. Email={Email}.", email);
                 return new ReturnCodeAndTokenResponseModel(null!, LibraryReturnedCodes.InvalidCredentials);
             }
 
@@ -276,7 +276,7 @@ public class AuthenticationProcedures : IAuthenticationProcedures
         }
     }
 
-    public AuthenticationProperties GetExternalIdentityProvidersPropertiesAsync(string identityProviderName, string redirectUrl)
+    public AuthenticationProperties GetExternalIdentityProvidersProperties(string identityProviderName, string redirectUrl)
     {
         try
         {
@@ -292,7 +292,7 @@ public class AuthenticationProcedures : IAuthenticationProcedures
         }
     }
 
-    public async Task<ReturnCodeAndTokenResponseModel> ExternalSignInUserAsync()
+    public async Task<ReturnCodeAndTokenResponseModel> HandleExternalSignInCallbackAsync()
     {
         try
         {
@@ -300,7 +300,7 @@ public class AuthenticationProcedures : IAuthenticationProcedures
             string? accessToken = null;
             if (loginInfo is null)
             {
-                _logger.LogWarning(new EventId(4207, "ExternalSignInFailureDueToNullLoginInfo"), "login info of external identity provider was not received.");
+                _logger.LogWarning(new EventId(3210, "ExternalSignInFailureDueToNullLoginInfo"), "login info of external identity provider was not received.");
                 return new ReturnCodeAndTokenResponseModel(null!, LibraryReturnedCodes.LoginInfoNotReceivedFromIdentityProvider);
             }
 
@@ -309,7 +309,7 @@ public class AuthenticationProcedures : IAuthenticationProcedures
             //if the returned information does not contain email give up
             if (email is null)
             {
-                _logger.LogWarning(new EventId(4207, "ExternalSignInFailureBecauseEmailClaimIsMissing"), "Sign in faulre, because the email claim of the user was not received from the external identity provider.");
+                _logger.LogWarning(new EventId(3211, "ExternalSignInFailureBecauseEmailClaimIsMissing"), "Sign in faulre, because the email claim of the user was not received from the external identity provider.");
                 return new ReturnCodeAndTokenResponseModel(null!, LibraryReturnedCodes.EmailClaimNotReceivedFromIdentityProvider);
             }
 
@@ -354,72 +354,40 @@ public class AuthenticationProcedures : IAuthenticationProcedures
         }
         catch (Exception ex)
         {
-            _logger.LogError(new EventId(4207, "ExternalUserSignFailure"), ex, "An error occurred while trying to sign in the user with external identity provider. " +
+            _logger.LogError(new EventId(4210, "ExternalUserSignFailure"), ex, "An error occurred while trying to sign in the user with external identity provider. " +
                 "ExceptionMessage: {ExceptionMessage}. StackTrace: {StackTrace}.", ex.Message, ex.StackTrace);
             throw;
         }
     }
 
-    public async Task<bool> UpdateAccountAsync(AppUser appUser)
-    {
-        try
-        {
-            //here make sure that email and email are the same
-            var result = await _userManager.UpdateAsync(appUser);
-            if (!result.Succeeded)
-                _logger.LogWarning(new EventId(3204, "UserInformationUpdateFailureNoException"), "User account information could not be updated. " +
-                    "UserId={UserId}, Email={Email}. Errors={Errors}.", appUser.Id, appUser.Email, result.Errors);
-            else
-                _logger.LogInformation(new EventId(2204, "UserRetrievalError"), "Successfully updated user account information. UserId={UserId}, Email={Email}.",
-                    appUser.Id, appUser.Email);
-            return result.Succeeded;
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(new EventId(4208, "UserInformationUpdateFailure"), ex, "An error occurred while trying update the users account information. " +
-                "UserId: {UserId}, Email: {Email}, Username: {Username}. " +
-                "ExceptionMessage: {ExceptionMessage}. StackTrace: {StackTrace}."
-                , appUser.Id, appUser.Email, appUser.UserName, ex.Message, ex.StackTrace);
-            throw;
-        }
-    }
-
-    public async Task<LibraryReturnedCodes> DeleteAccountAsync(string userId, string accessToken)
+    public async Task<LibraryReturnedCodes> DeleteAccountAsync(string accessToken)
     {
         try
         {
             AppUser? appUser = await GetCurrentUserByToken(accessToken);
             if (appUser is null)
             {
-                _logger.LogWarning(new EventId(2208, "DeleteAccountFailureDueToValidTokenButUserNotInSystem"), "The token was valid, but it does not correspond to any user in the system and thus the process of deleting account. " +
-                    "UserId={UserId}, AccessToken={AccessToken}.", userId, accessToken);
+                _logger.LogWarning(new EventId(3212, "DeleteAccountFailureDueToValidTokenButUserNotInSystem"), "The token was valid, but it does not correspond to any user in the system and thus the process of deleting account. " +
+                    "AccessToken={AccessToken}.", accessToken);
                 return LibraryReturnedCodes.ValidTokenButUserNotInSystem;
-            }
-
-            AppUser? user = await FindByUserIdAsync(userId);
-            if (user is null || appUser.Id != user.Id)
-            {
-                _logger.LogWarning(new EventId(2208, "DeleteAccountFailureDueToUserNotOwningTheAccountWithGivenId"),"The account could not be deleted, because the user, who sent the request, does not own the account with the given id. " +
-                    "UserId={UserId}, AccessToken={AccessToken}.", userId, accessToken);
-                return LibraryReturnedCodes.UserDoesNotOwnGivenAccount;
             }
 
             var result = await _userManager.DeleteAsync(appUser);
             if (!result.Succeeded)
             {
-                _logger.LogWarning(new EventId(3205, "UserDeletionFailureNoException"), "User account could not be deleted, but no exception was thrown. " +
-                "UserId={UserId}, AccessToken={AccessToken}, Email={Email}. Errors={Errors}.", userId, accessToken, appUser.Email, result.Errors);
+                _logger.LogWarning(new EventId(3213, "UserDeletionFailureNoException"), "User account could not be deleted, but no exception was thrown. " +
+                "AccessToken={AccessToken}, Email={Email}. Errors={Errors}.", accessToken, appUser.Email, result.Errors);
                 return LibraryReturnedCodes.UnknownError;
             }
 
-            _logger.LogInformation(new EventId(2205, "UserDeletionSuccess"), "Successfully deleted user account. UserId={UserId}, AccessToken={AccessToken}, Email={Email}", userId, accessToken, appUser.Email);
+            _logger.LogInformation(new EventId(2207, "UserDeletionSuccess"), "Successfully deleted user account. AccessToken={AccessToken}, Email={Email}", accessToken, appUser.Email);
 
             return LibraryReturnedCodes.NoError;
         }
         catch (Exception ex)
         {
-            _logger.LogError(new EventId(4209, "UserDeletionFailure"), ex, "An error occurred while trying to delete the user account. " +
-                "UserId={UserId}, AccessToken={AccessToken}. ExceptionMessage: {ExceptionMessage}. StackTrace: {StackTrace}.", userId, accessToken, ex.Message, ex.StackTrace);
+            _logger.LogError(new EventId(4211, "UserDeletionFailure"), ex, "An error occurred while trying to delete the user account. " +
+                "AccessToken={AccessToken}. ExceptionMessage: {ExceptionMessage}. StackTrace: {StackTrace}.", accessToken, ex.Message, ex.StackTrace);
             throw;
         }
     }
@@ -432,12 +400,18 @@ public class AuthenticationProcedures : IAuthenticationProcedures
 
             if (appUser is null)
             {
-                _logger.LogWarning(new EventId(3200, "UserResetTokenCreationFailureDueToNullUser"), "Tried to create reset password token for null user: Email={Email}.", email);
+                _logger.LogWarning(new EventId(3214, "UserResetTokenCreationFailureDueToNullUser"), "Tried to create reset password token for null user: Email={Email}.", email);
                 return new ReturnCodeAndTokenResponseModel(null!, LibraryReturnedCodes.UserNotFoundWithGivenEmail);
             }
 
+            if (!appUser.EmailConfirmed)
+            {
+                _logger.LogWarning(new EventId(3215, "UserResetTokenFailureDueToUnconfirmedEmail"), "User with unconfirmed email tried to create reset token password: Email={Email}.", email);
+                return new ReturnCodeAndTokenResponseModel(null!, LibraryReturnedCodes.UserAccountNotActivated);
+            }
+
             string passwordResetToken = await _userManager.GeneratePasswordResetTokenAsync(appUser);
-            _logger.LogInformation(new EventId(2206, "UserResetTokenCreationSuccess"), "Successfully created password reset token. " +
+            _logger.LogInformation(new EventId(2208, "UserResetTokenCreationSuccess"), "Successfully created password reset token. " +
                     "UserId={UserId}, Email={Email}, Username={Username}.",
                     appUser.Id, appUser.Email, appUser.UserName);
 
@@ -445,7 +419,7 @@ public class AuthenticationProcedures : IAuthenticationProcedures
         }
         catch (Exception ex)
         {
-            _logger.LogError(new EventId(4210, "UserResetTokenCreationFailure"), ex, "An error occurred while trying to create reset account password token. " +
+            _logger.LogError(new EventId(4212, "UserResetTokenCreationFailure"), ex, "An error occurred while trying to create reset account password token. " +
                 "Email: {Email}. ExceptionMessage: {ExceptionMessage}. StackTrace: {StackTrace}.", email, ex.Message, ex.StackTrace);
             throw;
         }
@@ -458,23 +432,29 @@ public class AuthenticationProcedures : IAuthenticationProcedures
             var user = await _userManager.FindByIdAsync(userId);
             if (user is null)
             {
-                _logger.LogWarning(new EventId(3206, "UserPasswordResetFailureDueToNullUser"), "Tried to reset account password of null user: " +
+                _logger.LogWarning(new EventId(3216, "UserPasswordResetFailureDueToNullUser"), "Tried to reset account password of null user: " +
                     "UserId={UserId}, ResetPasswordToken={ResetPasswordToken}.", userId, resetPasswordToken);
                 return new ReturnCodeAndTokenResponseModel(null!, LibraryReturnedCodes.UserNotFoundWithGivenId);
+            }
+
+            if (!user.EmailConfirmed)
+            {
+                _logger.LogWarning(new EventId(3217, "ResetPasswordFailureDueToUnconfirmedEmail"), "User with unconfirmed email tried to reset their password: UserId={UserId}.", userId);
+                return new ReturnCodeAndTokenResponseModel(null!, LibraryReturnedCodes.UserAccountNotActivated);
             }
 
             var result = await _userManager.ResetPasswordAsync(user, resetPasswordToken, newPassword);
 
             if (!result.Succeeded)
             {
-                _logger.LogWarning(new EventId(3207, "UserPasswordResetFailureNoException"), "User account password could not be reset. " +
+                _logger.LogWarning(new EventId(3218, "UserPasswordResetFailureNoException"), "User account password could not be reset. " +
                     "UserId={UserId}, ResetPasswordToken={ResetPasswordToken}. " +
                     "Errors={Errors}.", userId, resetPasswordToken, result.Errors);
                 return new ReturnCodeAndTokenResponseModel(null!, LibraryReturnedCodes.UnknownError);
             }
 
             string accessToken = GenerateToken(user);
-            _logger.LogInformation(new EventId(2207, "UserPasswordResetSuccess"), "Successfully reset account password. " +
+            _logger.LogInformation(new EventId(2209, "UserPasswordResetSuccess"), "Successfully reset account password. " +
                     "UserId={UserId}, ResetPasswordToken={ResetPasswordToken}.",
                     userId, resetPasswordToken);
 
@@ -482,7 +462,7 @@ public class AuthenticationProcedures : IAuthenticationProcedures
         }
         catch (Exception ex)
         {
-            _logger.LogError(new EventId(4211, "UserPasswordResetFailure"), ex, "An error occurred while trying reset user's account password. " +
+            _logger.LogError(new EventId(4213, "UserPasswordResetFailure"), ex, "An error occurred while trying reset user's account password. " +
                 "UserId: {UserId}. ExceptionMessage: {ExceptionMessage}. StackTrace: {StackTrace}."
                 , userId, ex.Message, ex.StackTrace);
             throw;
@@ -496,7 +476,7 @@ public class AuthenticationProcedures : IAuthenticationProcedures
             AppUser? appUser = await GetCurrentUserByToken(accessToken);
             if (appUser is null)
             { 
-                _logger.LogWarning(new EventId(2208, "EmailChangeTokenCreationFailureDueToValidTokenButUserNotInSystem"), "The token was valid, but it does not correspond to any user in the system and thus the process of creating " +
+                _logger.LogWarning(new EventId(3219, "EmailChangeTokenCreationFailureDueToValidTokenButUserNotInSystem"), "The token was valid, but it does not correspond to any user in the system and thus the process of creating " +
                     "the email change token could not be completed. Token={Token}, NewEmail={NewEmail}.", accessToken, newEmail);
                 return new ReturnCodeAndTokenResponseModel(null!, LibraryReturnedCodes.ValidTokenButUserNotInSystem);
             }
@@ -504,13 +484,13 @@ public class AuthenticationProcedures : IAuthenticationProcedures
             AppUser? otherUser = await FindByEmailAsync(newEmail!);
             if (otherUser is not null)
             {
-                _logger.LogWarning(new EventId(2208, "EmailChangeTokenCreationFailureDueToDuplicateEmail"), "Another user has the given new email and thus the process of creating email change token could not be completed. " +
+                _logger.LogWarning(new EventId(3220, "EmailChangeTokenCreationFailureDueToDuplicateEmail"), "Another user has the given new email and thus the process of creating email change token could not be completed. " +
                     "Token={Token}, NewEmail={NewEmail}.", accessToken, newEmail);
                 return new ReturnCodeAndTokenResponseModel(null!, LibraryReturnedCodes.DuplicateEmail);
             }
 
             string emailChangeToken = await _userManager.GenerateChangeEmailTokenAsync(appUser, newEmail);
-            _logger.LogInformation(new EventId(2208, "EmailChangeTokenCreationSuccess"), "Successfully created email change token. " +
+            _logger.LogInformation(new EventId(2210, "EmailChangeTokenCreationSuccess"), "Successfully created email change token. " +
                     "UserId={UserId}, Email={Email}, NewEmail={NewEmail}.",
                     appUser.Id, appUser.Email, newEmail);
 
@@ -518,7 +498,7 @@ public class AuthenticationProcedures : IAuthenticationProcedures
         }
         catch (Exception ex)
         {
-            _logger.LogError(new EventId(4212, "EmailChangeTokenCreationFailure"), ex, "An error occurred while trying to create account email reset token. " +
+            _logger.LogError(new EventId(4214, "EmailChangeTokenCreationFailure"), ex, "An error occurred while trying to create account email reset token. " +
                 "Token:{token}. ExceptionMessage: {ExceptionMessage}. StackTrace: {StackTrace}.", accessToken, ex.Message, ex.StackTrace);
             throw;
         }
@@ -537,7 +517,7 @@ public class AuthenticationProcedures : IAuthenticationProcedures
                 var user = await _userManager.FindByIdAsync(userId);
                 if (user is null)
                 {
-                    _logger.LogWarning(new EventId(3208, "UserEmailChangeFailureDueToNullUser"),
+                    _logger.LogWarning(new EventId(3221, "UserEmailChangeFailureDueToNullUser"),
                         "Tried to change account email of null user: UserId={UserId}, ChangeEmailToken={ChangeEmailToken}, NewEmail={NewEmail}.",
                         userId, changeEmailToken, newEmail);
                     return new ReturnCodeAndTokenResponseModel(null!, LibraryReturnedCodes.UserNotFoundWithGivenId);
@@ -546,7 +526,7 @@ public class AuthenticationProcedures : IAuthenticationProcedures
                 AppUser? otherUser = await FindByEmailAsync(newEmail!);
                 if (otherUser is not null)
                 {
-                    _logger.LogWarning(new EventId(2208, "EmailChangeFailureDueToDuplicateEmail"),
+                    _logger.LogWarning(new EventId(3222, "EmailChangeFailureDueToDuplicateEmail"),
                         "Another user has the given new email and thus the process of changing the email of the account could not be completed. " +
                         "UserId={UserId}, ChangeEmailToken={ChangeEmailToken}, NewEmail={NewEmail}.",
                         userId, changeEmailToken, newEmail);
@@ -556,7 +536,7 @@ public class AuthenticationProcedures : IAuthenticationProcedures
                 var emailChangeResult = await _userManager.ChangeEmailAsync(user, newEmail, changeEmailToken);
                 if (!emailChangeResult.Succeeded)
                 {
-                    _logger.LogWarning(new EventId(3209, "UserEmailChangeFailureDueToInvalidTokenEmailCombination"),
+                    _logger.LogWarning(new EventId(3223, "UserEmailChangeFailureDueToInvalidTokenEmailCombination"),
                         "Tried to change email of user, but the token and the new email combination seems to be invalid: " +
                         "UserId={UserId}, ChangeEmailToken={ChangeEmailToken}, NewEmail={NewEmail}.",
                         userId, changeEmailToken, newEmail);
@@ -567,7 +547,7 @@ public class AuthenticationProcedures : IAuthenticationProcedures
                 var updateUsernameResult = await _userManager.UpdateAsync(user);
                 if (!updateUsernameResult.Succeeded)
                 {
-                    _logger.LogWarning(new EventId(3210, "UnknownError"),
+                    _logger.LogWarning(new EventId(3224, "UnknownError"),
                         "Tried to change username to much email field, but something went wrong, so there needs to be a rollback: " +
                         "UserId={UserId}, ChangeEmailToken={ChangeEmailToken}, NewEmail={NewEmail}.",
                         userId, changeEmailToken, newEmail);
@@ -578,7 +558,7 @@ public class AuthenticationProcedures : IAuthenticationProcedures
                 await _identityDbContext.SaveChangesAsync();
                 await transaction.CommitAsync();
 
-                _logger.LogInformation(new EventId(2209, "UserEmailChangeSuccess"),
+                _logger.LogInformation(new EventId(2211, "UserEmailChangeSuccess"),
                     "Successfully changed user's email account. UserId={UserId}, ChangeEmailToken={ChangeEmailToken}, NewEmail={NewEmail}.",
                     userId, changeEmailToken, newEmail);
 
@@ -588,13 +568,38 @@ public class AuthenticationProcedures : IAuthenticationProcedures
             catch (Exception ex)
             {
                 await transaction.RollbackAsync();
-                _logger.LogError(new EventId(4213, "UserEmailChangeFailure"), ex,
+                _logger.LogError(new EventId(4215, "UserEmailChangeFailure"), ex,
                     "An error occurred while trying to change user email account. UserId: {UserId}, NewEmail: {NewEmail}. " +
                     "ExceptionMessage: {ExceptionMessage}. StackTrace: {StackTrace}.",
                     userId, newEmail, ex.Message, ex.StackTrace);
                 throw;
             }
         });
+    }
+
+    //TODO Think about how to do this...
+    public async Task<bool> UpdateAccountAsync(AppUser appUser)
+    {
+        try
+        {
+            //here make sure that email and email are the same
+            var result = await _userManager.UpdateAsync(appUser);
+            if (!result.Succeeded)
+                _logger.LogWarning(new EventId(3225, "UserInformationUpdateFailureNoException"), "User account information could not be updated. " +
+                    "UserId={UserId}, Email={Email}. Errors={Errors}.", appUser.Id, appUser.Email, result.Errors);
+            else
+                _logger.LogInformation(new EventId(2212, "UserRetrievalError"), "Successfully updated user account information. UserId={UserId}, Email={Email}.",
+                    appUser.Id, appUser.Email);
+            return result.Succeeded;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(new EventId(4216, "UserInformationUpdateFailure"), ex, "An error occurred while trying update the users account information. " +
+                "UserId: {UserId}, Email: {Email}, Username: {Username}. " +
+                "ExceptionMessage: {ExceptionMessage}. StackTrace: {StackTrace}."
+                , appUser.Id, appUser.Email, appUser.UserName, ex.Message, ex.StackTrace);
+            throw;
+        }
     }
 
     private string GenerateToken(AppUser user, bool isPersistent = false)

--- a/EshopApp.AuthLibrary/UserLogic/IAuthenticationProcedures.cs
+++ b/EshopApp.AuthLibrary/UserLogic/IAuthenticationProcedures.cs
@@ -1,5 +1,6 @@
 ﻿using EshopApp.AuthLibrary.Models;
 using EshopApp.AuthLibrary.Models.ResponseModels;
+using Microsoft.AspNetCore.Authentication;
 
 namespace EshopApp.AuthLibrary.UserLogic;
 
@@ -10,12 +11,13 @@ public interface IAuthenticationProcedures
     Task<ReturnCodeAndTokenResponseModel> ConfirmEmailAsync(string userId, string confirmationToken);
     Task<ReturnCodeAndTokenResponseModel> CreateChangeEmailTokenAsync(string accessToken, string newEmail);
     Task<ReturnCodeAndTokenResponseModel> CreateResetPasswordTokenAsync(string email);
-    Task<LibraryReturnedCodes> DeleteAccountAsync(string userId, string accessToken);
-    Task<AppUser?> FindByEmailAsync(string email);
-    Task<AppUser?> FindByUserIdAsync(string userId);
+    Task<LibraryReturnedCodes> DeleteAccountAsync(string accessToken);
     Task<AppUser?> GetCurrentUserByToken(string token);
     Task<LibSignUpResponseModel> SignUpAsync(string email, string phoneNumber, string password);
     Task<ReturnCodeAndTokenResponseModel> ResetPasswordAsync(string userId, string resetPasswordToken, string newPassword);
     Task<ReturnCodeAndTokenResponseModel> SignInAsync(string username, string password, bool isPersistent);
     Task<bool> UpdateAccountAsync(AppUser appUser);
+    AuthenticationProperties GetExternalIdentityProvidersProperties(string identityProviderName, string redirectUrl);
+    Task<ReturnCodeAndTokenResponseModel> HandleExternalSignInCallbackAsync();
+    Task<IEnumerable<AuthenticationScheme>> GetExternalIdentityProvidersAsync();
 }

--- a/EshopApp.AuthLibraryAPI.Tests/IntegrationTests/ControllerTests/AuthenticationControllerTests.cs
+++ b/EshopApp.AuthLibraryAPI.Tests/IntegrationTests/ControllerTests/AuthenticationControllerTests.cs
@@ -159,7 +159,7 @@ internal class AuthenticationControllerTests
         string? emailConfirmationToken = WebUtility.UrlEncode(_chosenConfirmationEmailToken);
         
         //Act
-        HttpResponseMessage response = await httpClient.GetAsync($"api/authentication/confirmemail?userid={bogusUserId}&token={emailConfirmationToken}");
+        HttpResponseMessage response = await httpClient.GetAsync($"api/authentication/confirmemail?userid={bogusUserId}&confirmEmailToken={emailConfirmationToken}");
 
         //Assert
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
@@ -175,7 +175,7 @@ internal class AuthenticationControllerTests
         string? bogusEmailConfirmationToken = "bogusEmailConfirmationToken";
 
         //Act
-        HttpResponseMessage response = await httpClient.GetAsync($"api/authentication/confirmemail?userid={userId}&token={bogusEmailConfirmationToken}");
+        HttpResponseMessage response = await httpClient.GetAsync($"api/authentication/confirmemail?userid={userId}&confirmEmailToken={bogusEmailConfirmationToken}");
 
         //Assert
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
@@ -191,7 +191,7 @@ internal class AuthenticationControllerTests
         string? emailConfirmationToken = WebUtility.UrlEncode(_chosenConfirmationEmailToken);
 
         //Act
-        HttpResponseMessage response = await httpClient.GetAsync($"api/authentication/confirmemail?userid={userId}&token={emailConfirmationToken}");
+        HttpResponseMessage response = await httpClient.GetAsync($"api/authentication/confirmemail?userid={userId}&confirmEmailToken={emailConfirmationToken}");
         string? accessToken = await JsonParsingHelperMethods.GetSingleStringValueFromBody(response, "accessToken");
 
         //Assert
@@ -201,7 +201,7 @@ internal class AuthenticationControllerTests
     }
 
     [Test, Order(9)]
-    public async Task TryGetCurrentUser_ShouldReturnUnauthorized_IfAPIKeyIsInvalid()
+    public async Task GetUserByAccessToken_ShouldReturnUnauthorized_IfAPIKeyIsInvalid()
     {
         //Arrange
         httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", _chosenAccessToken);
@@ -209,7 +209,7 @@ internal class AuthenticationControllerTests
         httpClient.DefaultRequestHeaders.Add("X-API-KEY", "bogusKey");
 
         //Act
-        HttpResponseMessage response = await httpClient.GetAsync("api/authentication/trygetcurrentuser");
+        HttpResponseMessage response = await httpClient.GetAsync("api/authentication/getuserbyaccesstoken");
         string? errorMessage = await JsonParsingHelperMethods.GetSingleStringValueFromBody(response, "errorMessage");
 
         //Assert
@@ -219,7 +219,7 @@ internal class AuthenticationControllerTests
     }
 
     [Test, Order(10)]
-    public async Task TryGetCurrentUser_ShouldReturnUnauthorized_IfAccessTokenIsInvalid()
+    public async Task GetUserByAccessToken_ShouldReturnUnauthorized_IfAccessTokenIsInvalid()
     {
         //Arrange
         httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", "bogusToken");
@@ -227,14 +227,14 @@ internal class AuthenticationControllerTests
         httpClient.DefaultRequestHeaders.Add("X-API-KEY", _chosenApiKey);
 
         //Act
-        HttpResponseMessage response = await httpClient.GetAsync("api/authentication/trygetcurrentuser");
+        HttpResponseMessage response = await httpClient.GetAsync("api/authentication/getuserbyaccesstoken");
 
         //Assert
         response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
     }
 
     [Test, Order(11)]
-    public async Task TryGetCurrentUser_ShouldReturnOkAndUser()
+    public async Task GetUserByAccessToken_ShouldReturnOkAndUser()
     {
         //Arrange
         httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", _chosenAccessToken);
@@ -242,7 +242,7 @@ internal class AuthenticationControllerTests
         httpClient.DefaultRequestHeaders.Add("X-API-KEY", _chosenApiKey);
 
         //Act
-        HttpResponseMessage response = await httpClient.GetAsync("api/authentication/trygetcurrentuser");
+        HttpResponseMessage response = await httpClient.GetAsync("api/authentication/getuserbyaccesstoken");
         string? responseBody = await response.Content.ReadAsStringAsync();
         TestAppUser? testAppUser = JsonSerializer.Deserialize<TestAppUser>(responseBody, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
 
@@ -655,7 +655,7 @@ internal class AuthenticationControllerTests
         httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", _chosenAccessToken);
 
         //Act
-        HttpResponseMessage response = await httpClient.DeleteAsync($"api/authentication/deleteaccount?UserId={_chosenUserId}");
+        HttpResponseMessage response = await httpClient.DeleteAsync($"api/authentication/deleteaccount");
         string? errorMessage = await JsonParsingHelperMethods.GetSingleStringValueFromBody(response, "errorMessage");
 
         //Assert
@@ -673,30 +673,13 @@ internal class AuthenticationControllerTests
         httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", "bogusToken");
         
         //Act
-        HttpResponseMessage response = await httpClient.DeleteAsync($"api/authentication/deleteaccount?UserId={_chosenUserId}");
+        HttpResponseMessage response = await httpClient.DeleteAsync($"api/authentication/deleteaccount");
 
         //Assert
         response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
     }
 
     [Test, Order(34)]
-    public async Task DeleteAccount_ShouldReturnUnauthorized_IfUserDoesNotOwnGivenEmailForDeletion()
-    {
-        //Arrange
-        httpClient.DefaultRequestHeaders.Remove("X-API-KEY");
-        httpClient.DefaultRequestHeaders.Add("X-API-KEY", _chosenApiKey);
-        httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", _chosenAccessToken);
-
-        //Act
-        HttpResponseMessage response = await httpClient.DeleteAsync($"api/authentication/deleteaccount?UserId={_otherUserId}");
-        string? errorMessage = await JsonParsingHelperMethods.GetSingleStringValueFromBody(response, "errorMessage");
-
-        //Assert
-        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
-        errorMessage.Should().NotBeNull();
-    }
-
-    [Test, Order(35)]
     public async Task DeleteAccount_ShouldReturnNoContentAndSucceed()
     {
         //Arrange
@@ -705,14 +688,14 @@ internal class AuthenticationControllerTests
         httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", _chosenAccessToken);
 
         //Act
-        HttpResponseMessage response = await httpClient.DeleteAsync($"api/authentication/deleteaccount?UserId={_chosenUserId}");
+        HttpResponseMessage response = await httpClient.DeleteAsync($"api/authentication/deleteaccount");
 
         //Assert
         response.StatusCode.Should().Be(HttpStatusCode.NoContent);
     }
 
     //Redirect Testing Area
-    [Test, Order(36)]
+    [Test, Order(35)]
     public async Task ConfirmEmail_ShouldReturnBadRequest_IfRedirectUrlIsNotTrusted()
     {
         //Arrange
@@ -734,7 +717,7 @@ internal class AuthenticationControllerTests
         string? redirectUrl = WebUtility.UrlEncode("https://evil.com/handleRedirect?returnUrl=https://evil.com/home");
 
         //Act
-        HttpResponseMessage response = await httpClient.GetAsync($"api/authentication/confirmemail?userid={userId}&token={emailConfirmationToken}&redirectUrl={redirectUrl}");
+        HttpResponseMessage response = await httpClient.GetAsync($"api/authentication/confirmemail?userid={userId}&confirmEmailToken={emailConfirmationToken}&redirectUrl={redirectUrl}");
         string? errorMessage = await JsonParsingHelperMethods.GetSingleStringValueFromBody(response, "errorMessage");
 
         //Assert
@@ -743,7 +726,7 @@ internal class AuthenticationControllerTests
         errorMessage.Should().Be("InvalidRedirectUrl");
     }
 
-    [Test, Order(37)]
+    [Test, Order(36)]
     public async Task ConfirmEmail_ShouldReturnRedirectConfirmEmailAndReturnAccessToken()
     {
         //Arrange
@@ -753,7 +736,7 @@ internal class AuthenticationControllerTests
         string? redirectUrl = WebUtility.UrlEncode("https://localhost:7255/handleRedirect?returnUrl=https://localhost:7255.com/home");
 
         //Act
-        HttpResponseMessage response = await httpClient.GetAsync($"api/authentication/confirmemail?userid={userId}&token={emailConfirmationToken}&redirectUrl={redirectUrl}");
+        HttpResponseMessage response = await httpClient.GetAsync($"api/authentication/confirmemail?userid={userId}&confirmEmailToken={emailConfirmationToken}&redirectUrl={redirectUrl}");
 
         //Assert
         response.StatusCode.Should().Be(HttpStatusCode.Redirect);
@@ -765,7 +748,7 @@ internal class AuthenticationControllerTests
         _chosenAccessToken = query["accessToken"];
     }
 
-    [Test, Order(38)]
+    [Test, Order(37)]
     public async Task ConfirmChangeEmail_ShouldReturnBadRequest_IfRedirectUrlIsNotTrusted()
     {
         //Arrange
@@ -794,7 +777,7 @@ internal class AuthenticationControllerTests
         errorMessage.Should().Be("InvalidRedirectUrl");
     }
 
-    [Test, Order(39)]
+    [Test, Order(38)]
     public async Task ConfirmChangeEmail_ShouldReturnRedirectConfirmNewEmailAndReturnAccessToken()
     {
         //Arrange
@@ -815,7 +798,7 @@ internal class AuthenticationControllerTests
     }
     
     //Rate Limit Test
-    [Test, Order(40)]
+    [Test, Order(39)]
     public async Task SignIn_ShouldFail_IfRateLimitIsExceededAndBypassHeaderNotFilledCorrectly()
     {
         //Arrange

--- a/EshopApp.AuthLibraryAPI/EshopApp.AuthLibraryAPI.csproj
+++ b/EshopApp.AuthLibraryAPI/EshopApp.AuthLibraryAPI.csproj
@@ -4,6 +4,16 @@
     <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
+    <GenerateDocumentationFile>True</GenerateDocumentationFile>
+    <UserSecretsId>dede7099-1aa2-4746-9a8d-b880d7417c31</UserSecretsId>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <NoWarn>1701;1702;1591</NoWarn>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+    <NoWarn>1701;1702;1591</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/EshopApp.AuthLibraryAPI/Middlewares/ApiKeyProtectionMiddleware.cs
+++ b/EshopApp.AuthLibraryAPI/Middlewares/ApiKeyProtectionMiddleware.cs
@@ -18,7 +18,7 @@ public class ApiKeyProtectionMiddleware
         var path = context.Request.Path;
 
         // Bypass API key check for specific endpoints(add the external login eventually, because it goes thought sign in
-        if (path.StartsWithSegments("/api/authentication/ConfirmEmail") || path.StartsWithSegments("/api/authentication/ConfirmChangeEmail"))
+        if (path.StartsWithSegments("/api/authentication/ConfirmEmail") || path.StartsWithSegments("/api/authentication/ConfirmChangeEmail") || path.StartsWithSegments("/api/authentication/ExternalSignInCallback"))
         {
             await _next(context);
             return;

--- a/EshopApp.AuthLibraryAPI/Models/RequestModels/ApiExternalSignInRequestModel.cs
+++ b/EshopApp.AuthLibraryAPI/Models/RequestModels/ApiExternalSignInRequestModel.cs
@@ -1,0 +1,11 @@
+﻿using System.ComponentModel.DataAnnotations;
+
+namespace EshopApp.AuthLibraryAPI.Models.RequestModels;
+
+public class ApiExternalSignInRequestModel
+{
+    [Required]
+    public string? IdentityProviderName { get; set; }
+    [Required]
+    public string? ReturnUrl { get; set; }
+}

--- a/EshopApp.AuthLibraryAPI/Program.cs
+++ b/EshopApp.AuthLibraryAPI/Program.cs
@@ -8,6 +8,7 @@ using System.Text;
 using Microsoft.IdentityModel.Tokens;
 using EshopApp.AuthLibraryAPI.Middlewares;
 using Microsoft.AspNetCore.RateLimiting;
+using System.Reflection;
 
 namespace EshopApp.AuthLibraryAPI;
 
@@ -23,7 +24,13 @@ public class Program()
         builder.Services.AddControllers();
         // Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
         builder.Services.AddEndpointsApiExplorer();
-        builder.Services.AddSwaggerGen();
+        builder.Services.AddSwaggerGen(options =>
+        {
+            string xmlFile = $"{Assembly.GetExecutingAssembly().GetName().Name}.xml"; //Convoluted way of getting 'EshopApp.AuthLibraryAPI.xml', but more safe
+            var xmlPath = Path.Combine(AppContext.BaseDirectory, xmlFile); //Combine the otherpartofpath/bin/Debug/net8.0 with the EshopApp.AuthLibraryAPI.xml
+
+            options.IncludeXmlComments(xmlPath);
+        });
 
         builder.Services.AddRateLimiter(options =>
         {
@@ -99,6 +106,14 @@ public class Program()
                 ValidAudience = configuration["Jwt:Audience"],
                 IssuerSigningKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(configuration["Jwt:Key"]!))
             };
+        }).AddGoogle(options =>
+        {
+            options.ClientId = configuration.GetValue<string>("Authentication:Google:ClientId")!;
+            options.ClientSecret = configuration.GetValue<string>("Authentication:Google:ClientSecret")!;
+        }).AddTwitter(options =>
+        {
+            options.ConsumerKey = configuration.GetValue<string>("Authentication:Twitter:ClientId")!;
+            options.ConsumerSecret = configuration.GetValue<string>("Authentication:Twitter:ClientSecret")!;
         });
 
         builder.Services.AddScoped<IAuthenticationProcedures, AuthenticationProcedures>();


### PR DESCRIPTION
I added the necessary endpoints that will allow the user to sign up or sign in with the external identity provider of their choice. For now only Twitter/X and Google are configured, but I might add Facebook and Microsoft in the future. Because integration tests might be hard to add for the external login callback I decided to do some minor testing with postman and for now the endpoints(ExternalSignIn and ExternalSignInCallback) seems to work as intended, but further testing will be needed. Also changed some minor things like the DeleteAccount endpoint and its underlying library method and some minor things when it comes to logging in the auth library.