### PR TITLE
Added Authorization Endpoints In The Auth Library Api

### DIFF
--- a/EshopApp.AuthLibrary/AppIdentityDbContext.cs
+++ b/EshopApp.AuthLibrary/AppIdentityDbContext.cs
@@ -56,10 +56,10 @@ public class AppIdentityDbContext : IdentityDbContext<AppUser, AppRole, string>
         );
 
         builder.Entity<IdentityRoleClaim<string>>().HasData(
-            new IdentityRoleClaim<string> { Id = 1, RoleId = adminRoleGuid, ClaimType = "Permission", ClaimValue = "CanViewUser" },
-            new IdentityRoleClaim<string> { Id = 2, RoleId = adminRoleGuid, ClaimType = "Permission", ClaimValue = "CanEditUser" },
-            new IdentityRoleClaim<string> { Id = 3, RoleId = adminRoleGuid, ClaimType = "Permission", ClaimValue = "CanViewAdmin" },
-            new IdentityRoleClaim<string> { Id = 4, RoleId = adminRoleGuid, ClaimType = "Permission", ClaimValue = "CanEditAdmin" },
+            new IdentityRoleClaim<string> { Id = 1, RoleId = adminRoleGuid, ClaimType = "Permission", ClaimValue = "CanViewUsers" },
+            new IdentityRoleClaim<string> { Id = 2, RoleId = adminRoleGuid, ClaimType = "Permission", ClaimValue = "CanEditUsers" },
+            new IdentityRoleClaim<string> { Id = 3, RoleId = adminRoleGuid, ClaimType = "Permission", ClaimValue = "CanViewAdmins" },
+            new IdentityRoleClaim<string> { Id = 4, RoleId = adminRoleGuid, ClaimType = "Permission", ClaimValue = "CanEditAdmins" },
             new IdentityRoleClaim<string> { Id = 5, RoleId = adminRoleGuid, ClaimType = "Permission", ClaimValue = "CanViewUserRoles" },
             new IdentityRoleClaim<string> { Id = 6, RoleId = adminRoleGuid, ClaimType = "Permission", ClaimValue = "CanEditUserRoles" },
             new IdentityRoleClaim<string> { Id = 7, RoleId = adminRoleGuid, ClaimType = "Permission", ClaimValue = "CanViewAdminRoles" },
@@ -67,9 +67,9 @@ public class AppIdentityDbContext : IdentityDbContext<AppUser, AppRole, string>
         );
 
         builder.Entity<IdentityRoleClaim<string>>().HasData(
-            new IdentityRoleClaim<string> { Id = 9, RoleId = managerRoleGuid, ClaimType = "Permission", ClaimValue = "CanViewUser" },
-            new IdentityRoleClaim<string> { Id = 10, RoleId = managerRoleGuid, ClaimType = "Permission", ClaimValue = "CanEditUser" },
-            new IdentityRoleClaim<string> { Id = 11, RoleId = managerRoleGuid, ClaimType = "Permission", ClaimValue = "CanViewAdmin" },
+            new IdentityRoleClaim<string> { Id = 9, RoleId = managerRoleGuid, ClaimType = "Permission", ClaimValue = "CanViewUsers" },
+            new IdentityRoleClaim<string> { Id = 10, RoleId = managerRoleGuid, ClaimType = "Permission", ClaimValue = "CanEditUsers" },
+            new IdentityRoleClaim<string> { Id = 11, RoleId = managerRoleGuid, ClaimType = "Permission", ClaimValue = "CanViewAdmins" },
             new IdentityRoleClaim<string> { Id = 12, RoleId = managerRoleGuid, ClaimType = "Permission", ClaimValue = "CanViewUserRoles" },
             new IdentityRoleClaim<string> { Id = 13, RoleId = managerRoleGuid, ClaimType = "Permission", ClaimValue = "CanEditUserRoles" },
             new IdentityRoleClaim<string> { Id = 14, RoleId = managerRoleGuid, ClaimType = "Permission", ClaimValue = "CanViewAdminRoles" }

--- a/EshopApp.AuthLibrary/AuthLogic/HelperMethods.cs
+++ b/EshopApp.AuthLibrary/AuthLogic/HelperMethods.cs
@@ -62,7 +62,7 @@ public class HelperMethods : IHelperMethods
 
         if(await IsAccountLockedOut(appUser, new EventId(templateEvent.Id + 2, templateEvent.Name + "FailureDueToAccountBeingLocked"), 
             "The account was locked out at the time of the process and thus the process could not proceed: Email={Email}."))
-            return new ReturnUserAndCodeResponseModel(null!, LibraryReturnedCodes.UserAccountNotActivated);
+            return new ReturnUserAndCodeResponseModel(null!, LibraryReturnedCodes.UserAccountLocked);
 
         return new ReturnUserAndCodeResponseModel(appUser, LibraryReturnedCodes.NoError);
     }
@@ -88,7 +88,7 @@ public class HelperMethods : IHelperMethods
         {
             _logger.LogWarning(new EventId(templateEvent.Id + 2, templateEvent.Name + "FailureDueToRoleNotInUserRolesInSystem"),
                 "The role existed correctly in the access token, but the user is not connected to the role with RoleName={RoleName} in the database. AccessToken={AccessToken}.", roleName, accessToken);
-            return new ReturnUserAndCodeResponseModel(null!, LibraryReturnedCodes.ValidTokenButUserNotInSystem);
+            return new ReturnUserAndCodeResponseModel(null!, LibraryReturnedCodes.ValidTokenButUserNotInRoleInSystem);
         }
 
         var userRoleClaimsInSystem = await _roleManager.GetClaimsAsync(userRole!);
@@ -99,7 +99,7 @@ public class HelperMethods : IHelperMethods
                 _logger.LogWarning(new EventId(templateEvent.Id + 3, templateEvent.Name + "FailureDueToClaimNotPartOfRoleInSystem"),
                     "The claims existed correctly in the access token, but the claim with ClaimType={ClaimType} and ClaimValue={ClaimValue} is not currently part of the role with RoleName={RoleName}. " +
                     "AccessToken={AccessToken}.", expectedClaim.Type, expectedClaim.Value, roleName, accessToken);
-                return new ReturnUserAndCodeResponseModel(null!, LibraryReturnedCodes.ValidTokenButUserNotInSystem);
+                return new ReturnUserAndCodeResponseModel(null!, LibraryReturnedCodes.ValidTokenButClaimNotInSystem);
             }
         }
 
@@ -109,7 +109,7 @@ public class HelperMethods : IHelperMethods
 
         if (await IsAccountLockedOut(appUser, new EventId(templateEvent.Id + 5, templateEvent.Name + "FailureDueToAccountBeingLocked"),
             "The account was locked out at the time of the process and thus the process could not proceed: Email={Email}."))
-            return new ReturnUserAndCodeResponseModel(null!, LibraryReturnedCodes.UserAccountNotActivated);
+            return new ReturnUserAndCodeResponseModel(null!, LibraryReturnedCodes.UserAccountLocked);
 
         return new ReturnUserAndCodeResponseModel(appUser, LibraryReturnedCodes.NoError);
     }

--- a/EshopApp.AuthLibrary/AuthLogic/IAdminProcedures.cs
+++ b/EshopApp.AuthLibrary/AuthLogic/IAdminProcedures.cs
@@ -1,0 +1,16 @@
+﻿using EshopApp.AuthLibrary.Models;
+using EshopApp.AuthLibrary.Models.ResponseModels;
+using System.Security.Claims;
+
+namespace EshopApp.AuthLibrary.AuthLogic
+{
+    public interface IAdminProcedures
+    {
+        Task<ReturnUserAndCodeResponseModel> CreateUserAccountAsync(string accessToken, List<Claim> expectedClaims, string email, string password, string? phoneNumber = null);
+        Task<LibraryReturnedCodes> DeleteUserAccountAsync(string accessToken, List<Claim> expectedClaims, string userId);
+        Task<ReturnUserAndCodeResponseModel?> FindUserByEmailAsync(string accessToken, List<Claim> expectedClaims, string email);
+        Task<ReturnUserAndCodeResponseModel?> FindUserByIdAsync(string accessToken, List<Claim> expectedClaims, string userId);
+        Task<ReturnUsersAndCodeResponseModel> GetUsersAsync(string accessToken, List<Claim> expectedClaims);
+        Task<LibraryReturnedCodes> UpdateUserAccountAsync(string accessToken, List<Claim> expectedClaims, AppUser updatedUser, bool activateEmail, string? password = null);
+    }
+}

--- a/EshopApp.AuthLibrary/AuthLogic/IRoleManagementProcedures.cs
+++ b/EshopApp.AuthLibrary/AuthLogic/IRoleManagementProcedures.cs
@@ -12,7 +12,7 @@ namespace EshopApp.AuthLibrary.AuthLogic
         Task<ReturnClaimsAndCodeResponseModel> GetAllUniqueClaimsInSystemAsync(string accessToken, List<Claim> expectedClaims);
         Task<ReturnRoleAndCodeResponseModel> GetRoleByIdAsync(string accessToken, List<Claim> expectedClaims, string roleId);
         Task<ReturnRoleAndCodeResponseModel> GetRoleByNameAsync(string accessToken, List<Claim> expectedClaims, string roleName);
-        Task<ReturnRolesAndCodeResponseModel> GetRolesAsync(string accessToken, List<Claim> expectedClaims, string roleId);
+        Task<ReturnRolesAndCodeResponseModel> GetRolesAsync(string accessToken, List<Claim> expectedClaims);
         Task<ReturnRolesAndCodeResponseModel> GetRolesOfUserAsync(string accessToken, List<Claim> expectedClaims, string userId);
         Task<ReturnUsersAndCodeResponseModel> GetUsersOfGivenRoleAsync(string accessToken, List<Claim> expectedClaims, string roleId);
         Task<LibraryReturnedCodes> RemoveRoleFromUserAsync(string accessToken, List<Claim> expectedClaims, string userId, string roleId);

--- a/EshopApp.AuthLibrary/AuthLogic/RoleManagementProcedures.cs
+++ b/EshopApp.AuthLibrary/AuthLogic/RoleManagementProcedures.cs
@@ -29,7 +29,7 @@ public class RoleManagementProcedures : IRoleManagementProcedures
         _logger = logger ?? NullLogger<AuthenticationProcedures>.Instance;
     }
 
