### PR TITLE
Added Integration Tests For The Added External Identity Provider Endp…

### DIFF
--- a/EshopApp.AuthLibraryAPI.Tests/IntegrationTests/Models/RequestModels/TestExternalSignInRequestModel.cs
+++ b/EshopApp.AuthLibraryAPI.Tests/IntegrationTests/Models/RequestModels/TestExternalSignInRequestModel.cs
@@ -1,0 +1,7 @@
+﻿namespace EshopApp.AuthLibraryAPI.Tests.IntegrationTests.Models.RequestModels;
+
+internal class TestExternalSignInRequestModel
+{
+    public string? IdentityProviderName { get; set; }
+    public string? ReturnUrl { get; set; }
+}

--- a/EshopApp.AuthLibraryAPI/Controllers/AuthenticationController.cs
+++ b/EshopApp.AuthLibraryAPI/Controllers/AuthenticationController.cs
@@ -209,7 +209,11 @@ public class AuthenticationController : ControllerBase
         try
         {
             IEnumerable<AuthenticationScheme> externalIdentityProviders = await _authenticationProcedures.GetExternalIdentityProvidersAsync();
-            return Ok(new {ExternalIdentityProviders = externalIdentityProviders}); 
+            List<string> externalIdentityProvidersNames = new List<string>();
+            foreach (AuthenticationScheme scheme in externalIdentityProviders) 
+                externalIdentityProvidersNames.Add(scheme.Name);
+
+            return Ok(externalIdentityProvidersNames); 
         }
         catch
         {


### PR DESCRIPTION
…oints

I added tests for the 2 out of the 3 endpoints that I added in the previous commit. Those tests test a typical flow and some edge cases. The reason why I did not test the ExternalSignInCallback is because I have no idea how to do that. I could mock certain things, but it would defeat the purpose of integration tests. Hopefully the manual postman tests I did in the previous commit are enough to make sure that the endpoint does not have any logical errors.