-    public async Task<ReturnRolesAndCodeResponseModel> GetRolesAsync(string accessToken, List<Claim> expectedClaims, string roleId)
+    public async Task<ReturnRolesAndCodeResponseModel> GetRolesAsync(string accessToken, List<Claim> expectedClaims)
     {
         try
         {

--- a/EshopApp.AuthLibrary/Migrations/20240812135156_ChangedTheNamesOfSomeSeededClaims.Designer.cs
+++ b/EshopApp.AuthLibrary/Migrations/20240812135156_ChangedTheNamesOfSomeSeededClaims.Designer.cs
@@ -4,6 +4,7 @@ using EshopApp.AuthLibrary;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace EshopApp.AuthLibrary.Migrations
 {
     [DbContext(typeof(AppIdentityDbContext))]
-    partial class AppIdentityDbContextModelSnapshot : ModelSnapshot
+    [Migration("20240812135156_ChangedTheNamesOfSomeSeededClaims")]
+    partial class ChangedTheNamesOfSomeSeededClaims
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/EshopApp.AuthLibrary/Migrations/20240812135156_ChangedTheNamesOfSomeSeededClaims.cs
+++ b/EshopApp.AuthLibrary/Migrations/20240812135156_ChangedTheNamesOfSomeSeededClaims.cs
@@ -1,0 +1,288 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+#pragma warning disable CA1814 // Prefer jagged arrays over multidimensional
+
+namespace EshopApp.AuthLibrary.Migrations
+{
+    /// <inheritdoc />
+    public partial class ChangedTheNamesOfSomeSeededClaims : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "IdentityRole");
+
+            migrationBuilder.DeleteData(
+                table: "AspNetUsers",
+                keyColumn: "Id",
+                keyValue: "bc4e7fe5-6779-4531-9938-33514b7557db");
+
+            migrationBuilder.UpdateData(
+                table: "AspNetRoleClaims",
+                keyColumn: "Id",
+                keyValue: 1,
+                columns: new[] { "ClaimValue", "RoleId" },
+                values: new object[] { "CanViewUsers", "df308491-a530-404b-be4e-43ca15afda90" });
+
+            migrationBuilder.UpdateData(
+                table: "AspNetRoleClaims",
+                keyColumn: "Id",
+                keyValue: 2,
+                columns: new[] { "ClaimValue", "RoleId" },
+                values: new object[] { "CanEditUsers", "df308491-a530-404b-be4e-43ca15afda90" });
+
+            migrationBuilder.UpdateData(
+                table: "AspNetRoleClaims",
+                keyColumn: "Id",
+                keyValue: 3,
+                columns: new[] { "ClaimValue", "RoleId" },
+                values: new object[] { "CanViewAdmins", "df308491-a530-404b-be4e-43ca15afda90" });
+
+            migrationBuilder.UpdateData(
+                table: "AspNetRoleClaims",
+                keyColumn: "Id",
+                keyValue: 4,
+                columns: new[] { "ClaimValue", "RoleId" },
+                values: new object[] { "CanEditAdmins", "df308491-a530-404b-be4e-43ca15afda90" });
+
+            migrationBuilder.UpdateData(
+                table: "AspNetRoleClaims",
+                keyColumn: "Id",
+                keyValue: 5,
+                column: "RoleId",
+                value: "df308491-a530-404b-be4e-43ca15afda90");
+
+            migrationBuilder.UpdateData(
+                table: "AspNetRoleClaims",
+                keyColumn: "Id",
+                keyValue: 6,
+                column: "RoleId",
+                value: "df308491-a530-404b-be4e-43ca15afda90");
+
+            migrationBuilder.UpdateData(
+                table: "AspNetRoleClaims",
+                keyColumn: "Id",
+                keyValue: 7,
+                column: "RoleId",
+                value: "df308491-a530-404b-be4e-43ca15afda90");
+
+            migrationBuilder.UpdateData(
+                table: "AspNetRoleClaims",
+                keyColumn: "Id",
+                keyValue: 8,
+                column: "RoleId",
+                value: "df308491-a530-404b-be4e-43ca15afda90");
+
+            migrationBuilder.UpdateData(
+                table: "AspNetRoleClaims",
+                keyColumn: "Id",
+                keyValue: 9,
+                columns: new[] { "ClaimValue", "RoleId" },
+                values: new object[] { "CanViewUsers", "7d7618e1-5b9a-4639-b433-05427cdde79f" });
+
+            migrationBuilder.UpdateData(
+                table: "AspNetRoleClaims",
+                keyColumn: "Id",
+                keyValue: 10,
+                columns: new[] { "ClaimValue", "RoleId" },
+                values: new object[] { "CanEditUsers", "7d7618e1-5b9a-4639-b433-05427cdde79f" });
+
+            migrationBuilder.UpdateData(
+                table: "AspNetRoleClaims",
+                keyColumn: "Id",
+                keyValue: 11,
+                columns: new[] { "ClaimValue", "RoleId" },
+                values: new object[] { "CanViewAdmins", "7d7618e1-5b9a-4639-b433-05427cdde79f" });
+
+            migrationBuilder.UpdateData(
+                table: "AspNetRoleClaims",
+                keyColumn: "Id",
+                keyValue: 12,
+                column: "RoleId",
+                value: "7d7618e1-5b9a-4639-b433-05427cdde79f");
+
+            migrationBuilder.UpdateData(
+                table: "AspNetRoleClaims",
+                keyColumn: "Id",
+                keyValue: 13,
+                column: "RoleId",
+                value: "7d7618e1-5b9a-4639-b433-05427cdde79f");
+
+            migrationBuilder.UpdateData(
+                table: "AspNetRoleClaims",
+                keyColumn: "Id",
+                keyValue: 14,
+                column: "RoleId",
+                value: "7d7618e1-5b9a-4639-b433-05427cdde79f");
+
+            migrationBuilder.InsertData(
+                table: "AspNetRoles",
+                columns: new[] { "Id", "ConcurrencyStamp", "Name", "NormalizedName" },
+                values: new object[,]
+                {
+                    { "7d7618e1-5b9a-4639-b433-05427cdde79f", "4872c74a-5c10-476a-954f-40f54a061e8b", "Manager", "MANAGER" },
+                    { "cfa9cc7f-c5fa-494a-a812-f843b51c9ee2", "dacbc9bb-3f41-47cd-9bfa-c5779d37e0a3", "User", "USER" },
+                    { "df308491-a530-404b-be4e-43ca15afda90", "97e547c5-2947-4390-a9aa-949dbf16d3bd", "Admin", "ADMIN" }
+                });
+
+            migrationBuilder.InsertData(
+                table: "AspNetUsers",
+                columns: new[] { "Id", "AccessFailedCount", "ConcurrencyStamp", "Email", "EmailConfirmed", "LockoutEnabled", "LockoutEnd", "NormalizedEmail", "NormalizedUserName", "PasswordHash", "PhoneNumber", "PhoneNumberConfirmed", "SecurityStamp", "TwoFactorEnabled", "UserName" },
+                values: new object[] { "47aefaf2-7592-4947-88d1-f6b424e978e0", 0, "c153c671-dc74-403c-9917-900551780536", "admin@hotmail.com", true, false, null, "ADMIN@HOTMAIL.COM", "ADMIN@HOTMAIL.COM", "AQAAAAIAAYagAAAAEGJt9WiGcXYW5kN71PUXli557wKiNAy5+ld9thr06psFvYfv3Xdxtywq8cs4q8BhsA==", null, false, "df586591-460a-453b-9b2e-5ae5702caf12", false, "admin@hotmail.com" });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DeleteData(
+                table: "AspNetRoles",
+                keyColumn: "Id",
+                keyValue: "7d7618e1-5b9a-4639-b433-05427cdde79f");
+
+            migrationBuilder.DeleteData(
+                table: "AspNetRoles",
+                keyColumn: "Id",
+                keyValue: "cfa9cc7f-c5fa-494a-a812-f843b51c9ee2");
+
+            migrationBuilder.DeleteData(
+                table: "AspNetRoles",
+                keyColumn: "Id",
+                keyValue: "df308491-a530-404b-be4e-43ca15afda90");
+
+            migrationBuilder.DeleteData(
+                table: "AspNetUsers",
+                keyColumn: "Id",
+                keyValue: "47aefaf2-7592-4947-88d1-f6b424e978e0");
+
+            migrationBuilder.CreateTable(
+                name: "IdentityRole",
+                columns: table => new
+                {
+                    Id = table.Column<string>(type: "nvarchar(450)", nullable: false),
+                    ConcurrencyStamp = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    Name = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    NormalizedName = table.Column<string>(type: "nvarchar(max)", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_IdentityRole", x => x.Id);
+                });
+
+            migrationBuilder.UpdateData(
+                table: "AspNetRoleClaims",
+                keyColumn: "Id",
+                keyValue: 1,
+                columns: new[] { "ClaimValue", "RoleId" },
+                values: new object[] { "CanViewUser", "66448807-40c5-4067-b60b-a0d9d48be760" });
+
+            migrationBuilder.UpdateData(
+                table: "AspNetRoleClaims",
+                keyColumn: "Id",
+                keyValue: 2,
+                columns: new[] { "ClaimValue", "RoleId" },
+                values: new object[] { "CanEditUser", "66448807-40c5-4067-b60b-a0d9d48be760" });
+
+            migrationBuilder.UpdateData(
+                table: "AspNetRoleClaims",
+                keyColumn: "Id",
+                keyValue: 3,
+                columns: new[] { "ClaimValue", "RoleId" },
+                values: new object[] { "CanViewAdmin", "66448807-40c5-4067-b60b-a0d9d48be760" });
+
+            migrationBuilder.UpdateData(
+                table: "AspNetRoleClaims",
+                keyColumn: "Id",
+                keyValue: 4,
+                columns: new[] { "ClaimValue", "RoleId" },
+                values: new object[] { "CanEditAdmin", "66448807-40c5-4067-b60b-a0d9d48be760" });
+
+            migrationBuilder.UpdateData(
+                table: "AspNetRoleClaims",
+                keyColumn: "Id",
+                keyValue: 5,
+                column: "RoleId",
+                value: "66448807-40c5-4067-b60b-a0d9d48be760");
+
+            migrationBuilder.UpdateData(
+                table: "AspNetRoleClaims",
+                keyColumn: "Id",
+                keyValue: 6,
+                column: "RoleId",
+                value: "66448807-40c5-4067-b60b-a0d9d48be760");
+
+            migrationBuilder.UpdateData(
+                table: "AspNetRoleClaims",
+                keyColumn: "Id",
+                keyValue: 7,
+                column: "RoleId",
+                value: "66448807-40c5-4067-b60b-a0d9d48be760");
+
+            migrationBuilder.UpdateData(
+                table: "AspNetRoleClaims",
+                keyColumn: "Id",
+                keyValue: 8,
+                column: "RoleId",
+                value: "66448807-40c5-4067-b60b-a0d9d48be760");
+
+            migrationBuilder.UpdateData(
+                table: "AspNetRoleClaims",
+                keyColumn: "Id",
+                keyValue: 9,
+                columns: new[] { "ClaimValue", "RoleId" },
+                values: new object[] { "CanViewUser", "83eb3f59-e27a-4ef5-ab46-10fe52772ffe" });
+
+            migrationBuilder.UpdateData(
+                table: "AspNetRoleClaims",
+                keyColumn: "Id",
+                keyValue: 10,
+                columns: new[] { "ClaimValue", "RoleId" },
+                values: new object[] { "CanEditUser", "83eb3f59-e27a-4ef5-ab46-10fe52772ffe" });
+
+            migrationBuilder.UpdateData(
+                table: "AspNetRoleClaims",
+                keyColumn: "Id",
+                keyValue: 11,
+                columns: new[] { "ClaimValue", "RoleId" },
+                values: new object[] { "CanViewAdmin", "83eb3f59-e27a-4ef5-ab46-10fe52772ffe" });
+
+            migrationBuilder.UpdateData(
+                table: "AspNetRoleClaims",
+                keyColumn: "Id",
+                keyValue: 12,
+                column: "RoleId",
+                value: "83eb3f59-e27a-4ef5-ab46-10fe52772ffe");
+
+            migrationBuilder.UpdateData(
+                table: "AspNetRoleClaims",
+                keyColumn: "Id",
+                keyValue: 13,
+                column: "RoleId",
+                value: "83eb3f59-e27a-4ef5-ab46-10fe52772ffe");
+
+            migrationBuilder.UpdateData(
+                table: "AspNetRoleClaims",
+                keyColumn: "Id",
+                keyValue: 14,
+                column: "RoleId",
+                value: "83eb3f59-e27a-4ef5-ab46-10fe52772ffe");
+
+            migrationBuilder.InsertData(
+                table: "AspNetUsers",
+                columns: new[] { "Id", "AccessFailedCount", "ConcurrencyStamp", "Email", "EmailConfirmed", "LockoutEnabled", "LockoutEnd", "NormalizedEmail", "NormalizedUserName", "PasswordHash", "PhoneNumber", "PhoneNumberConfirmed", "SecurityStamp", "TwoFactorEnabled", "UserName" },
+                values: new object[] { "bc4e7fe5-6779-4531-9938-33514b7557db", 0, "375e514b-2da8-4ec6-abc6-9cedcf8eb2b8", "admin@hotmail.com", true, false, null, "ADMIN@HOTMAIL.COM", "ADMIN@HOTMAIL.COM", "AQAAAAIAAYagAAAAEPvGdgzdbB/1BT0b4CFzkkwpNKnxPyCr0qq8BG5PL/QpQyri00lIZUUJXbORD/MjQw==", null, false, "5c8af473-7772-4deb-b338-b1b94d2a1b5a", false, "admin@hotmail.com" });
+
+            migrationBuilder.InsertData(
+                table: "IdentityRole",
+                columns: new[] { "Id", "ConcurrencyStamp", "Name", "NormalizedName" },
+                values: new object[,]
+                {
+                    { "05888481-649e-46f9-96aa-2588ff5b00cb", "92824b71-f797-4b82-a279-8b2655b77677", "User", "USER" },
+                    { "66448807-40c5-4067-b60b-a0d9d48be760", "5a48029f-e8b2-40db-aa4e-adec6deef27c", "Admin", "ADMIN" },
+                    { "83eb3f59-e27a-4ef5-ab46-10fe52772ffe", "8f167eb5-134d-4046-85fa-f5ebfdc1f112", "Manager", "MANAGER" }
+                });
+        }
+    }
+}

--- a/EshopApp.AuthLibrary/Models/ResponseModels/LibraryReturnedCodes.cs
+++ b/EshopApp.AuthLibrary/Models/ResponseModels/LibraryReturnedCodes.cs
@@ -17,6 +17,7 @@ public enum LibraryReturnedCodes
     EmailClaimNotReceivedFromIdentityProvider,
     ValidTokenButUserNotInSystem,
     ValidTokenButClaimNotInSystem,
+    ValidTokenButUserNotInRoleInSystem,
     UnknownError,
     NoError
 }

--- a/EshopApp.AuthLibraryAPI/Controllers/AdminController.cs
+++ b/EshopApp.AuthLibraryAPI/Controllers/AdminController.cs
@@ -1,0 +1,228 @@
+﻿using EshopApp.AuthLibrary.AuthLogic;
+using EshopApp.AuthLibrary.Models.ResponseModels;
+using EshopApp.AuthLibraryAPI.Models.RequestModels.AdminModels;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.RateLimiting;
+using System.Security.Claims;
+
+namespace EshopApp.AuthLibraryAPI.Controllers;
+
+[ApiController]
+[EnableRateLimiting("DefaultWindowLimiter")]
+[Route("api/[controller]")]
+
+public class AdminController : ControllerBase
+{
+    private readonly IAdminProcedures _adminProcedures;
+
+    public AdminController(IAdminProcedures adminProcedures)
+    {
+        _adminProcedures = adminProcedures;
+    }
+
+    [HttpGet]
+    [Authorize(Policy = "CanViewUsersPolicy")]
+    public async Task<IActionResult> GetUsers()
+    {
+		try
+		{
+            string authorizationHeader = HttpContext.Request.Headers["Authorization"]!;
+            string accessToken = authorizationHeader.Substring("Bearer ".Length).Trim();
+
+            ReturnUsersAndCodeResponseModel returnUsersAndCodeResponseModel = await _adminProcedures.GetUsersAsync(accessToken, new List<Claim>(){ new Claim("Permission", "CanViewUsers")});
+            if (returnUsersAndCodeResponseModel.LibraryReturnedCodes == LibraryReturnedCodes.ValidTokenButUserNotInSystem)
+                return Unauthorized(new { ErrorMessage = "ValidTokenButUserNotInSystem" });
+            else if (returnUsersAndCodeResponseModel.LibraryReturnedCodes == LibraryReturnedCodes.ValidTokenButUserNotInRoleInSystem)
+                return Unauthorized(new { ErrorMessage = "ValidTokenButUserNotInRoleInSystem" });
+            else if (returnUsersAndCodeResponseModel.LibraryReturnedCodes == LibraryReturnedCodes.ValidTokenButClaimNotInSystem)
+                return Unauthorized(new { ErrorMessage = "ValidTokenButClaimNotInSystem" });
+            else if (returnUsersAndCodeResponseModel.LibraryReturnedCodes == LibraryReturnedCodes.UserAccountNotActivated)
+                return Unauthorized(new { ErrorMessage = "UserAccountNotActivated" });
+            else if (returnUsersAndCodeResponseModel.LibraryReturnedCodes == LibraryReturnedCodes.UserAccountLocked)
+                return Unauthorized(new { ErrorMessage = "UserAccountLocked" });
+
+            return Ok(returnUsersAndCodeResponseModel.AppUsers);
+        }
+        catch (Exception)
+		{
+            return StatusCode(500);
+        }
+    }
+
+    [HttpGet("GetUserById")]
+    [Authorize(Policy = "CanViewUsersPolicy")]
+    public async Task<IActionResult> GetUserById(string userId)
+    {
+        try
+        {
+            string authorizationHeader = HttpContext.Request.Headers["Authorization"]!;
+            string accessToken = authorizationHeader.Substring("Bearer ".Length).Trim();
+
+            ReturnUserAndCodeResponseModel? returnUserAndCodeResponseModel = await _adminProcedures.FindUserByIdAsync(accessToken, new List<Claim>() { new Claim("Permission", "CanViewUsers") }, userId);
+            if (returnUserAndCodeResponseModel!.LibraryReturnedCodes == LibraryReturnedCodes.ValidTokenButUserNotInSystem)
+                return Unauthorized(new { ErrorMessage = "ValidTokenButUserNotInSystem" });
+            else if (returnUserAndCodeResponseModel.LibraryReturnedCodes == LibraryReturnedCodes.ValidTokenButUserNotInRoleInSystem)
+                return Unauthorized(new { ErrorMessage = "ValidTokenButUserNotInRoleInSystem" });
+            else if (returnUserAndCodeResponseModel.LibraryReturnedCodes == LibraryReturnedCodes.ValidTokenButClaimNotInSystem)
+                return Unauthorized(new { ErrorMessage = "ValidTokenButClaimNotInSystem" });
+            else if (returnUserAndCodeResponseModel.LibraryReturnedCodes == LibraryReturnedCodes.UserAccountNotActivated)
+                return Unauthorized(new { ErrorMessage = "UserAccountNotActivated" });
+            else if (returnUserAndCodeResponseModel.LibraryReturnedCodes == LibraryReturnedCodes.UserAccountLocked)
+                return Unauthorized(new { ErrorMessage = "UserAccountLocked" });
+
+            if (returnUserAndCodeResponseModel.AppUser is null)
+                return NotFound();
+
+            return Ok(returnUserAndCodeResponseModel.AppUser);
+        }
+        catch (Exception)
+        {
+            return StatusCode(500);
+        }
+    }
+
+    [HttpGet("GetUserByEmail")]
+    [Authorize(Policy = "CanViewUsersPolicy")]
+    public async Task<IActionResult> GetUserByEmail(string email)
+    {
+        try
+        {
+            string authorizationHeader = HttpContext.Request.Headers["Authorization"]!;
+            string accessToken = authorizationHeader.Substring("Bearer ".Length).Trim();
+
+            ReturnUserAndCodeResponseModel? returnUserAndCodeResponseModel = await _adminProcedures.FindUserByEmailAsync(accessToken, new List<Claim>() { new Claim("Permission", "CanViewUsers") }, email);
+            if (returnUserAndCodeResponseModel!.LibraryReturnedCodes == LibraryReturnedCodes.ValidTokenButUserNotInSystem)
+                return Unauthorized(new { ErrorMessage = "ValidTokenButUserNotInSystem" });
+            else if (returnUserAndCodeResponseModel.LibraryReturnedCodes == LibraryReturnedCodes.ValidTokenButUserNotInRoleInSystem)
+                return Unauthorized(new { ErrorMessage = "ValidTokenButUserNotInRoleInSystem" });
+            else if (returnUserAndCodeResponseModel.LibraryReturnedCodes == LibraryReturnedCodes.ValidTokenButClaimNotInSystem)
+                return Unauthorized(new { ErrorMessage = "ValidTokenButClaimNotInSystem" });
+            else if (returnUserAndCodeResponseModel.LibraryReturnedCodes == LibraryReturnedCodes.UserAccountNotActivated)
+                return Unauthorized(new { ErrorMessage = "UserAccountNotActivated" });
+            else if (returnUserAndCodeResponseModel.LibraryReturnedCodes == LibraryReturnedCodes.UserAccountLocked)
+                return Unauthorized(new { ErrorMessage = "UserAccountLocked" });
+
+            if (returnUserAndCodeResponseModel.AppUser is null)
+                return NotFound();
+
+            return Ok(returnUserAndCodeResponseModel.AppUser);
+        }
+        catch (Exception)
+        {
+            return StatusCode(500);
+        }
+    }
+
+    [HttpPost]
+    [Authorize(Policy = "CanViewUsersPolicy")]
+    [Authorize(Policy = "CanEditUsersPolicy")]
+    public async Task<IActionResult> CreateUserAccount([FromBody] ApiCreateUserRequestModel apiCreateUserRequestModel)
+    {
+        try
+        {
+            string authorizationHeader = HttpContext.Request.Headers["Authorization"]!;
+            string accessToken = authorizationHeader.Substring("Bearer ".Length).Trim();
+
+            List<Claim> expectedClaims = new List<Claim>() { new Claim("Permission", "CanViewUsers") , new Claim("Permission", "CanEditUsers")};
+            ReturnUserAndCodeResponseModel returnUserAndCodeResponseModel = await _adminProcedures.CreateUserAccountAsync(accessToken, expectedClaims, apiCreateUserRequestModel.Email!, apiCreateUserRequestModel.Password!, 
+                apiCreateUserRequestModel.PhoneNumber!);
+
+            if (returnUserAndCodeResponseModel!.LibraryReturnedCodes == LibraryReturnedCodes.ValidTokenButUserNotInSystem)
+                return Unauthorized(new { ErrorMessage = "ValidTokenButUserNotInSystem" });
+            else if (returnUserAndCodeResponseModel.LibraryReturnedCodes == LibraryReturnedCodes.ValidTokenButUserNotInRoleInSystem)
+                return Unauthorized(new { ErrorMessage = "ValidTokenButUserNotInRoleInSystem" });
+            else if (returnUserAndCodeResponseModel.LibraryReturnedCodes == LibraryReturnedCodes.ValidTokenButClaimNotInSystem)
+                return Unauthorized(new { ErrorMessage = "ValidTokenButClaimNotInSystem" });
+            else if (returnUserAndCodeResponseModel.LibraryReturnedCodes == LibraryReturnedCodes.UserAccountNotActivated)
+                return Unauthorized(new { ErrorMessage = "UserAccountNotActivated" });
+            else if (returnUserAndCodeResponseModel.LibraryReturnedCodes == LibraryReturnedCodes.UserAccountLocked)
+                return Unauthorized(new { ErrorMessage = "UserAccountLocked" });
+            else if (returnUserAndCodeResponseModel.LibraryReturnedCodes == LibraryReturnedCodes.DuplicateEmail)
+                return BadRequest(new { ErrorMessage = "DuplicateEmail" });
+            else if (returnUserAndCodeResponseModel.LibraryReturnedCodes == LibraryReturnedCodes.UnknownError)
+                return BadRequest(new { ErrorMessage = "UnknownError" });
+
+            return CreatedAtAction(nameof(GetUserById), new { userId = returnUserAndCodeResponseModel.AppUser!.Id}, returnUserAndCodeResponseModel.AppUser);
+        }
+        catch (Exception)
+        {
+            return StatusCode(500);
+        }
+    }
+
+    [HttpPut]
+    [Authorize(Policy = "CanViewUsersPolicy")]
+    [Authorize(Policy = "CanEditUsersPolicy")]
+    public async Task<IActionResult> UpdateUserAccount([FromBody] ApiUpdateUserRequestModel apiUpdateUserRequestModel)
+    {
+        try
+        {
+            string authorizationHeader = HttpContext.Request.Headers["Authorization"]!;
+            string accessToken = authorizationHeader.Substring("Bearer ".Length).Trim();
+
+            List<Claim> expectedClaims = new List<Claim>() { new Claim("Permission", "CanViewUsers"), new Claim("Permission", "CanEditUsers") };
+            LibraryReturnedCodes returnedCode = await _adminProcedures.UpdateUserAccountAsync(accessToken, expectedClaims, apiUpdateUserRequestModel.AppUser!,
+                apiUpdateUserRequestModel.ActivateEmail, apiUpdateUserRequestModel.Password);
+
+            if (returnedCode == LibraryReturnedCodes.ValidTokenButUserNotInSystem)
+                return Unauthorized(new { ErrorMessage = "ValidTokenButUserNotInSystem" });
+            else if (returnedCode == LibraryReturnedCodes.ValidTokenButUserNotInRoleInSystem)
+                return Unauthorized(new { ErrorMessage = "ValidTokenButUserNotInRoleInSystem" });
+            else if (returnedCode == LibraryReturnedCodes.ValidTokenButClaimNotInSystem)
+                return Unauthorized(new { ErrorMessage = "ValidTokenButClaimNotInSystem" });
+            else if (returnedCode == LibraryReturnedCodes.UserAccountNotActivated)
+                return Unauthorized(new { ErrorMessage = "UserAccountNotActivated" });
+            else if (returnedCode == LibraryReturnedCodes.UserAccountLocked)
+                return Unauthorized(new { ErrorMessage = "UserAccountLocked" });
+            else if(returnedCode == LibraryReturnedCodes.UserNotFoundWithGivenId)
+                return BadRequest(new { ErrorMessage =  "UserNotFoundWithGivenId"});
+            else if (returnedCode == LibraryReturnedCodes.DuplicateEmail)
+                return BadRequest(new { ErrorMessage = "DuplicateEmail" });
+            else if (returnedCode == LibraryReturnedCodes.UnknownError)
+                return BadRequest(new { ErrorMessage = "UnknownError" });
+
+            return NoContent();
+        }
+        catch (Exception)
+        {
+            return StatusCode(500);
+        }
+    }
+
+    [HttpDelete("{userId}")]
+    [Authorize(Policy = "CanViewUsersPolicy")]
+    [Authorize(Policy = "CanEditUsersPolicy")]
+    public async Task<IActionResult> DeleteUserAccount(string userId)
+    {
+        try
+        {
+            string authorizationHeader = HttpContext.Request.Headers["Authorization"]!;
+            string accessToken = authorizationHeader.Substring("Bearer ".Length).Trim();
+
+            List<Claim> expectedClaims = new List<Claim>() { new Claim("Permission", "CanViewUsers"), new Claim("Permission", "CanEditUsers") };
+            LibraryReturnedCodes returnedCode = await _adminProcedures.DeleteUserAccountAsync(accessToken, expectedClaims, userId);
+
+            if (returnedCode == LibraryReturnedCodes.ValidTokenButUserNotInSystem)
+                return Unauthorized(new { ErrorMessage = "ValidTokenButUserNotInSystem" });
+            else if (returnedCode == LibraryReturnedCodes.ValidTokenButUserNotInRoleInSystem)
+                return Unauthorized(new { ErrorMessage = "ValidTokenButUserNotInRoleInSystem" });
+            else if (returnedCode == LibraryReturnedCodes.ValidTokenButClaimNotInSystem)
+                return Unauthorized(new { ErrorMessage = "ValidTokenButClaimNotInSystem" });
+            else if (returnedCode == LibraryReturnedCodes.UserAccountNotActivated)
+                return Unauthorized(new { ErrorMessage = "UserAccountNotActivated" });
+            else if (returnedCode == LibraryReturnedCodes.UserAccountLocked)
+                return Unauthorized(new { ErrorMessage = "UserAccountLocked" });
+            else if (returnedCode == LibraryReturnedCodes.UserNotFoundWithGivenId)
+                return BadRequest(new { ErrorMessage = "UserNotFoundWithGivenId" });
+            else if (returnedCode == LibraryReturnedCodes.UnknownError)
+                return BadRequest(new { ErrorMessage = "UnknownError" });
+            
+            return NoContent();
+        }
+        catch (Exception)
+        {
+            return StatusCode(500);
+        }
+    }
+}

--- a/EshopApp.AuthLibraryAPI/Controllers/AuthenticationController.cs
+++ b/EshopApp.AuthLibraryAPI/Controllers/AuthenticationController.cs
@@ -1,6 +1,5 @@
 ﻿using EshopApp.AuthLibrary.Models.ResponseModels.AuthenticationModels;
 using EshopApp.AuthLibrary.AuthLogic;
-using EshopApp.AuthLibraryAPI.Models.RequestModels;
 using EshopApp.AuthLibraryAPI.Models.ResponseModels;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authorization;
@@ -8,6 +7,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.RateLimiting;
 using System.Web;
 using EshopApp.AuthLibrary.Models.ResponseModels;
+using EshopApp.AuthLibraryAPI.Models.RequestModels.AuthenticationModels;
 
 namespace EshopApp.AuthLibraryAPI.Controllers;
 

--- a/EshopApp.AuthLibraryAPI/Controllers/RoleController.cs
+++ b/EshopApp.AuthLibraryAPI/Controllers/RoleController.cs
@@ -1,0 +1,432 @@
+﻿using EshopApp.AuthLibrary.AuthLogic;
+using EshopApp.AuthLibrary.Models.ResponseModels;
+using EshopApp.AuthLibrary.Models.ResponseModels.RoleManagementModels;
+using EshopApp.AuthLibraryAPI.Models.RequestModels.RoleModels;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.RateLimiting;
+using System.Security.Claims;
+
+namespace EshopApp.AuthLibraryAPI.Controllers;
+
+[ApiController]
+[EnableRateLimiting("DefaultWindowLimiter")]
+[Route("api/[controller]")]
+public class RoleController : ControllerBase
+{
+    private readonly RoleManagementProcedures _roleManagementProcedures;
+
+    public RoleController(RoleManagementProcedures roleManagementProcedures)
+    {
+        _roleManagementProcedures = roleManagementProcedures;
+    }
+
+    [HttpGet]
+    [Authorize(Policy = "CanViewUserRolesPolicy")]
+    public async Task<IActionResult> GetRoles()
+    {
+        try
+        {
+            string authorizationHeader = HttpContext.Request.Headers["Authorization"]!;
+            string accessToken = authorizationHeader.Substring("Bearer ".Length).Trim();
+
+            ReturnRolesAndCodeResponseModel returnRolesAndCodeResponseModel = await _roleManagementProcedures.GetRolesAsync(accessToken, new List<Claim>() { new Claim("Permission", "CanViewUserRoles") });
+            if (returnRolesAndCodeResponseModel.LibraryReturnedCodes == LibraryReturnedCodes.ValidTokenButUserNotInSystem)
+                return Unauthorized(new { ErrorMessage = "ValidTokenButUserNotInSystem" });
+            else if (returnRolesAndCodeResponseModel.LibraryReturnedCodes == LibraryReturnedCodes.ValidTokenButUserNotInRoleInSystem)
+                return Unauthorized(new { ErrorMessage = "ValidTokenButUserNotInRoleInSystem" });
+            else if (returnRolesAndCodeResponseModel.LibraryReturnedCodes == LibraryReturnedCodes.ValidTokenButClaimNotInSystem)
+                return Unauthorized(new { ErrorMessage = "ValidTokenButClaimNotInSystem" });
+            else if (returnRolesAndCodeResponseModel.LibraryReturnedCodes == LibraryReturnedCodes.UserAccountNotActivated)
+                return Unauthorized(new { ErrorMessage = "UserAccountNotActivated" });
+            else if (returnRolesAndCodeResponseModel.LibraryReturnedCodes == LibraryReturnedCodes.UserAccountLocked)
+                return Unauthorized(new { ErrorMessage = "UserAccountLocked" });
+
+            return Ok(returnRolesAndCodeResponseModel.AppRoles);
+        }
+        catch (Exception)
+        {
+            return StatusCode(500);
+        }
+    }
+
+    [HttpGet("GetRoleById/{roleId}")]
+    [Authorize(Policy = "CanViewUserRolesPolicy")]
+    public async Task<IActionResult> GetRoleById(string roleId)
+    {
+        try
+        {
+            string authorizationHeader = HttpContext.Request.Headers["Authorization"]!;
+            string accessToken = authorizationHeader.Substring("Bearer ".Length).Trim();
+
+            ReturnRoleAndCodeResponseModel returnRoleAndCodeResponseModel = await _roleManagementProcedures.GetRoleByIdAsync(accessToken, new List<Claim>() { new Claim("Permission", "CanViewUserRoles") }, roleId);
+            if (returnRoleAndCodeResponseModel.LibraryReturnedCodes == LibraryReturnedCodes.ValidTokenButUserNotInSystem)
+                return Unauthorized(new { ErrorMessage = "ValidTokenButUserNotInSystem" });
+            else if (returnRoleAndCodeResponseModel.LibraryReturnedCodes == LibraryReturnedCodes.ValidTokenButUserNotInRoleInSystem)
+                return Unauthorized(new { ErrorMessage = "ValidTokenButUserNotInRoleInSystem" });
+            else if (returnRoleAndCodeResponseModel.LibraryReturnedCodes == LibraryReturnedCodes.ValidTokenButClaimNotInSystem)
+                return Unauthorized(new { ErrorMessage = "ValidTokenButClaimNotInSystem" });
+            else if (returnRoleAndCodeResponseModel.LibraryReturnedCodes == LibraryReturnedCodes.UserAccountNotActivated)
+                return Unauthorized(new { ErrorMessage = "UserAccountNotActivated" });
+            else if (returnRoleAndCodeResponseModel.LibraryReturnedCodes == LibraryReturnedCodes.UserAccountLocked)
+                return Unauthorized(new { ErrorMessage = "UserAccountLocked" });
+
+            if(returnRoleAndCodeResponseModel.AppRole is null)
+                return NotFound();
+
+            return Ok(returnRoleAndCodeResponseModel.AppRole);
+        }
+        catch (Exception)
+        {
+            return StatusCode(500);
+        }
+    }
+
+    [HttpGet("GetRoleByName/{roleName}")]
+    [Authorize(Policy = "CanViewUserRolesPolicy")]
+    public async Task<IActionResult> GetRoleByName(string roleName)
+    {
+        try
+        {
+            string authorizationHeader = HttpContext.Request.Headers["Authorization"]!;
+            string accessToken = authorizationHeader.Substring("Bearer ".Length).Trim();
+
+            ReturnRoleAndCodeResponseModel returnRoleAndCodeResponseModel = await _roleManagementProcedures.GetRoleByIdAsync(accessToken, new List<Claim>() { new Claim("Permission", "CanViewUserRoles") }, roleName);
+            if (returnRoleAndCodeResponseModel.LibraryReturnedCodes == LibraryReturnedCodes.ValidTokenButUserNotInSystem)
+                return Unauthorized(new { ErrorMessage = "ValidTokenButUserNotInSystem" });
+            else if (returnRoleAndCodeResponseModel.LibraryReturnedCodes == LibraryReturnedCodes.ValidTokenButUserNotInRoleInSystem)
+                return Unauthorized(new { ErrorMessage = "ValidTokenButUserNotInRoleInSystem" });
+            else if (returnRoleAndCodeResponseModel.LibraryReturnedCodes == LibraryReturnedCodes.ValidTokenButClaimNotInSystem)
+                return Unauthorized(new { ErrorMessage = "ValidTokenButClaimNotInSystem" });
+            else if (returnRoleAndCodeResponseModel.LibraryReturnedCodes == LibraryReturnedCodes.UserAccountNotActivated)
+                return Unauthorized(new { ErrorMessage = "UserAccountNotActivated" });
+            else if (returnRoleAndCodeResponseModel.LibraryReturnedCodes == LibraryReturnedCodes.UserAccountLocked)
+                return Unauthorized(new { ErrorMessage = "UserAccountLocked" });
+
+            if (returnRoleAndCodeResponseModel.AppRole is null)
+                return NotFound();
+
+            return Ok(returnRoleAndCodeResponseModel.AppRole);
+        }
+        catch (Exception)
+        {
+            return StatusCode(500);
+        }
+    }
+
+    [HttpGet("GetRolesOfUser/{userId}")]
+    [Authorize(Policy = "CanViewUserRolesPolicy")]
+    public async Task<IActionResult> GetRolesOfUser(string userId)
+    {
+        try
+        {
+            string authorizationHeader = HttpContext.Request.Headers["Authorization"]!;
+            string accessToken = authorizationHeader.Substring("Bearer ".Length).Trim();
+
+            ReturnRolesAndCodeResponseModel returnRolesAndCodeResponseModel = await _roleManagementProcedures.GetRolesAsync(accessToken, new List<Claim>() { new Claim("Permission", "CanViewUserRoles") });
+            if (returnRolesAndCodeResponseModel.LibraryReturnedCodes == LibraryReturnedCodes.ValidTokenButUserNotInSystem)
+                return Unauthorized(new { ErrorMessage = "ValidTokenButUserNotInSystem" });
+            else if (returnRolesAndCodeResponseModel.LibraryReturnedCodes == LibraryReturnedCodes.ValidTokenButUserNotInRoleInSystem)
+                return Unauthorized(new { ErrorMessage = "ValidTokenButUserNotInRoleInSystem" });
+            else if (returnRolesAndCodeResponseModel.LibraryReturnedCodes == LibraryReturnedCodes.ValidTokenButClaimNotInSystem)
+                return Unauthorized(new { ErrorMessage = "ValidTokenButClaimNotInSystem" });
+            else if (returnRolesAndCodeResponseModel.LibraryReturnedCodes == LibraryReturnedCodes.UserAccountNotActivated)
+                return Unauthorized(new { ErrorMessage = "UserAccountNotActivated" });
+            else if (returnRolesAndCodeResponseModel.LibraryReturnedCodes == LibraryReturnedCodes.UserAccountLocked)
+                return Unauthorized(new { ErrorMessage = "UserAccountLocked" });
+            else if (returnRolesAndCodeResponseModel.LibraryReturnedCodes == LibraryReturnedCodes.UserNotFoundWithGivenId)
+                return BadRequest(new { ErrorMessage = "UserNotFoundWithGivenId" });
+
+            return Ok(returnRolesAndCodeResponseModel.AppRoles);
+        }
+        catch (Exception)
+        {
+            return StatusCode(500);
+        }
+    }
+
+    [HttpPost]
+    [Authorize(Policy = "CanViewUserRolesPolicy")]
+    [Authorize(Policy = "CanEditUserRolesPolicy")]
+    public async Task<IActionResult> CreateRole([FromBody] ApiCreateRoleRequestModel apiCreateRoleRequestModel)
+    {
+        try
+        {
+            string authorizationHeader = HttpContext.Request.Headers["Authorization"]!;
+            string accessToken = authorizationHeader.Substring("Bearer ".Length).Trim();
+
+            List<Claim> expectedClaims = new List<Claim>() { new Claim("Permission", "CanViewUserRoles"), new Claim("Permission", "CanEditUserRoles") };
+            ReturnRoleAndCodeResponseModel returnRoleAndCodeResponseModel = await _roleManagementProcedures.CreateRoleAsync(accessToken, expectedClaims,
+                apiCreateRoleRequestModel.RoleName!, apiCreateRoleRequestModel.Claims);
+            if (returnRoleAndCodeResponseModel.LibraryReturnedCodes == LibraryReturnedCodes.ValidTokenButUserNotInSystem)
+                return Unauthorized(new { ErrorMessage = "ValidTokenButUserNotInSystem" });
+            else if (returnRoleAndCodeResponseModel.LibraryReturnedCodes == LibraryReturnedCodes.ValidTokenButUserNotInRoleInSystem)
+                return Unauthorized(new { ErrorMessage = "ValidTokenButUserNotInRoleInSystem" });
+            else if (returnRoleAndCodeResponseModel.LibraryReturnedCodes == LibraryReturnedCodes.ValidTokenButClaimNotInSystem)
+                return Unauthorized(new { ErrorMessage = "ValidTokenButClaimNotInSystem" });
+            else if (returnRoleAndCodeResponseModel.LibraryReturnedCodes == LibraryReturnedCodes.UserAccountNotActivated)
+                return Unauthorized(new { ErrorMessage = "UserAccountNotActivated" });
+            else if (returnRoleAndCodeResponseModel.LibraryReturnedCodes == LibraryReturnedCodes.UserAccountLocked)
+                return Unauthorized(new { ErrorMessage = "UserAccountLocked" });
+            else if (returnRoleAndCodeResponseModel.LibraryReturnedCodes == LibraryReturnedCodes.DuplicateRole)
+                return BadRequest(new { ErrorMessage = "DuplicateRole" });
+            else if (returnRoleAndCodeResponseModel.LibraryReturnedCodes == LibraryReturnedCodes.UnknownError)
+                return BadRequest(new { ErrorMessage = "UnknownError" });
+
+            return CreatedAtAction(nameof(GetRoleById), new { userId = returnRoleAndCodeResponseModel.AppRole!.Id }, returnRoleAndCodeResponseModel.AppRole);
+        }
+        catch (Exception)
+        {
+            return StatusCode(500);
+        }
+    }
+
+    [HttpDelete]
+    [Authorize(Policy = "CanViewUserRolesPolicy")]
+    [Authorize(Policy = "CanEditUserRolesPolicy")]
+    public async Task<IActionResult> DeleteRole(string roleId)
+    {
+        try
+        {
+            string authorizationHeader = HttpContext.Request.Headers["Authorization"]!;
+            string accessToken = authorizationHeader.Substring("Bearer ".Length).Trim();
+
+            List<Claim> expectedClaims = new List<Claim>() { new Claim("Permission", "CanViewUserRoles"), new Claim("Permission", "CanEditUserRoles") };
+            LibraryReturnedCodes returnCode = await _roleManagementProcedures.DeleteRoleAsync(accessToken, expectedClaims, roleId);
+            if (returnCode == LibraryReturnedCodes.ValidTokenButUserNotInSystem)
+                return Unauthorized(new { ErrorMessage = "ValidTokenButUserNotInSystem" });
+            else if (returnCode == LibraryReturnedCodes.ValidTokenButUserNotInRoleInSystem)
+                return Unauthorized(new { ErrorMessage = "ValidTokenButUserNotInRoleInSystem" });
+            else if (returnCode == LibraryReturnedCodes.ValidTokenButClaimNotInSystem)
+                return Unauthorized(new { ErrorMessage = "ValidTokenButClaimNotInSystem" });
+            else if (returnCode == LibraryReturnedCodes.UserAccountNotActivated)
+                return Unauthorized(new { ErrorMessage = "UserAccountNotActivated" });
+            else if (returnCode == LibraryReturnedCodes.UserAccountLocked)
+                return Unauthorized(new { ErrorMessage = "UserAccountLocked" });
+            else if (returnCode == LibraryReturnedCodes.RoleNotFoundWithGivenId)
+                return BadRequest(new { ErrorMessage = "RoleNotFoundWithGivenId" });
+            else if (returnCode == LibraryReturnedCodes.UnknownError)
+                return BadRequest(new { ErrorMessage = "UnknownError" });
+
+            return NoContent();
+        }
+        catch (Exception)
+        {
+            return StatusCode(500);
+        }
+    }
+
+    [HttpGet("GetUsersOfRole/{roleId}")]
+    [Authorize(Policy = "CanViewUserRolesPolicy")]
+    public async Task<IActionResult> GetUsersOfRole(string roleId)
+    {
+        try
+        {
+            string authorizationHeader = HttpContext.Request.Headers["Authorization"]!;
+            string accessToken = authorizationHeader.Substring("Bearer ".Length).Trim();
+
+            ReturnUsersAndCodeResponseModel returnUsersAndCodeResponseModel = await _roleManagementProcedures.GetUsersOfGivenRoleAsync(accessToken, new List<Claim>() { new Claim("Permission", "CanViewUserRoles") }, roleId);
+            if (returnUsersAndCodeResponseModel.LibraryReturnedCodes == LibraryReturnedCodes.ValidTokenButUserNotInSystem)
+                return Unauthorized(new { ErrorMessage = "ValidTokenButUserNotInSystem" });
+            else if (returnUsersAndCodeResponseModel.LibraryReturnedCodes == LibraryReturnedCodes.ValidTokenButUserNotInRoleInSystem)
+                return Unauthorized(new { ErrorMessage = "ValidTokenButUserNotInRoleInSystem" });
+            else if (returnUsersAndCodeResponseModel.LibraryReturnedCodes == LibraryReturnedCodes.ValidTokenButClaimNotInSystem)
+                return Unauthorized(new { ErrorMessage = "ValidTokenButClaimNotInSystem" });
+            else if (returnUsersAndCodeResponseModel.LibraryReturnedCodes == LibraryReturnedCodes.UserAccountNotActivated)
+                return Unauthorized(new { ErrorMessage = "UserAccountNotActivated" });
+            else if (returnUsersAndCodeResponseModel.LibraryReturnedCodes == LibraryReturnedCodes.UserAccountLocked)
+                return Unauthorized(new { ErrorMessage = "UserAccountLocked" });
+            else if (returnUsersAndCodeResponseModel.LibraryReturnedCodes == LibraryReturnedCodes.RoleNotFoundWithGivenId)
+                return BadRequest(new { ErrorMessage = "RoleNotFoundWithGivenId" });
+
+            return Ok(returnUsersAndCodeResponseModel.AppUsers);
+        }
+        catch (Exception)
+        {
+            return StatusCode(500);
+        }
+    }
+
+    [HttpPost("AddRoleToUser")]
+    [Authorize(Policy = "CanViewUserRolesPolicy")]
+    [Authorize(Policy = "CanEditUserRolesPolicy")]
+    public async Task<IActionResult> AddRoleToUser([FromBody] ApiAddRoleToUserRequestModel apiAddRoleToUserRequestModel)
+    {
+        try
+        {
+            string authorizationHeader = HttpContext.Request.Headers["Authorization"]!;
+            string accessToken = authorizationHeader.Substring("Bearer ".Length).Trim();
+
+            List<Claim> expectedClaims = new List<Claim>() { new Claim("Permission", "CanViewUserRoles"), new Claim("Permission", "CanEditUserRoles") };
+            LibraryReturnedCodes returnedCode = await _roleManagementProcedures.AddRoleToUserAsync(accessToken, expectedClaims, 
+                apiAddRoleToUserRequestModel.UserId!, apiAddRoleToUserRequestModel.RoleId!);
+            
+            if (returnedCode == LibraryReturnedCodes.ValidTokenButUserNotInSystem)
+                return Unauthorized(new { ErrorMessage = "ValidTokenButUserNotInSystem" });
+            else if (returnedCode== LibraryReturnedCodes.ValidTokenButUserNotInRoleInSystem)
+                return Unauthorized(new { ErrorMessage = "ValidTokenButUserNotInRoleInSystem" });
+            else if (returnedCode == LibraryReturnedCodes.ValidTokenButClaimNotInSystem)
+                return Unauthorized(new { ErrorMessage = "ValidTokenButClaimNotInSystem" });
+            else if (returnedCode == LibraryReturnedCodes.UserAccountNotActivated)
+                return Unauthorized(new { ErrorMessage = "UserAccountNotActivated" });
+            else if (returnedCode == LibraryReturnedCodes.UserAccountLocked)
+                return Unauthorized(new { ErrorMessage = "UserAccountLocked" });
+            else if (returnedCode == LibraryReturnedCodes.UserNotFoundWithGivenId)
+                return BadRequest(new { ErrorMessage = "UserNotFoundWithGivenId" });
+            else if (returnedCode == LibraryReturnedCodes.RoleNotFoundWithGivenId)
+                return BadRequest(new { ErrorMessage = "RoleNotFoundWithGivenId" });
+            else if (returnedCode == LibraryReturnedCodes.UnknownError)
+                return BadRequest(new { ErrorMessage = "UnknownError" });
+
+            return NoContent();
+        }
+        catch (Exception)
+        {
+            return StatusCode(500);
+        }
+    }
+
+    [HttpPost("ReplaceRoleOfUser")]
+    [Authorize(Policy = "CanViewUserRolesPolicy")]
+    [Authorize(Policy = "CanEditUserRolesPolicy")]
+    public async Task<IActionResult> ReplaceRoleOfUser([FromBody] ApiReplaceRoleOfUserRequestModel apiReplaceRoleOfUserRequestModel)
+    {
+        try
+        {
+            string authorizationHeader = HttpContext.Request.Headers["Authorization"]!;
+            string accessToken = authorizationHeader.Substring("Bearer ".Length).Trim();
+
+            List<Claim> expectedClaims = new List<Claim>() { new Claim("Permission", "CanViewUserRoles"), new Claim("Permission", "CanEditUserRoles") };
+            LibraryReturnedCodes returnedCode = await _roleManagementProcedures.ReplaceRoleOfUserAsync(accessToken, expectedClaims,
+                apiReplaceRoleOfUserRequestModel.UserId!, apiReplaceRoleOfUserRequestModel.CurrentRoleId!, apiReplaceRoleOfUserRequestModel.NewRoleId!);
+
+            if (returnedCode == LibraryReturnedCodes.ValidTokenButUserNotInSystem)
+                return Unauthorized(new { ErrorMessage = "ValidTokenButUserNotInSystem" });
+            else if (returnedCode == LibraryReturnedCodes.ValidTokenButUserNotInRoleInSystem)
+                return Unauthorized(new { ErrorMessage = "ValidTokenButUserNotInRoleInSystem" });
+            else if (returnedCode == LibraryReturnedCodes.ValidTokenButClaimNotInSystem)
+                return Unauthorized(new { ErrorMessage = "ValidTokenButClaimNotInSystem" });
+            else if (returnedCode == LibraryReturnedCodes.UserAccountNotActivated)
+                return Unauthorized(new { ErrorMessage = "UserAccountNotActivated" });
+            else if (returnedCode == LibraryReturnedCodes.UserAccountLocked)
+                return Unauthorized(new { ErrorMessage = "UserAccountLocked" });
+            else if (returnedCode == LibraryReturnedCodes.UserNotFoundWithGivenId)
+                return BadRequest(new { ErrorMessage = "UserNotFoundWithGivenId" });
+            else if (returnedCode == LibraryReturnedCodes.RoleNotFoundWithGivenId)
+                return BadRequest(new { ErrorMessage = "RoleNotFoundWithGivenId" });
+            else if (returnedCode == LibraryReturnedCodes.UnknownError)
+                return BadRequest(new { ErrorMessage = "UnknownError" });
+
+            return NoContent();
+        }
+        catch (Exception)
+        {
+            return StatusCode(500);
+        }
+    }
+
+    [HttpDelete("RemoveRoleFromUser/{userId}/role/{roldId}")]
+    [Authorize(Policy = "CanViewUserRolesPolicy")]
+    [Authorize(Policy = "CanEditUserRolesPolicy")]
+    public async Task<IActionResult> RemoveRoleFromUser(string userId, string roleId)
+    {
+        try
+        {
+            string authorizationHeader = HttpContext.Request.Headers["Authorization"]!;
+            string accessToken = authorizationHeader.Substring("Bearer ".Length).Trim();
+
+            List<Claim> expectedClaims = new List<Claim>() { new Claim("Permission", "CanViewUserRoles"), new Claim("Permission", "CanEditUserRoles") };
+            LibraryReturnedCodes returnedCode = await _roleManagementProcedures.RemoveRoleFromUserAsync(accessToken, expectedClaims, userId, roleId);
+
+            if (returnedCode == LibraryReturnedCodes.ValidTokenButUserNotInSystem)
+                return Unauthorized(new { ErrorMessage = "ValidTokenButUserNotInSystem" });
+            else if (returnedCode == LibraryReturnedCodes.ValidTokenButUserNotInRoleInSystem)
+                return Unauthorized(new { ErrorMessage = "ValidTokenButUserNotInRoleInSystem" });
+            else if (returnedCode == LibraryReturnedCodes.ValidTokenButClaimNotInSystem)
+                return Unauthorized(new { ErrorMessage = "ValidTokenButClaimNotInSystem" });
+            else if (returnedCode == LibraryReturnedCodes.UserAccountNotActivated)
+                return Unauthorized(new { ErrorMessage = "UserAccountNotActivated" });
+            else if (returnedCode == LibraryReturnedCodes.UserAccountLocked)
+                return Unauthorized(new { ErrorMessage = "UserAccountLocked" });
+            else if (returnedCode == LibraryReturnedCodes.UserNotFoundWithGivenId)
+                return BadRequest(new { ErrorMessage = "UserNotFoundWithGivenId" });
+            else if (returnedCode == LibraryReturnedCodes.RoleNotFoundWithGivenId)
+                return BadRequest(new { ErrorMessage = "RoleNotFoundWithGivenId" });
+            else if (returnedCode == LibraryReturnedCodes.UnknownError)
+                return BadRequest(new { ErrorMessage = "UnknownError" });
+
+            return NoContent();
+        }
+        catch (Exception)
+        {
+            return StatusCode(500);
+        }
+    }
+
+    [HttpGet("GetClaims")]
+    [Authorize(Policy = "CanViewUserRolesPolicy")]
+    public async Task<IActionResult> GetClaimsInSystem()
+    {
+        try
+        {
+            string authorizationHeader = HttpContext.Request.Headers["Authorization"]!;
+            string accessToken = authorizationHeader.Substring("Bearer ".Length).Trim();
+
+            ReturnClaimsAndCodeResponseModel returnClaimsAndCodeResponseModel = await _roleManagementProcedures.GetAllUniqueClaimsInSystemAsync(accessToken, new List<Claim>() { new Claim("Permission", "CanViewUserRoles") });
+            if (returnClaimsAndCodeResponseModel.LibraryReturnedCodes == LibraryReturnedCodes.ValidTokenButUserNotInSystem)
+                return Unauthorized(new { ErrorMessage = "ValidTokenButUserNotInSystem" });
+            else if (returnClaimsAndCodeResponseModel.LibraryReturnedCodes == LibraryReturnedCodes.ValidTokenButUserNotInRoleInSystem)
+                return Unauthorized(new { ErrorMessage = "ValidTokenButUserNotInRoleInSystem" });
+            else if (returnClaimsAndCodeResponseModel.LibraryReturnedCodes == LibraryReturnedCodes.ValidTokenButClaimNotInSystem)
+                return Unauthorized(new { ErrorMessage = "ValidTokenButClaimNotInSystem" });
+            else if (returnClaimsAndCodeResponseModel.LibraryReturnedCodes == LibraryReturnedCodes.UserAccountNotActivated)
+                return Unauthorized(new { ErrorMessage = "UserAccountNotActivated" });
+            else if (returnClaimsAndCodeResponseModel.LibraryReturnedCodes == LibraryReturnedCodes.UserAccountLocked)
+                return Unauthorized(new { ErrorMessage = "UserAccountLocked" });
+
+
+            return Ok(returnClaimsAndCodeResponseModel.Claims);
+        }
+        catch (Exception)
+        {
+            return StatusCode(500);
+        }
+    }
+
+    [HttpPost("UpdateClaimsOfRole")]
+    [Authorize(Policy = "CanViewUserRolesPolicy")]
+    [Authorize(Policy = "CanEditUserRolesPolicy")]
+    public async Task<IActionResult> UpdateClaimsOfRole([FromBody] ApiUpdateClaimsOfRoleRequestModel apiUpdateClaimsOfRoleRequestModel)
+    {
+        try
+        {
+            string authorizationHeader = HttpContext.Request.Headers["Authorization"]!;
+            string accessToken = authorizationHeader.Substring("Bearer ".Length).Trim();
+
+            List<Claim> expectedClaims = new List<Claim>() { new Claim("Permission", "CanViewUserRoles"), new Claim("Permission", "CanEditUserRoles") };
+            ReturnRoleAndCodeResponseModel returnRoleAndCodeResponseModel = await _roleManagementProcedures.UpdateClaimsOfRoleAsync(accessToken, expectedClaims,
+                apiUpdateClaimsOfRoleRequestModel.RoleId!, apiUpdateClaimsOfRoleRequestModel.NewClaims);
+
+            if (returnRoleAndCodeResponseModel.LibraryReturnedCodes == LibraryReturnedCodes.ValidTokenButUserNotInSystem)
+                return Unauthorized(new { ErrorMessage = "ValidTokenButUserNotInSystem" });
+            else if (returnRoleAndCodeResponseModel.LibraryReturnedCodes == LibraryReturnedCodes.ValidTokenButUserNotInRoleInSystem)
+                return Unauthorized(new { ErrorMessage = "ValidTokenButUserNotInRoleInSystem" });
+            else if (returnRoleAndCodeResponseModel.LibraryReturnedCodes == LibraryReturnedCodes.ValidTokenButClaimNotInSystem)
+                return Unauthorized(new { ErrorMessage = "ValidTokenButClaimNotInSystem" });
+            else if (returnRoleAndCodeResponseModel.LibraryReturnedCodes == LibraryReturnedCodes.UserAccountNotActivated)
+                return Unauthorized(new { ErrorMessage = "UserAccountNotActivated" });
+            else if (returnRoleAndCodeResponseModel.LibraryReturnedCodes == LibraryReturnedCodes.UserAccountLocked)
+                return Unauthorized(new { ErrorMessage = "UserAccountLocked" });
+            else if (returnRoleAndCodeResponseModel.LibraryReturnedCodes == LibraryReturnedCodes.RoleNotFoundWithGivenId)
+                return BadRequest(new { ErrorMessage = "RoleNotFoundWithGivenId" });
+            else if (returnRoleAndCodeResponseModel.LibraryReturnedCodes == LibraryReturnedCodes.UnknownError)
+                return BadRequest(new { ErrorMessage = "UnknownError" });
+
+            return Ok(returnRoleAndCodeResponseModel.AppRole);
+        }
+        catch (Exception)
+        {
+            return StatusCode(500);
+        }
+    }
+}

--- a/EshopApp.AuthLibraryAPI/EshopApp.AuthLibraryAPI.csproj
+++ b/EshopApp.AuthLibraryAPI/EshopApp.AuthLibraryAPI.csproj
@@ -26,6 +26,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Folder Include="Models\RequestModels\RoleModels\" />
     <Folder Include="Models\ResponseModels\" />
   </ItemGroup>
 

--- a/EshopApp.AuthLibraryAPI/Models/RequestModels/AdminModels/ApiCreateUserRequestModel.cs
+++ b/EshopApp.AuthLibraryAPI/Models/RequestModels/AdminModels/ApiCreateUserRequestModel.cs
@@ -1,0 +1,17 @@
+﻿using EshopApp.AuthLibrary.Models;
+using System.ComponentModel.DataAnnotations;
+
+namespace EshopApp.AuthLibraryAPI.Models.RequestModels.AdminModels;
+
+public class ApiCreateUserRequestModel
+{
+    [Required]
+    [EmailAddress]
+    public string? Email { get; set; }
+
+    [Phone]
+    public string? PhoneNumber { get; set; }
+    
+    [Required]
+    public string? Password { get; set; }
+}

--- a/EshopApp.AuthLibraryAPI/Models/RequestModels/AdminModels/ApiUpdateUserRequestModel.cs
+++ b/EshopApp.AuthLibraryAPI/Models/RequestModels/AdminModels/ApiUpdateUserRequestModel.cs
@@ -1,0 +1,10 @@
+﻿using EshopApp.AuthLibrary.Models;
+
+namespace EshopApp.AuthLibraryAPI.Models.RequestModels.AdminModels;
+
+public class ApiUpdateUserRequestModel
+{
+    public AppUser? AppUser { get; set; }
+    public string? Password { get; set; }
+    public bool ActivateEmail { get; set; } = true;
+}

--- a/EshopApp.AuthLibraryAPI/Models/RequestModels/AuthenticationModels/ApiAccountBasicSettingsRequestModel.cs
+++ b/EshopApp.AuthLibraryAPI/Models/RequestModels/AuthenticationModels/ApiAccountBasicSettingsRequestModel.cs
@@ -1,4 +1,4 @@
-﻿namespace EshopApp.AuthLibraryAPI.Models.RequestModels;
+﻿namespace EshopApp.AuthLibraryAPI.Models.RequestModels.AuthenticationModels;
 
 public class ApiAccountBasicSettingsRequestModel
 {

--- a/EshopApp.AuthLibraryAPI/Models/RequestModels/AuthenticationModels/ApiChangeEmailRequestModel.cs
+++ b/EshopApp.AuthLibraryAPI/Models/RequestModels/AuthenticationModels/ApiChangeEmailRequestModel.cs
@@ -1,6 +1,6 @@
 ﻿using System.ComponentModel.DataAnnotations;
 
-namespace EshopApp.AuthLibraryAPI.Models.RequestModels;
+namespace EshopApp.AuthLibraryAPI.Models.RequestModels.AuthenticationModels;
 
 public class ApiChangeEmailRequestModel
 {

--- a/EshopApp.AuthLibraryAPI/Models/RequestModels/AuthenticationModels/ApiChangePasswordRequestModel.cs
+++ b/EshopApp.AuthLibraryAPI/Models/RequestModels/AuthenticationModels/ApiChangePasswordRequestModel.cs
@@ -1,6 +1,6 @@
 ﻿using System.ComponentModel.DataAnnotations;
 
-namespace EshopApp.AuthLibraryAPI.Models.RequestModels;
+namespace EshopApp.AuthLibraryAPI.Models.RequestModels.AuthenticationModels;
 
 public class ApiChangePasswordRequestModel
 {

--- a/EshopApp.AuthLibraryAPI/Models/RequestModels/AuthenticationModels/ApiExternalSignInRequestModel.cs
+++ b/EshopApp.AuthLibraryAPI/Models/RequestModels/AuthenticationModels/ApiExternalSignInRequestModel.cs
@@ -1,6 +1,6 @@
 ﻿using System.ComponentModel.DataAnnotations;
 
-namespace EshopApp.AuthLibraryAPI.Models.RequestModels;
+namespace EshopApp.AuthLibraryAPI.Models.RequestModels.AuthenticationModels;
 
 public class ApiExternalSignInRequestModel
 {

--- a/EshopApp.AuthLibraryAPI/Models/RequestModels/AuthenticationModels/ApiForgotPasswordRequestModel.cs
+++ b/EshopApp.AuthLibraryAPI/Models/RequestModels/AuthenticationModels/ApiForgotPasswordRequestModel.cs
@@ -1,6 +1,6 @@
 ﻿using System.ComponentModel.DataAnnotations;
 
-namespace EshopApp.AuthLibraryAPI.Models.RequestModels;
+namespace EshopApp.AuthLibraryAPI.Models.RequestModels.AuthenticationModels;
 
 public class ApiForgotPasswordRequestModel
 {

--- a/EshopApp.AuthLibraryAPI/Models/RequestModels/AuthenticationModels/ApiResetPasswordRequestModel.cs
+++ b/EshopApp.AuthLibraryAPI/Models/RequestModels/AuthenticationModels/ApiResetPasswordRequestModel.cs
@@ -1,6 +1,6 @@
 ﻿using System.ComponentModel.DataAnnotations;
 
-namespace EshopApp.AuthLibraryAPI.Models.RequestModels;
+namespace EshopApp.AuthLibraryAPI.Models.RequestModels.AuthenticationModels;
 
 public class ApiResetPasswordRequestModel
 {

--- a/EshopApp.AuthLibraryAPI/Models/RequestModels/AuthenticationModels/ApiSignInRequestModel.cs
+++ b/EshopApp.AuthLibraryAPI/Models/RequestModels/AuthenticationModels/ApiSignInRequestModel.cs
@@ -1,6 +1,6 @@
 ﻿using System.ComponentModel.DataAnnotations;
 
-namespace EshopApp.AuthLibraryAPI.Models.RequestModels;
+namespace EshopApp.AuthLibraryAPI.Models.RequestModels.AuthenticationModels;
 
 public class ApiSignInRequestModel
 {

--- a/EshopApp.AuthLibraryAPI/Models/RequestModels/AuthenticationModels/ApiSignUpRequestModel.cs
+++ b/EshopApp.AuthLibraryAPI/Models/RequestModels/AuthenticationModels/ApiSignUpRequestModel.cs
@@ -1,6 +1,6 @@
 ﻿using System.ComponentModel.DataAnnotations;
 
-namespace EshopApp.AuthLibraryAPI.Models.RequestModels;
+namespace EshopApp.AuthLibraryAPI.Models.RequestModels.AuthenticationModels;
 
 public class ApiSignUpRequestModel
 {

--- a/EshopApp.AuthLibraryAPI/Models/RequestModels/RoleModels/ApiAddRoleToUserRequestModel.cs
+++ b/EshopApp.AuthLibraryAPI/Models/RequestModels/RoleModels/ApiAddRoleToUserRequestModel.cs
@@ -1,0 +1,12 @@
+﻿using System.ComponentModel.DataAnnotations;
+
+namespace EshopApp.AuthLibraryAPI.Models.RequestModels.RoleModels;
+
+public class ApiAddRoleToUserRequestModel
+{
+    [Required]
+    public string? UserId { get; set; }
+
+    [Required]
+    public string? RoleId { get; set; }
+}

--- a/EshopApp.AuthLibraryAPI/Models/RequestModels/RoleModels/ApiCreateRoleRequestModel.cs
+++ b/EshopApp.AuthLibraryAPI/Models/RequestModels/RoleModels/ApiCreateRoleRequestModel.cs
@@ -1,0 +1,11 @@
+﻿using System.ComponentModel.DataAnnotations;
+using System.Security.Claims;
+
+namespace EshopApp.AuthLibraryAPI.Models.RequestModels.RoleModels;
+
+public class ApiCreateRoleRequestModel
+{
+    [Required]
+    public string? RoleName { get; set; }
+    public List<Claim> Claims { get; set; } = new List<Claim>();
+}

--- a/EshopApp.AuthLibraryAPI/Models/RequestModels/RoleModels/ApiReplaceRoleOfUserRequestModel.cs
+++ b/EshopApp.AuthLibraryAPI/Models/RequestModels/RoleModels/ApiReplaceRoleOfUserRequestModel.cs
@@ -1,0 +1,15 @@
+﻿using System.ComponentModel.DataAnnotations;
+
+namespace EshopApp.AuthLibraryAPI.Models.RequestModels.RoleModels;
+
+public class ApiReplaceRoleOfUserRequestModel
+{
+
+    [Required]
+    public string? UserId { get; set; }
+
+    [Required]
+    public string? CurrentRoleId { get; set; }
+    [Required]
+    public string? NewRoleId { get; set; }
+}

--- a/EshopApp.AuthLibraryAPI/Models/RequestModels/RoleModels/ApiUpdateClaimsOfRoleRequestModel.cs
+++ b/EshopApp.AuthLibraryAPI/Models/RequestModels/RoleModels/ApiUpdateClaimsOfRoleRequestModel.cs
@@ -1,0 +1,13 @@
+﻿using System.ComponentModel.DataAnnotations;
+using System.Security.Claims;
+
+namespace EshopApp.AuthLibraryAPI.Models.RequestModels.RoleModels;
+
+public class ApiUpdateClaimsOfRoleRequestModel
+{
+    [Required]
+    public string? RoleId{ get; set; }
+    [Required]
+    public List<Claim> NewClaims { get; set; } = new List<Claim>();
+
+}

--- a/EshopApp.AuthLibraryAPI/Program.cs
+++ b/EshopApp.AuthLibraryAPI/Program.cs
@@ -114,7 +114,17 @@ public class Program()
             options.ConsumerSecret = configuration.GetValue<string>("Authentication:Twitter:ClientSecret")!;
         });
 
+        builder.Services.AddAuthorization(options =>
+        {
+            options.AddPolicy("CanViewUserPolicy", policy => policy.RequireClaim("Permission", "CanViewUsers"));
+            options.AddPolicy("CanEditUserPolicy", policy => policy.RequireClaim("Permission", "CanEditUsers"));
+            options.AddPolicy("CanViewUserRolesPolicy", policy => policy.RequireClaim("Permission", "CanViewUserRoles"));
+            options.AddPolicy("CanEditUserRolesPolicy", policy => policy.RequireClaim("Permission", "CanEditUserRoles"));
+        });
+
         builder.Services.AddScoped<IAuthenticationProcedures, AuthenticationProcedures>();
+        builder.Services.AddScoped<IAdminProcedures, AdminProcedures>();
+        builder.Services.AddScoped<IRoleManagementProcedures, RoleManagementProcedures>();
         builder.Services.AddScoped<IHelperMethods, HelperMethods>();
 
         var app = builder.Build();


### PR DESCRIPTION
I added the necessary authorization endpoints in the AuthLibraryApi module, that give the users the ability to access the utilities of the AdminProcedures and the RoleManagementProcedures that were added in the previous commit in the AuthLibrary. Some minor changes were also made in the name of the roles and in the configuration of some services.