### PR TITLE
Added Coupons Entity Modified Discounts Entity Added Endpoints To The…

### DIFF
--- a/EshopApp.DataLibrary/DataAccess/CouponDataAccess.cs
+++ b/EshopApp.DataLibrary/DataAccess/CouponDataAccess.cs
@@ -1,0 +1,419 @@
+﻿using EshopApp.DataLibrary.Models;
+using EshopApp.DataLibrary.Models.ResponseModels;
+using EshopApp.DataLibrary.Models.ResponseModels.CouponModels;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace EshopApp.DataLibrary.DataAccess;
+public class CouponDataAccess : ICouponDataAccess
+{
+    private readonly AppDataDbContext _appDataDbContext;
+    private readonly ILogger<CouponDataAccess> _logger;
+
+    public CouponDataAccess(AppDataDbContext appDataDbContext, ILogger<CouponDataAccess> logger = null!)
+    {
+        _appDataDbContext = appDataDbContext;
+        _logger = logger ?? NullLogger<CouponDataAccess>.Instance;
+    }
+
+    public async Task<ReturnCouponsAndCodeResponseModel> GetCouponsAsync(int amount, bool includeDeactivated)
+    {
+        try
+        {
+            List<Coupon> coupons;
+            if (!includeDeactivated)
+            {
+                coupons = await _appDataDbContext.Coupons
+                    .Include(c => c.UserCoupons)
+                    .Where(coupon => !coupon.IsDeactivated!.Value)
+                    .Take(amount)
+                    .ToListAsync();
+            }
+            else
+            {
+                coupons = await _appDataDbContext.Coupons
+                    .Include(c => c.UserCoupons)
+                    .Take(amount)
+                    .ToListAsync();
+            }
+
+            return new ReturnCouponsAndCodeResponseModel(coupons, DataLibraryReturnedCodes.NoError);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(new EventId(9999, "GetCouponsFailure"), ex, "An error occurred while retrieving the coupons. " +
+                "ExceptionMessage={ExceptionMessage}. StackTrace={StackTrace}.", ex.Message, ex.StackTrace);
+            throw;
+        }
+    }
+
+    public async Task<ReturnCouponAndCodeResponseModel> GetCouponByIdAsync(string id, bool includeDeactivated)
+    {
+        try
+        {
+            Coupon? foundCoupon;
+            if (!includeDeactivated)
+            {
+                foundCoupon = await _appDataDbContext.Coupons
+                    .Include(c => c.UserCoupons)
+                    .FirstOrDefaultAsync(coupon => coupon.Id == id && !coupon.IsDeactivated!.Value);
+            }
+            else
+            {
+                foundCoupon = await _appDataDbContext.Coupons
+                    .Include(c => c.UserCoupons)
+                    .FirstOrDefaultAsync(coupon => coupon.Id == id);
+            }
+
+            return new ReturnCouponAndCodeResponseModel(foundCoupon!, DataLibraryReturnedCodes.NoError);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(new EventId(9999, "GetCouponByIdFailure"), ex, "An error occurred while retrieving the coupon with Id={id}. " +
+                "ExceptionMessage={ExceptionMessage}. StackTrace={StackTrace}.", id, ex.Message, ex.StackTrace);
+            throw;
+        }
+    }
+
+    public async Task<ReturnCouponAndCodeResponseModel> CreateCouponAsync(Coupon coupon)
+    {
+        try
+        {
+            if (!coupon.IsUserSpecific!.Value && (coupon.StartDate is null || coupon.ExpirationDate is null))
+                return new ReturnCouponAndCodeResponseModel(null!, DataLibraryReturnedCodes.StartAndExpirationDatesCanNotBeNullForUniversalCoupons);
+            else if (coupon.IsUserSpecific!.Value && coupon.DefaultDateIntervalInDays is null)
+                return new ReturnCouponAndCodeResponseModel(null!, DataLibraryReturnedCodes.DefaultDateIntervalInDaysCanNotBeNullForUserSpecificCoupons);
+
+            coupon.Id = Guid.NewGuid().ToString();
+            while (await _appDataDbContext.Coupons.FirstOrDefaultAsync(otherCoupon => otherCoupon.Id == coupon.Id) is not null)
+                coupon.Id = Guid.NewGuid().ToString();
+
+            DateTime dateTimeNow = DateTime.Now;
+            coupon.CreatedAt = dateTimeNow;
+            coupon.ModifiedAt = dateTimeNow;
+            coupon.Description = coupon.Description ?? "";
+            coupon.IsUserSpecific = coupon.IsUserSpecific ?? false; //once set this can not change
+            coupon.IsDeactivated = coupon.IsDeactivated ?? false;
+            coupon.ExistsInOrder = coupon.ExistsInOrder ?? false;
+            coupon.Code = coupon.Code ?? Guid.NewGuid().ToString().Substring(0, 6);
+            while (await _appDataDbContext.Coupons.FirstOrDefaultAsync(otherUserCoupon => otherUserCoupon.Code == coupon.Code) is not null)
+                coupon.Code = Guid.NewGuid().ToString().Substring(0, 6);
+
+            //NoTrigger should be assigned to the triggerEvent if the coming trigger event does not have a valid value
+            //or if the trigger event is not user specific
+            if (coupon.TriggerEvent is null || !coupon.IsUserSpecific.Value || (coupon.TriggerEvent != "OnSignUp" &&
+                coupon.TriggerEvent != "OnFirstOrder" && coupon.TriggerEvent != "OnEveryFiveOrders" &&
+                coupon.TriggerEvent != "OnEveryTenOrders" && coupon.TriggerEvent != "NoTrigger"))
+                coupon.TriggerEvent = "NoTrigger";
+
+            if (coupon.IsUserSpecific.Value)
+            {
+                coupon.StartDate = null;
+                coupon.ExpirationDate = null;
+            }
+            else
+                coupon.DefaultDateIntervalInDays = null;
+
+            await _appDataDbContext.Coupons.AddAsync(coupon);
+
+            await _appDataDbContext.SaveChangesAsync();
+
+            _logger.LogInformation(new EventId(9999, "CreateCouponSuccess"), "The coupon was successfully created.");
+            return new ReturnCouponAndCodeResponseModel(coupon, DataLibraryReturnedCodes.NoError);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(new EventId(9999, "CreateCouponFailure"), ex, "An error occurred while creating the coupon. " +
+            "ExceptionMessage={ExceptionMessage}. StackTrace={StackTrace}.", ex.Message, ex.StackTrace);
+            throw;
+        }
+    }
+
+    public async Task<DataLibraryReturnedCodes> UpdateCouponAsync(Coupon updatedCoupon)
+    {
+        try
+        {
+            if (updatedCoupon.Id is null)
+                return DataLibraryReturnedCodes.TheIdOfTheEntityCanNotBeNull;
+
+            Coupon? foundCoupon = await _appDataDbContext.Coupons.FirstOrDefaultAsync(coupon => coupon.Id == updatedCoupon.Id);
+            if (foundCoupon is null)
+            {
+                _logger.LogWarning(new EventId(9999, "UpdateCouponFailureDueToNullCoupon"), "The coupon with Id={id} was not found and thus the update could not proceed.", updatedCoupon.Id);
+                return DataLibraryReturnedCodes.EntityNotFoundWithGivenId;
+            }
+
+            //if null do nothing
+            foundCoupon.Description = updatedCoupon.Description ?? foundCoupon.Description;
+            foundCoupon.DiscountPercentage = updatedCoupon.DiscountPercentage ?? foundCoupon.DiscountPercentage;
+            foundCoupon.UsageLimit = updatedCoupon.UsageLimit ?? foundCoupon.UsageLimit;
+            foundCoupon.IsDeactivated = updatedCoupon.IsDeactivated ?? foundCoupon.IsDeactivated;
+            foundCoupon.ExistsInOrder = updatedCoupon.ExistsInOrder ?? foundCoupon.ExistsInOrder;
+
+            //if null do nothing and in this specific case make sure that it does not exist inside an order
+            if (updatedCoupon.Code is not null && !foundCoupon.ExistsInOrder!.Value)
+            {
+                if (await _appDataDbContext.Coupons.AnyAsync(existingCoupon => existingCoupon.Code == updatedCoupon.Code && existingCoupon.Id != updatedCoupon.Id))
+                    return DataLibraryReturnedCodes.DuplicateEntityCode;
+                foundCoupon.Code = updatedCoupon.Code;
+            }
+
+            if (foundCoupon.IsUserSpecific!.Value) //if it is user specific the intervalInDays DOES matter
+            {
+                foundCoupon.DefaultDateIntervalInDays = updatedCoupon.DefaultDateIntervalInDays ?? foundCoupon.DefaultDateIntervalInDays;
+            }
+            else //if it is universal the coupons date DOES matter
+            {
+                foundCoupon.StartDate = updatedCoupon.StartDate ?? foundCoupon.StartDate;
+                foundCoupon.ExpirationDate = updatedCoupon.ExpirationDate ?? foundCoupon.ExpirationDate;
+            }
+
+            if (updatedCoupon.TriggerEvent is not null && foundCoupon.IsUserSpecific!.Value &&
+                (updatedCoupon.TriggerEvent == "OnSignUp" ||
+                updatedCoupon.TriggerEvent == "OnFirstOrder" || updatedCoupon.TriggerEvent == "OnEveryFiveOrders" ||
+                updatedCoupon.TriggerEvent == "OnEveryTenOrders" || updatedCoupon.TriggerEvent == "NoTrigger"))
+                foundCoupon.TriggerEvent = updatedCoupon.TriggerEvent;
+
+            //For now this only removes user coupons if needed, but can add them. In general the UpdateCoupon should probably not be used to add or remove coupons from users since the addCouponToUser exists
+            //I just did it, because it was easy to do for the remove, but I think the add would complicate a lot the code, since I would have to preserve the previous codes.
+            //Also another thing to keep in mind is that usercoupons can not exist on their own(they depend the coupon), so creating new here using the update method seems wrong(since it should not create other entities)
+            if (updatedCoupon.UserCoupons is not null && !updatedCoupon.UserCoupons.Any())
+                foundCoupon.UserCoupons.Clear();
+            else if (updatedCoupon.UserCoupons is not null)
+            {
+                List<string> updatedUserCoupons = updatedCoupon.UserCoupons.Select(userCoupon => userCoupon.Id!).ToList(); // just add them here, for filtering below
+                List<UserCoupon> filteredUserCoupons = await _appDataDbContext.UserCoupons
+                    .Where(databaseUserCoupon => updatedUserCoupons.Contains(databaseUserCoupon.Id!))
+                    .ToListAsync();
+
+                foreach (var filteredUserCoupon in filteredUserCoupons)
+                {
+                    if (!foundCoupon.IsUserSpecific!.Value) //if the coupon is universal the values of the userCoupons should be updated accordingly since the rest of the coupon was most likely updated
+                    {
+                        filteredUserCoupon.Code = foundCoupon.Code;
+                        filteredUserCoupon.StartDate = foundCoupon.StartDate;
+                        filteredUserCoupon.ExpirationDate = foundCoupon.ExpirationDate;
+                    }
+                    else
+                    {
+                        filteredUserCoupon.StartDate = DateTime.Now;
+                        filteredUserCoupon.ExpirationDate = DateTime.Now.AddDays((double)foundCoupon.DefaultDateIntervalInDays!);
+                    }
+                }
+
+                foundCoupon.UserCoupons.Clear();
+                foundCoupon.UserCoupons.AddRange(filteredUserCoupons);
+            }
+
+            foundCoupon.ModifiedAt = DateTime.Now;
+            await _appDataDbContext.SaveChangesAsync();
+
+            _logger.LogInformation(new EventId(9999, "UpdateCouponSuccess"), "The coupon was successfully updated.");
+            return DataLibraryReturnedCodes.NoError;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(new EventId(9999, "UpdateCouponFailure"), ex, "An error occurred while updating the coupon with Id={id}. " +
+            "ExceptionMessage={ExceptionMessage}. StackTrace={StackTrace}.", updatedCoupon.Id, ex.Message, ex.StackTrace);
+            throw;
+        }
+    }
+
+    public async Task<DataLibraryReturnedCodes> DeleteCouponAsync(string couponId)
+    {
+        try
+        {
+            Coupon? foundCoupon = await _appDataDbContext.Coupons.FirstOrDefaultAsync(coupon => coupon.Id == couponId);
+            if (foundCoupon is null)
+            {
+                _logger.LogWarning(new EventId(9999, "DeleteCouponFailureDueToNullCoupon"), "The coupon with Id={id} was not found and thus the deletion could not proceed.", couponId);
+                return DataLibraryReturnedCodes.EntityNotFoundWithGivenId;
+            }
+
+            if (foundCoupon.ExistsInOrder!.Value)
+            {
+                foundCoupon.IsDeactivated = true;
+                await _appDataDbContext.SaveChangesAsync();
+
+                _logger.LogInformation(new EventId(9999, "DeleteCouponSuccessButSetToDeactivated"), "The coupon with Id={id} exists in an order and thus can not be fully deleted until that order is deleted, " +
+                    "but it was correctly deactivated.", couponId);
+                return DataLibraryReturnedCodes.NoErrorButNotFullyDeleted;
+            }
+
+            _appDataDbContext.Coupons.Remove(foundCoupon);
+            await _appDataDbContext.SaveChangesAsync();
+
+            _logger.LogInformation(new EventId(9999, "DeleteCouponSuccess"), "The coupon was successfully deleted with Id={id}.", couponId);
+            return DataLibraryReturnedCodes.NoError;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(new EventId(9999, "DeleteCouponFailure"), ex, "An error occurred while deleting the coupon with Id={id}. " +
+            "ExceptionMessage={ExceptionMessage}. StackTrace={StackTrace}.", couponId, ex.Message, ex.StackTrace);
+            throw;
+        }
+    }
+
+    public async Task<ReturnUserCouponsAndCodeResponseModel> GetCouponsOfUserAsync(string userId, bool includeDeactivated)
+    {
+        try
+        {
+            List<UserCoupon> userCoupons;
+            if (!includeDeactivated)
+            {
+                //a userCoupon can not exist without being connected to a coupon & a coupon has the IsDeactivated property always filled
+                userCoupons = await _appDataDbContext.UserCoupons
+                    .Include(userCoupon => userCoupon.Coupon)
+                    .Where(userCoupon => !userCoupon.Coupon!.IsDeactivated!.Value)
+                    .ToListAsync();
+            }
+            else
+            {
+                userCoupons = await _appDataDbContext.UserCoupons
+                    .Include(userCoupon => userCoupon.Coupon)
+                    .ToListAsync();
+            }
+
+            return new ReturnUserCouponsAndCodeResponseModel(userCoupons, DataLibraryReturnedCodes.NoError);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(new EventId(9999, "GetCouponsOfUserFailure"), ex, "An error occurred while retrieving the coupons. " +
+                "ExceptionMessage={ExceptionMessage}. StackTrace={StackTrace}.", ex.Message, ex.StackTrace);
+            throw;
+        }
+    }
+
+    public async Task<ReturnUserCouponAndCodeResponseModel> AddCouponToUserAsync(UserCoupon userCoupon)
+    {
+        try
+        {
+            if (userCoupon.CouponId is null)
+                return new ReturnUserCouponAndCodeResponseModel(null!, DataLibraryReturnedCodes.TheIdOfTheCouponCanNotBeNull);
+            else if (userCoupon.UserId is null)
+                return new ReturnUserCouponAndCodeResponseModel(null!, DataLibraryReturnedCodes.TheIdOfTheUserCanNotBeNull);
+
+            Coupon? foundCoupon = await _appDataDbContext.Coupons.FirstOrDefaultAsync(otherCoupon => otherCoupon.Id == userCoupon.CouponId);
+            if (foundCoupon is null)
+                return new ReturnUserCouponAndCodeResponseModel(null!, DataLibraryReturnedCodes.InvalidCouponIdWasGiven);
+
+            userCoupon.TimesUsed = userCoupon.TimesUsed ?? 0;
+            userCoupon.Id = Guid.NewGuid().ToString();
+            while (await _appDataDbContext.UserCoupons.FirstOrDefaultAsync(otherUserCoupon => otherUserCoupon.Id == userCoupon.Id) is not null)
+                userCoupon.Id = Guid.NewGuid().ToString();
+
+            DateTime dateTimeNow = DateTime.Now;
+            userCoupon.CreatedAt = dateTimeNow;
+            userCoupon.ModifiedAt = dateTimeNow;
+
+            //in case where the coupon is universal just copy most of the information for safery to the user coupon(I could have left those field null, but I think this is more safe)
+            if (!foundCoupon.IsUserSpecific!.Value)
+            {
+                userCoupon.StartDate = foundCoupon.StartDate;
+                userCoupon.ExpirationDate = foundCoupon.ExpirationDate;
+                userCoupon.Code = foundCoupon.Code;
+            }
+            else if (foundCoupon.IsUserSpecific!.Value && userCoupon.StartDate is not null && userCoupon.ExpirationDate is not null)
+            {
+                userCoupon.Code = userCoupon.Code ?? Guid.NewGuid().ToString().Substring(0, 6);
+                while (await _appDataDbContext.UserCoupons.FirstOrDefaultAsync(otherUserCoupon => otherUserCoupon.Code == userCoupon.Code) is not null)
+                    userCoupon.Code = Guid.NewGuid().ToString().Substring(0, 6);
+            }
+            //if the startdate and the expiration date are null, but the coupon is user specific
+            else
+            {
+                userCoupon.Code = userCoupon.Code ?? Guid.NewGuid().ToString().Substring(0, 6);
+                while (await _appDataDbContext.UserCoupons.FirstOrDefaultAsync(otherUserCoupon => otherUserCoupon.Code == userCoupon.Code) is not null)
+                    userCoupon.Code = Guid.NewGuid().ToString().Substring(0, 6);
+                userCoupon.StartDate = dateTimeNow;
+                userCoupon.ExpirationDate = dateTimeNow.AddDays((double)foundCoupon.DefaultDateIntervalInDays!);
+            }
+
+            await _appDataDbContext.UserCoupons.AddAsync(userCoupon);
+            await _appDataDbContext.SaveChangesAsync();
+
+            _logger.LogInformation(new EventId(9999, "AddCouponToUserSuccess"), "The coupon was successfully added to user.");
+            return new ReturnUserCouponAndCodeResponseModel(userCoupon, DataLibraryReturnedCodes.NoError);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(new EventId(9999, "AddCouponToUserFailure"), ex, "An error occurred while adding the coupon to user. " +
+            "ExceptionMessage={ExceptionMessage}. StackTrace={StackTrace}.", ex.Message, ex.StackTrace);
+            throw;
+        }
+    }
+
+    public async Task<DataLibraryReturnedCodes> UpdateUserCouponAsync(UserCoupon updatedUserCoupon)
+    {
+        try
+        {
+            if (updatedUserCoupon.Id is null)
+                return DataLibraryReturnedCodes.TheIdOfTheEntityCanNotBeNull;
+
+            UserCoupon? foundUserCoupon = await _appDataDbContext.UserCoupons.Include(userCoupon => userCoupon.Coupon).FirstOrDefaultAsync(userCoupon => userCoupon.Id == updatedUserCoupon.Id);
+            if (foundUserCoupon is null)
+            {
+                _logger.LogWarning(new EventId(9999, "UpdateUserCouponFailureDueToNullCoupon"), "The user coupon with Id={id} was not found and thus the update could not proceed.", updatedUserCoupon.Id);
+                return DataLibraryReturnedCodes.EntityNotFoundWithGivenId;
+            }
+
+            if (foundUserCoupon.Coupon!.IsUserSpecific!.Value && !foundUserCoupon.Coupon.ExistsInOrder!.Value
+                && updatedUserCoupon.Code is not null)
+            {
+                if (await _appDataDbContext.UserCoupons.AnyAsync(existingUserCoupon => existingUserCoupon.Code == updatedUserCoupon.Code && existingUserCoupon.Id != updatedUserCoupon.Id))
+                    return DataLibraryReturnedCodes.DuplicateEntityCode;
+                foundUserCoupon.Code = updatedUserCoupon.Code;
+            }
+
+            if (foundUserCoupon.Coupon!.IsUserSpecific!.Value)
+            {
+                foundUserCoupon.StartDate = updatedUserCoupon.StartDate ?? foundUserCoupon!.StartDate;
+                foundUserCoupon.ExpirationDate = updatedUserCoupon.ExpirationDate ?? foundUserCoupon!.ExpirationDate;
+            }
+
+            foundUserCoupon.TimesUsed = updatedUserCoupon.TimesUsed ?? foundUserCoupon.TimesUsed;
+            foundUserCoupon.ModifiedAt = DateTime.Now;
+
+            await _appDataDbContext.SaveChangesAsync();
+
+            _logger.LogInformation(new EventId(9999, "UpdateUserCouponSuccess"), "The user coupon was successfully updated.");
+            return DataLibraryReturnedCodes.NoError;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(new EventId(9999, "UpdateUserCouponFailure"), ex, "An error occurred while updating the user coupon with Id={id}. " +
+            "ExceptionMessage={ExceptionMessage}. StackTrace={StackTrace}.", updatedUserCoupon.Id, ex.Message, ex.StackTrace);
+            throw;
+        }
+    }
+
+    public async Task<DataLibraryReturnedCodes> RemoveCouponFromUser(string userCouponId)
+    {
+        try
+        {
+            if (userCouponId is null)
+                return DataLibraryReturnedCodes.TheIdOfTheEntityCanNotBeNull;
+
+            UserCoupon? foundUserCoupon = await _appDataDbContext.UserCoupons.FirstOrDefaultAsync(userCoupon => userCoupon.Id == userCouponId);
+            if (foundUserCoupon is null)
+            {
+                _logger.LogWarning(new EventId(9999, "DeleteUserCouponFailureDueToNullUserCoupon"), "The user coupon with Id={id} was not found and thus the deletion could not proceed.", userCouponId);
+                return DataLibraryReturnedCodes.EntityNotFoundWithGivenId;
+            }
+
+            _appDataDbContext.UserCoupons.Remove(foundUserCoupon);
+            await _appDataDbContext.SaveChangesAsync();
+
+            _logger.LogInformation(new EventId(9999, "DeleteUserCouponSuccess"), "The user coupon was successfully deleted with Id={id}.", userCouponId);
+            return DataLibraryReturnedCodes.NoError;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(new EventId(9999, "DeleteUserCouponFailure"), ex, "An error occurred while deleting the user coupon with Id={id}. " +
+            "ExceptionMessage={ExceptionMessage}. StackTrace={StackTrace}.", userCouponId, ex.Message, ex.StackTrace);
+            throw;
+        }
+    }
+
+}

--- a/EshopApp.DataLibrary/DataAccess/ICouponDataAccess.cs
+++ b/EshopApp.DataLibrary/DataAccess/ICouponDataAccess.cs
@@ -1,0 +1,17 @@
+﻿using EshopApp.DataLibrary.Models;
+using EshopApp.DataLibrary.Models.ResponseModels;
+using EshopApp.DataLibrary.Models.ResponseModels.CouponModels;
+
+namespace EshopApp.DataLibrary.DataAccess;
+public interface ICouponDataAccess
+{
+    Task<ReturnUserCouponAndCodeResponseModel> AddCouponToUserAsync(UserCoupon userCoupon);
+    Task<ReturnCouponAndCodeResponseModel> CreateCouponAsync(Coupon coupon);
+    Task<DataLibraryReturnedCodes> DeleteCouponAsync(string couponId);
+    Task<ReturnCouponAndCodeResponseModel> GetCouponByIdAsync(string id, bool includeDeactivated);
+    Task<ReturnCouponsAndCodeResponseModel> GetCouponsAsync(int amount, bool includeDeactivated);
+    Task<ReturnUserCouponsAndCodeResponseModel> GetCouponsOfUserAsync(string userId, bool includeDeactivated);
+    Task<DataLibraryReturnedCodes> RemoveCouponFromUser(string userCouponId);
+    Task<DataLibraryReturnedCodes> UpdateCouponAsync(Coupon updatedCoupon);
+    Task<DataLibraryReturnedCodes> UpdateUserCouponAsync(UserCoupon updatedUserCoupon);
+}

--- a/EshopApp.DataLibrary/DataAccess/IDiscountDataAccess.cs
+++ b/EshopApp.DataLibrary/DataAccess/IDiscountDataAccess.cs
@@ -8,7 +8,7 @@ public interface IDiscountDataAccess
 {
     Task<ReturnDiscountAndCodeResponseModel> CreateDiscountAsync(Discount discount);
     Task<DataLibraryReturnedCodes> DeleteDiscountAsync(string discountId);
-    Task<ReturnDiscountAndCodeResponseModel> GetDiscountByIdAsync(string id);
-    Task<ReturnDiscountsAndCodeResponseModel> GetDiscountsAsync(int amount);
+    Task<ReturnDiscountAndCodeResponseModel> GetDiscountByIdAsync(string id, bool includeDeactivated);
+    Task<ReturnDiscountsAndCodeResponseModel> GetDiscountsAsync(int amount, bool includeDeactivated);
     Task<DataLibraryReturnedCodes> UpdateDiscountAsync(Discount updatedDiscount);
 }

--- a/EshopApp.DataLibrary/DataAccess/ProductDataAccess.cs
+++ b/EshopApp.DataLibrary/DataAccess/ProductDataAccess.cs
@@ -161,7 +161,7 @@ public class ProductDataAccess : IProductDataAccess
             }
 
             if (await _appDataDbContext.Products.AnyAsync(existingProduct => existingProduct.Code == product.Code))
-                return new ReturnProductAndCodeResponseModel(null!, DataLibraryReturnedCodes.DuplicateProductCode);
+                return new ReturnProductAndCodeResponseModel(null!, DataLibraryReturnedCodes.DuplicateEntityCode);
 
             if (await _appDataDbContext.Products.AnyAsync(existingProduct => existingProduct.Name == product.Name))
                 return new ReturnProductAndCodeResponseModel(null!, DataLibraryReturnedCodes.DuplicateEntityName);
@@ -284,7 +284,7 @@ public class ProductDataAccess : IProductDataAccess
             if (updatedProduct.Code is not null)
             {
                 if (await _appDataDbContext.Products.AnyAsync(existingProduct => existingProduct.Code == updatedProduct.Code && existingProduct.Id != updatedProduct.Id))
-                    return DataLibraryReturnedCodes.DuplicateProductCode;
+                    return DataLibraryReturnedCodes.DuplicateEntityCode;
 
                 foundProduct.Code = updatedProduct.Code;
             }

--- a/EshopApp.DataLibrary/Migrations/20241119011242_AddedCouponAndUserCouponEntities.Designer.cs
+++ b/EshopApp.DataLibrary/Migrations/20241119011242_AddedCouponAndUserCouponEntities.Designer.cs
@@ -4,6 +4,7 @@ using EshopApp.DataLibrary;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace EshopApp.DataLibrary.Migrations
 {
     [DbContext(typeof(AppDataDbContext))]
-    partial class AppDataDbContextModelSnapshot : ModelSnapshot
+    [Migration("20241119011242_AddedCouponAndUserCouponEntities")]
+    partial class AddedCouponAndUserCouponEntities
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -166,6 +169,7 @@ namespace EshopApp.DataLibrary.Migrations
                         .HasColumnType("bit");
 
                     b.Property<DateTime?>("ExpirationDate")
+                        .IsRequired()
                         .HasColumnType("datetime2");
 
                     b.Property<bool?>("IsDeactivated")
@@ -180,6 +184,7 @@ namespace EshopApp.DataLibrary.Migrations
                         .HasColumnType("datetime2");
 
                     b.Property<DateTime?>("StartDate")
+                        .IsRequired()
                         .HasColumnType("datetime2");
 
                     b.Property<string>("TriggerEvent")
@@ -206,14 +211,6 @@ namespace EshopApp.DataLibrary.Migrations
 
                     b.Property<DateTime>("CreatedAt")
                         .HasColumnType("datetime2");
-
-                    b.Property<bool?>("ExistsInOrder")
-                        .IsRequired()
-                        .HasColumnType("bit");
-
-                    b.Property<bool?>("IsDeactivated")
-                        .IsRequired()
-                        .HasColumnType("bit");
 
                     b.Property<DateTime>("ModifiedAt")
                         .HasColumnType("datetime2");
@@ -295,15 +292,13 @@ namespace EshopApp.DataLibrary.Migrations
                     b.Property<DateTime>("CreatedAt")
                         .HasColumnType("datetime2");
 
-                    b.Property<DateTime?>("ExpirationDate")
-                        .IsRequired()
+                    b.Property<DateTime>("ExpirationDate")
                         .HasColumnType("datetime2");
 
                     b.Property<DateTime>("ModifiedAt")
                         .HasColumnType("datetime2");
 
-                    b.Property<DateTime?>("StartDate")
-                        .IsRequired()
+                    b.Property<DateTime>("StartDate")
                         .HasColumnType("datetime2");
 
                     b.Property<int?>("TimesUsed")

--- a/EshopApp.DataLibrary/Migrations/20241119011242_AddedCouponAndUserCouponEntities.cs
+++ b/EshopApp.DataLibrary/Migrations/20241119011242_AddedCouponAndUserCouponEntities.cs
@@ -1,0 +1,85 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace EshopApp.DataLibrary.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddedCouponAndUserCouponEntities : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "Coupons",
+                columns: table => new
+                {
+                    Id = table.Column<string>(type: "nvarchar(450)", nullable: false),
+                    Code = table.Column<string>(type: "nvarchar(50)", maxLength: 50, nullable: false),
+                    Description = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    DiscountPercentage = table.Column<int>(type: "int", nullable: false),
+                    UsageLimit = table.Column<int>(type: "int", nullable: false),
+                    DefaultDateIntervalInDays = table.Column<int>(type: "int", nullable: true),
+                    IsUserSpecific = table.Column<bool>(type: "bit", nullable: false),
+                    IsDeactivated = table.Column<bool>(type: "bit", nullable: false),
+                    ExistsInOrder = table.Column<bool>(type: "bit", nullable: false),
+                    TriggerEvent = table.Column<string>(type: "nvarchar(50)", maxLength: 50, nullable: false),
+                    StartDate = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    ExpirationDate = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    ModifiedAt = table.Column<DateTime>(type: "datetime2", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Coupons", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "UserCoupons",
+                columns: table => new
+                {
+                    Id = table.Column<string>(type: "nvarchar(450)", nullable: false),
+                    Code = table.Column<string>(type: "nvarchar(50)", maxLength: 50, nullable: false),
+                    TimesUsed = table.Column<int>(type: "int", nullable: false),
+                    StartDate = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    ExpirationDate = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    ModifiedAt = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    UserId = table.Column<string>(type: "nvarchar(50)", maxLength: 50, nullable: false),
+                    CouponId = table.Column<string>(type: "nvarchar(450)", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_UserCoupons", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_UserCoupons_Coupons_CouponId",
+                        column: x => x.CouponId,
+                        principalTable: "Coupons",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Coupons_Code",
+                table: "Coupons",
+                column: "Code",
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_UserCoupons_CouponId",
+                table: "UserCoupons",
+                column: "CouponId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "UserCoupons");
+
+            migrationBuilder.DropTable(
+                name: "Coupons");
+        }
+    }
+}

--- a/EshopApp.DataLibrary/Migrations/20241119012832_AddedSoftDeletedColumnsToDiscountEntity.Designer.cs
+++ b/EshopApp.DataLibrary/Migrations/20241119012832_AddedSoftDeletedColumnsToDiscountEntity.Designer.cs
@@ -4,6 +4,7 @@ using EshopApp.DataLibrary;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace EshopApp.DataLibrary.Migrations
 {
     [DbContext(typeof(AppDataDbContext))]
-    partial class AppDataDbContextModelSnapshot : ModelSnapshot
+    [Migration("20241119012832_AddedSoftDeletedColumnsToDiscountEntity")]
+    partial class AddedSoftDeletedColumnsToDiscountEntity
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -166,6 +169,7 @@ namespace EshopApp.DataLibrary.Migrations
                         .HasColumnType("bit");
 
                     b.Property<DateTime?>("ExpirationDate")
+                        .IsRequired()
                         .HasColumnType("datetime2");
 
                     b.Property<bool?>("IsDeactivated")
@@ -180,6 +184,7 @@ namespace EshopApp.DataLibrary.Migrations
                         .HasColumnType("datetime2");
 
                     b.Property<DateTime?>("StartDate")
+                        .IsRequired()
                         .HasColumnType("datetime2");
 
                     b.Property<string>("TriggerEvent")
@@ -295,15 +300,13 @@ namespace EshopApp.DataLibrary.Migrations
                     b.Property<DateTime>("CreatedAt")
                         .HasColumnType("datetime2");
 
-                    b.Property<DateTime?>("ExpirationDate")
-                        .IsRequired()
+                    b.Property<DateTime>("ExpirationDate")
                         .HasColumnType("datetime2");
 
                     b.Property<DateTime>("ModifiedAt")
                         .HasColumnType("datetime2");
 
-                    b.Property<DateTime?>("StartDate")
-                        .IsRequired()
+                    b.Property<DateTime>("StartDate")
                         .HasColumnType("datetime2");
 
                     b.Property<int?>("TimesUsed")

--- a/EshopApp.DataLibrary/Migrations/20241119012832_AddedSoftDeletedColumnsToDiscountEntity.cs
+++ b/EshopApp.DataLibrary/Migrations/20241119012832_AddedSoftDeletedColumnsToDiscountEntity.cs
@@ -1,0 +1,40 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace EshopApp.DataLibrary.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddedSoftDeletedColumnsToDiscountEntity : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "ExistsInOrder",
+                table: "Discounts",
+                type: "bit",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "IsDeactivated",
+                table: "Discounts",
+                type: "bit",
+                nullable: false,
+                defaultValue: false);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "ExistsInOrder",
+                table: "Discounts");
+
+            migrationBuilder.DropColumn(
+                name: "IsDeactivated",
+                table: "Discounts");
+        }
+    }
+}

--- a/EshopApp.DataLibrary/Migrations/20241121064320_ChangedDatesOfCouponEntityToNotBeRequired.Designer.cs
+++ b/EshopApp.DataLibrary/Migrations/20241121064320_ChangedDatesOfCouponEntityToNotBeRequired.Designer.cs
@@ -4,6 +4,7 @@ using EshopApp.DataLibrary;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace EshopApp.DataLibrary.Migrations
 {
     [DbContext(typeof(AppDataDbContext))]
-    partial class AppDataDbContextModelSnapshot : ModelSnapshot
+    [Migration("20241121064320_ChangedDatesOfCouponEntityToNotBeRequired")]
+    partial class ChangedDatesOfCouponEntityToNotBeRequired
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/EshopApp.DataLibrary/Migrations/20241121064320_ChangedDatesOfCouponEntityToNotBeRequired.cs
+++ b/EshopApp.DataLibrary/Migrations/20241121064320_ChangedDatesOfCouponEntityToNotBeRequired.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace EshopApp.DataLibrary.Migrations
+{
+    /// <inheritdoc />
+    public partial class ChangedDatesOfCouponEntityToNotBeRequired : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<DateTime>(
+                name: "StartDate",
+                table: "Coupons",
+                type: "datetime2",
+                nullable: true,
+                oldClrType: typeof(DateTime),
+                oldType: "datetime2");
+
+            migrationBuilder.AlterColumn<DateTime>(
+                name: "ExpirationDate",
+                table: "Coupons",
+                type: "datetime2",
+                nullable: true,
+                oldClrType: typeof(DateTime),
+                oldType: "datetime2");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<DateTime>(
+                name: "StartDate",
+                table: "Coupons",
+                type: "datetime2",
+                nullable: false,
+                defaultValue: new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified),
+                oldClrType: typeof(DateTime),
+                oldType: "datetime2",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<DateTime>(
+                name: "ExpirationDate",
+                table: "Coupons",
+                type: "datetime2",
+                nullable: false,
+                defaultValue: new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified),
+                oldClrType: typeof(DateTime),
+                oldType: "datetime2",
+                oldNullable: true);
+        }
+    }
+}

--- a/EshopApp.DataLibrary/Models/Coupon.cs
+++ b/EshopApp.DataLibrary/Models/Coupon.cs
@@ -1,0 +1,19 @@
+﻿namespace EshopApp.DataLibrary.Models;
+public class Coupon
+{
+    public string? Id { get; set; }
+    public string? Code { get; set; }
+    public string? Description { get; set; }
+    public int? DiscountPercentage { get; set; }
+    public int? UsageLimit { get; set; }
+    public int? DefaultDateIntervalInDays { get; set; }
+    public bool? IsUserSpecific { get; set; }
+    public bool? IsDeactivated { get; set; }
+    public bool? ExistsInOrder { get; set; }
+    public string? TriggerEvent { get; set; } //OnSignUp - OnFirstOrder - OnEveryFiveOrders - OnEveryTenOrders - NoTrigger
+    public DateTime? StartDate { get; set; }
+    public DateTime? ExpirationDate { get; set; }
+    public DateTime CreatedAt { get; set; }
+    public DateTime ModifiedAt { get; set; }
+    public List<UserCoupon> UserCoupons { get; set; } = new List<UserCoupon>();
+}

--- a/EshopApp.DataLibrary/Models/Discount.cs
+++ b/EshopApp.DataLibrary/Models/Discount.cs
@@ -5,6 +5,8 @@ public class Discount
     public string? Id { get; set; }
     public string? Name { get; set; }
     public int? Percentage { get; set; }
+    public bool? ExistsInOrder { get; set; }
+    public bool? IsDeactivated { get; set; }
     public DateTime CreatedAt { get; set; }
     public DateTime ModifiedAt { get; set; }
     public List<Variant> Variants { get; set; } = new List<Variant>();

--- a/EshopApp.DataLibrary/Models/ResponseModels/CouponModels/ReturnCouponAndCodeResponseModel.cs
+++ b/EshopApp.DataLibrary/Models/ResponseModels/CouponModels/ReturnCouponAndCodeResponseModel.cs
@@ -1,0 +1,14 @@
+﻿namespace EshopApp.DataLibrary.Models.ResponseModels.CouponModels;
+public class ReturnCouponAndCodeResponseModel
+{
+    public Coupon? Coupon { get; set; }
+    public DataLibraryReturnedCodes ReturnedCode { get; set; }
+
+    public ReturnCouponAndCodeResponseModel() { }
+    public ReturnCouponAndCodeResponseModel(Coupon coupon, DataLibraryReturnedCodes libraryReturnedCodes)
+    {
+        Coupon = coupon;
+        ReturnedCode = libraryReturnedCodes;
+    }
+
+}

--- a/EshopApp.DataLibrary/Models/ResponseModels/CouponModels/ReturnCouponsAndCodeResponseModel.cs
+++ b/EshopApp.DataLibrary/Models/ResponseModels/CouponModels/ReturnCouponsAndCodeResponseModel.cs
@@ -1,0 +1,14 @@
+﻿namespace EshopApp.DataLibrary.Models.ResponseModels.CouponModels;
+public class ReturnCouponsAndCodeResponseModel
+{
+    public List<Coupon> Coupons { get; set; } = new List<Coupon>();
+    public DataLibraryReturnedCodes ReturnedCode { get; set; }
+
+    public ReturnCouponsAndCodeResponseModel() { }
+    public ReturnCouponsAndCodeResponseModel(List<Coupon> coupons, DataLibraryReturnedCodes libraryReturnedCodes)
+    {
+        foreach (var coupon in coupons ?? Enumerable.Empty<Coupon>())
+            Coupons.Add(coupon);
+        ReturnedCode = libraryReturnedCodes;
+    }
+}

--- a/EshopApp.DataLibrary/Models/ResponseModels/CouponModels/ReturnUserCouponAndCodeResponseModel.cs
+++ b/EshopApp.DataLibrary/Models/ResponseModels/CouponModels/ReturnUserCouponAndCodeResponseModel.cs
@@ -1,0 +1,14 @@
+﻿namespace EshopApp.DataLibrary.Models.ResponseModels.CouponModels;
+public class ReturnUserCouponAndCodeResponseModel
+{
+    public UserCoupon? UserCoupon { get; set; }
+    public DataLibraryReturnedCodes ReturnedCode { get; set; }
+
+    public ReturnUserCouponAndCodeResponseModel() { }
+    public ReturnUserCouponAndCodeResponseModel(UserCoupon userCoupon, DataLibraryReturnedCodes libraryReturnedCodes)
+    {
+        UserCoupon = userCoupon;
+        ReturnedCode = libraryReturnedCodes;
+    }
+
+}

--- a/EshopApp.DataLibrary/Models/ResponseModels/CouponModels/ReturnUserCouponsAndCodeResponseModel.cs
+++ b/EshopApp.DataLibrary/Models/ResponseModels/CouponModels/ReturnUserCouponsAndCodeResponseModel.cs
@@ -1,0 +1,15 @@
+﻿namespace EshopApp.DataLibrary.Models.ResponseModels.CouponModels;
+public class ReturnUserCouponsAndCodeResponseModel
+{
+    public List<UserCoupon> UserCoupons { get; set; } = new List<UserCoupon>();
+    public DataLibraryReturnedCodes ReturnedCode { get; set; }
+
+    public ReturnUserCouponsAndCodeResponseModel() { }
+    public ReturnUserCouponsAndCodeResponseModel(List<UserCoupon> userCoupons, DataLibraryReturnedCodes libraryReturnedCodes)
+    {
+        foreach (var userCoupon in userCoupons ?? Enumerable.Empty<UserCoupon>())
+            UserCoupons.Add(userCoupon);
+        ReturnedCode = libraryReturnedCodes;
+    }
+
+}

--- a/EshopApp.DataLibrary/Models/ResponseModels/DataLibraryReturnedCodes.cs
+++ b/EshopApp.DataLibrary/Models/ResponseModels/DataLibraryReturnedCodes.cs
@@ -5,11 +5,16 @@ public enum DataLibraryReturnedCodes
     NoError,
     NoErrorButNotFullyDeleted,
     TheIdOfTheEntityCanNotBeNull,
+    TheIdOfTheCouponCanNotBeNull,
+    TheIdOfTheUserCanNotBeNull,
     EntityNotFoundWithGivenId,
     InvalidProductIdWasGiven,
     InvalidVariantIdWasGiven,
+    InvalidCouponIdWasGiven,
+    StartAndExpirationDatesCanNotBeNullForUniversalCoupons,
+    DefaultDateIntervalInDaysCanNotBeNullForUserSpecificCoupons,
     NoVariantWasProvidedForProductCreation,
     DuplicateVariantSku,
-    DuplicateProductCode,
+    DuplicateEntityCode,
     DuplicateEntityName
 }

--- a/EshopApp.DataLibrary/Models/UserCoupon.cs
+++ b/EshopApp.DataLibrary/Models/UserCoupon.cs
@@ -1,0 +1,14 @@
+﻿namespace EshopApp.DataLibrary.Models;
+public class UserCoupon
+{
+    public string? Id { get; set; }
+    public string? Code { get; set; }
+    public int? TimesUsed { get; set; }
+    public DateTime? StartDate { get; set; } //nullable for implementation StartDate & ExpirationDate will always be filled
+    public DateTime? ExpirationDate { get; set; }
+    public DateTime CreatedAt { get; set; }
+    public DateTime ModifiedAt { get; set; }
+    public string? UserId { get; set; }
+    public string? CouponId { get; set; }
+    public Coupon? Coupon { get; set; }
+}

--- a/EshopApp.DataLibraryAPI.Tests/IntegrationTests/ControllerTests/AttributeControllerTests.cs
+++ b/EshopApp.DataLibraryAPI.Tests/IntegrationTests/ControllerTests/AttributeControllerTests.cs
@@ -34,7 +34,7 @@ internal class AttributeControllerTests
 
         TestUtilitiesLibrary.DatabaseUtilities.ResetSqlAuthDatabase(
             "Data Source=(localdb)\\MSSQLLocalDB;Initial Catalog=EshopAppDataDb;Integrated Security=True;Connect Timeout=30;Encrypt=False;TrustServerCertificate=False;ApplicationIntent=ReadWrite;MultiSubnetFailover=False",
-            new string[] { "dbo.Attributes", "dbo.Categories", "dbo.Products", "dbo.Variants", "dbo.Discounts", "dbo.Images", "dbo.VariantImages" },
+            new string[] { "dbo.Attributes", "dbo.Categories", "dbo.Products", "dbo.Variants", "dbo.Discounts", "dbo.Images", "dbo.VariantImages", "dbo.Coupons", "dbo.UserCoupons" },
             "Data Database Successfully Cleared!"
         );
 
@@ -432,7 +432,7 @@ internal class AttributeControllerTests
         httpClient.Dispose();
         TestUtilitiesLibrary.DatabaseUtilities.ResetSqlAuthDatabase(
             "Data Source=(localdb)\\MSSQLLocalDB;Initial Catalog=EshopAppDataDb;Integrated Security=True;Connect Timeout=30;Encrypt=False;TrustServerCertificate=False;ApplicationIntent=ReadWrite;MultiSubnetFailover=False",
-            new string[] { "dbo.Attributes", "dbo.Categories", "dbo.Products", "dbo.Variants", "dbo.Discounts", "dbo.Images", "dbo.VariantImages" },
+            new string[] { "dbo.Attributes", "dbo.Categories", "dbo.Products", "dbo.Variants", "dbo.Discounts", "dbo.Images", "dbo.VariantImages", "dbo.Coupons", "dbo.UserCoupons" },
             "Data Database Successfully Cleared!"
         );
     }

--- a/EshopApp.DataLibraryAPI.Tests/IntegrationTests/ControllerTests/CategoriesControllerTests.cs
+++ b/EshopApp.DataLibraryAPI.Tests/IntegrationTests/ControllerTests/CategoriesControllerTests.cs
@@ -32,7 +32,7 @@ internal class CategoriesControllerTests
 
         TestUtilitiesLibrary.DatabaseUtilities.ResetSqlAuthDatabase(
             "Data Source=(localdb)\\MSSQLLocalDB;Initial Catalog=EshopAppDataDb;Integrated Security=True;Connect Timeout=30;Encrypt=False;TrustServerCertificate=False;ApplicationIntent=ReadWrite;MultiSubnetFailover=False",
-            new string[] { "dbo.Attributes", "dbo.Categories", "dbo.Products", "dbo.Variants", "dbo.Discounts", "dbo.Images", "dbo.VariantImages" },
+            new string[] { "dbo.Attributes", "dbo.Categories", "dbo.Products", "dbo.Variants", "dbo.Discounts", "dbo.Images", "dbo.VariantImages", "dbo.Coupons", "dbo.UserCoupons" },
             "Data Database Successfully Cleared!"
         );
 
@@ -425,7 +425,7 @@ internal class CategoriesControllerTests
         httpClient.Dispose();
         TestUtilitiesLibrary.DatabaseUtilities.ResetSqlAuthDatabase(
             "Data Source=(localdb)\\MSSQLLocalDB;Initial Catalog=EshopAppDataDb;Integrated Security=True;Connect Timeout=30;Encrypt=False;TrustServerCertificate=False;ApplicationIntent=ReadWrite;MultiSubnetFailover=False",
-            new string[] { "dbo.Attributes", "dbo.Categories", "dbo.Products", "dbo.Variants", "dbo.Discounts", "dbo.Images", "dbo.VariantImages" },
+            new string[] { "dbo.Attributes", "dbo.Categories", "dbo.Products", "dbo.Variants", "dbo.Discounts", "dbo.Images", "dbo.VariantImages", "dbo.Coupons", "dbo.UserCoupons" },
             "Data Database Successfully Cleared!"
         );
     }

--- a/EshopApp.DataLibraryAPI.Tests/IntegrationTests/ControllerTests/CouponControllerTests.cs
+++ b/EshopApp.DataLibraryAPI.Tests/IntegrationTests/ControllerTests/CouponControllerTests.cs
@@ -1,0 +1,918 @@
+﻿using EshopApp.DataLibrary.Models;
+using EshopApp.DataLibraryAPI.Tests.IntegrationTests.Models;
+using EshopApp.DataLibraryAPI.Tests.IntegrationTests.Models.CouponModels;
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc.Testing;
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+
+namespace EshopApp.DataLibraryAPI.Tests.IntegrationTests.ControllerTests;
+
+[TestFixture]
+[Category("Integration")]
+[Author("konstantinos kinnas", "kinnaskonstantinos0@gmail.com")]
+internal class CouponControllerTests
+{
+    private HttpClient httpClient;
+    private string? _chosenApiKey;
+    private string? _chosenUserId;
+    private string? _chosenUniversalCouponId;
+    private string? _chosenUserSpecificCouponId;
+    private string? _otherCouponId;
+    private string? _otherCouponCode;
+    private string? _chosenUniversalUserCouponId;
+    private string? _chosenUserSpecificUserCouponId;
+
+    [OneTimeSetUp]
+    public async Task OnTimeSetup()
+    {
+        var webApplicationFactory = new WebApplicationFactory<Program>();
+        httpClient = webApplicationFactory.CreateClient();
+        httpClient.DefaultRequestHeaders.Add("X-Bypass-Rate-Limiting", "a7f3f1c6-3d2b-4e3a-8d70-4b6e8d6d53d8");
+        httpClient.DefaultRequestHeaders.Add("X-API-KEY", "user_e1f7b8c0-3c79-4a1b-9e7a-9d8b1d4a5c6e");
+        _chosenApiKey = "user_e1f7b8c0-3c79-4a1b-9e7a-9d8b1d4a5c6e";
+        _chosenUserId = "chosenUserId";
+
+        TestUtilitiesLibrary.DatabaseUtilities.ResetSqlAuthDatabase(
+            "Data Source=(localdb)\\MSSQLLocalDB;Initial Catalog=EshopAppDataDb;Integrated Security=True;Connect Timeout=30;Encrypt=False;TrustServerCertificate=False;ApplicationIntent=ReadWrite;MultiSubnetFailover=False",
+            new string[] { "dbo.Attributes", "dbo.Categories", "dbo.Products", "dbo.Variants", "dbo.Discounts", "dbo.Images", "dbo.VariantImages", "dbo.Coupons", "dbo.UserCoupons" },
+            "Data Database Successfully Cleared!"
+        );
+
+        httpClient.DefaultRequestHeaders.Remove("X-API-KEY");
+        httpClient.DefaultRequestHeaders.Add("X-API-KEY", _chosenApiKey);
+        TestCreateCouponRequestModel testCreateCouponRequestModel = new TestCreateCouponRequestModel();
+        testCreateCouponRequestModel.Code = _otherCouponCode; //because this code already exists it should create a random different code
+        testCreateCouponRequestModel.Description = "My other coupon description";
+        testCreateCouponRequestModel.DiscountPercentage = 10;
+        testCreateCouponRequestModel.UsageLimit = 1;
+        testCreateCouponRequestModel.IsUserSpecific = false; //it is universal
+        testCreateCouponRequestModel.IsDeactivated = false;
+        testCreateCouponRequestModel.ExistsInOrder = false;
+        testCreateCouponRequestModel.StartDate = DateTime.Now;
+        testCreateCouponRequestModel.ExpirationDate = DateTime.Now.AddDays(2);
+
+        HttpResponseMessage response = await httpClient.PostAsJsonAsync("api/coupon", testCreateCouponRequestModel);
+        string? responseBody = await response.Content.ReadAsStringAsync();
+        _otherCouponId = JsonSerializer.Deserialize<TestCoupon>(responseBody, new JsonSerializerOptions { PropertyNameCaseInsensitive = true })!.Id!;
+        _otherCouponCode = JsonSerializer.Deserialize<TestCoupon>(responseBody, new JsonSerializerOptions { PropertyNameCaseInsensitive = true })!.Code!;
+    }
+
+    [Test, Order(10)]
+    public async Task CreateCoupon_ShouldFailAndReturnUnauthorized_IfXAPIKEYHeaderIsMissing()
+    {
+        //Arrange
+        httpClient.DefaultRequestHeaders.Remove("X-API-KEY");
+        TestCreateCouponRequestModel testCreateCouponRequestModel = new TestCreateCouponRequestModel();
+        testCreateCouponRequestModel.Code = _otherCouponCode; //because this code already exists it should create a random different code
+        testCreateCouponRequestModel.Description = "My coupon description";
+        testCreateCouponRequestModel.DiscountPercentage = 20;
+        testCreateCouponRequestModel.UsageLimit = 2;
+        testCreateCouponRequestModel.DefaultDateIntervalInDays = 2;
+        testCreateCouponRequestModel.IsUserSpecific = false; //it is universal
+        testCreateCouponRequestModel.IsDeactivated = false;
+        testCreateCouponRequestModel.ExistsInOrder = false;
+        testCreateCouponRequestModel.TriggerEvent = "OnSignUp"; //this should become NoTrigger since the event is universal and thus triggered based on date
+        testCreateCouponRequestModel.StartDate = DateTime.Now;
+        testCreateCouponRequestModel.ExpirationDate = DateTime.Now.AddDays(2);
+
+        //Act
+        HttpResponseMessage response = await httpClient.PostAsJsonAsync("api/coupon", testCreateCouponRequestModel);
+        string? errorMessage = await TestUtilitiesLibrary.JsonUtilities.GetSingleStringValueFromBody(response, "errorMessage");
+
+        //Assert
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+        errorMessage.Should().NotBeNull().And.Contain("X-API-KEY");
+    }
+
+    [Test, Order(20)]
+    public async Task CreateCoupon_ShouldFailAndReturnUnauthorized_IfAPIKeyIsInvalid()
+    {
+        //Arrange
+        httpClient.DefaultRequestHeaders.Remove("X-API-KEY");
+        httpClient.DefaultRequestHeaders.Add("X-API-KEY", "bogusKey");
+        TestCreateCouponRequestModel testCreateCouponRequestModel = new TestCreateCouponRequestModel();
+        testCreateCouponRequestModel.Code = _otherCouponCode; //because this code already exists it should create a random different code
+        testCreateCouponRequestModel.Description = "My coupon description";
+        testCreateCouponRequestModel.DiscountPercentage = 20;
+        testCreateCouponRequestModel.UsageLimit = 2;
+        testCreateCouponRequestModel.DefaultDateIntervalInDays = 2;
+        testCreateCouponRequestModel.IsUserSpecific = false; //it is universal
+        testCreateCouponRequestModel.IsDeactivated = false;
+        testCreateCouponRequestModel.ExistsInOrder = false;
+        testCreateCouponRequestModel.TriggerEvent = "OnSignUp"; //this should become NoTrigger since the event is universal and thus triggered based on date
+        testCreateCouponRequestModel.StartDate = DateTime.Now;
+        testCreateCouponRequestModel.ExpirationDate = DateTime.Now.AddDays(2);
+
+        //Act
+        HttpResponseMessage response = await httpClient.PostAsJsonAsync("api/coupon", testCreateCouponRequestModel);
+        string? errorMessage = await TestUtilitiesLibrary.JsonUtilities.GetSingleStringValueFromBody(response, "errorMessage");
+
+        //Assert
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+        errorMessage.Should().NotBeNull().And.Contain("Invalid");
+    }
+
+    [Test, Order(30)]
+    public async Task CreateCoupon_ShouldFailAndReturnBadRequest_IfInvalidRequestModelFormatInCouponEntity()
+    {
+        //Arrange
+        httpClient.DefaultRequestHeaders.Remove("X-API-KEY");
+        httpClient.DefaultRequestHeaders.Add("X-API-KEY", _chosenApiKey);
+        TestCreateCouponRequestModel testCreateCouponRequestModel = new TestCreateCouponRequestModel();
+        testCreateCouponRequestModel.Code = _otherCouponCode; //because this code already exists it should create a random different code
+        testCreateCouponRequestModel.Description = "My coupon description";
+        testCreateCouponRequestModel.UsageLimit = 2;
+        testCreateCouponRequestModel.DefaultDateIntervalInDays = 2;
+        testCreateCouponRequestModel.IsUserSpecific = false; //it is universal
+        testCreateCouponRequestModel.IsDeactivated = false;
+        testCreateCouponRequestModel.ExistsInOrder = false;
+        testCreateCouponRequestModel.TriggerEvent = "OnSignUp"; //this should become NoTrigger since the event is universal and thus triggered based on date
+        testCreateCouponRequestModel.StartDate = DateTime.Now;
+        testCreateCouponRequestModel.ExpirationDate = DateTime.Now.AddDays(2);
+
+        //Act
+        HttpResponseMessage response = await httpClient.PostAsJsonAsync("api/coupon", testCreateCouponRequestModel); //The discount percentage value of the discount is missing and thus the request model is not valid
+
+        //Assert
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Test, Order(40)]
+    public async Task CreateCoupon_ShouldSucceedAndCreateUniversalCoupon()
+    {
+        //Arrange
+        httpClient.DefaultRequestHeaders.Remove("X-API-KEY");
+        httpClient.DefaultRequestHeaders.Add("X-API-KEY", _chosenApiKey);
+        TestCreateCouponRequestModel testCreateCouponRequestModel = new TestCreateCouponRequestModel();
+        testCreateCouponRequestModel.Code = _otherCouponCode; //because this code already exists it should create a random different code
+        testCreateCouponRequestModel.Description = "My coupon description";
+        testCreateCouponRequestModel.DiscountPercentage = 20;
+        testCreateCouponRequestModel.UsageLimit = 2;
+        testCreateCouponRequestModel.DefaultDateIntervalInDays = 2;
+        testCreateCouponRequestModel.IsUserSpecific = false; //it is universal
+        testCreateCouponRequestModel.IsDeactivated = false;
+        testCreateCouponRequestModel.ExistsInOrder = false;
+        testCreateCouponRequestModel.TriggerEvent = "OnSignUp"; //this should become NoTrigger since the event is universal and thus triggered based on date
+        testCreateCouponRequestModel.StartDate = DateTime.Now;
+        testCreateCouponRequestModel.ExpirationDate = DateTime.Now.AddDays(2);
+
+        //Act
+        HttpResponseMessage response = await httpClient.PostAsJsonAsync("api/coupon", testCreateCouponRequestModel);
+        string? responseBody = await response.Content.ReadAsStringAsync();
+        TestCoupon? testCoupon = JsonSerializer.Deserialize<TestCoupon>(responseBody, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+
+        //Assert
+        response.StatusCode.Should().Be(HttpStatusCode.Created);
+        testCoupon.Should().NotBeNull();
+        testCoupon!.Id.Should().NotBeNull();
+        testCoupon!.Code.Should().NotBeNull().And.NotBe(testCreateCouponRequestModel.Code);
+        testCoupon!.Description.Should().NotBeNull().And.Be(testCreateCouponRequestModel.Description);
+        testCoupon!.DiscountPercentage.Should().NotBeNull().And.Be(testCreateCouponRequestModel.DiscountPercentage);
+        testCoupon!.UsageLimit.Should().NotBeNull().And.Be(testCreateCouponRequestModel.UsageLimit);
+        testCoupon!.DefaultDateIntervalInDays.Should().BeNull();
+        testCoupon!.IsUserSpecific.Should().NotBeNull().And.Be(testCreateCouponRequestModel.IsUserSpecific);
+        testCoupon!.IsDeactivated.Should().NotBeNull().And.Be(testCreateCouponRequestModel.IsDeactivated);
+        testCoupon!.ExistsInOrder.Should().NotBeNull().And.Be(testCreateCouponRequestModel.ExistsInOrder);
+        testCoupon!.TriggerEvent.Should().NotBeNull().And.Be("NoTrigger");
+        testCoupon!.StartDate.Should().NotBeNull().And.Be(testCreateCouponRequestModel.StartDate);
+        testCoupon!.ExpirationDate.Should().NotBeNull().And.Be(testCreateCouponRequestModel.ExpirationDate);
+        _chosenUniversalCouponId = testCoupon.Id!;
+    }
+
+    [Test, Order(50)]
+    public async Task CreateCoupon_ShouldSucceedAndCreateUserSpecificCoupon()
+    {
+        //Arrange
+        httpClient.DefaultRequestHeaders.Remove("X-API-KEY");
+        httpClient.DefaultRequestHeaders.Add("X-API-KEY", _chosenApiKey);
+        TestCreateCouponRequestModel testCreateCouponRequestModel = new TestCreateCouponRequestModel();
+        testCreateCouponRequestModel.Description = "My user specific coupon description";
+        testCreateCouponRequestModel.DiscountPercentage = 40;
+        testCreateCouponRequestModel.UsageLimit = 4;
+        testCreateCouponRequestModel.DefaultDateIntervalInDays = 4;
+        testCreateCouponRequestModel.IsUserSpecific = true; //it is user specific
+        testCreateCouponRequestModel.IsDeactivated = false;
+        testCreateCouponRequestModel.ExistsInOrder = false;
+        testCreateCouponRequestModel.TriggerEvent = "OnSignUp"; //Now this trigger event is applied correctly
+        testCreateCouponRequestModel.StartDate = DateTime.Now; //this should become null, because the coupon is user specific
+        testCreateCouponRequestModel.ExpirationDate = DateTime.Now.AddDays(2); //this should become null, because the coupon is user specific
+
+        //Act
+        HttpResponseMessage response = await httpClient.PostAsJsonAsync("api/coupon", testCreateCouponRequestModel);
+        string? responseBody = await response.Content.ReadAsStringAsync();
+        TestCoupon? testCoupon = JsonSerializer.Deserialize<TestCoupon>(responseBody, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+
+        //Assert
+        response.StatusCode.Should().Be(HttpStatusCode.Created);
+        testCoupon.Should().NotBeNull();
+        testCoupon!.Id.Should().NotBeNull();
+        testCoupon!.Code.Should().NotBeNull().And.NotBe(testCreateCouponRequestModel.Code);
+        testCoupon!.Description.Should().NotBeNull().And.Be(testCreateCouponRequestModel.Description);
+        testCoupon!.DiscountPercentage.Should().NotBeNull().And.Be(testCreateCouponRequestModel.DiscountPercentage);
+        testCoupon!.UsageLimit.Should().NotBeNull().And.Be(testCreateCouponRequestModel.UsageLimit);
+        testCoupon!.DefaultDateIntervalInDays.Should().NotBeNull().And.Be(testCreateCouponRequestModel.DefaultDateIntervalInDays);
+        testCoupon!.IsUserSpecific.Should().NotBeNull().And.Be(testCreateCouponRequestModel.IsUserSpecific);
+        testCoupon!.IsDeactivated.Should().NotBeNull().And.Be(testCreateCouponRequestModel.IsDeactivated);
+        testCoupon!.ExistsInOrder.Should().NotBeNull().And.Be(testCreateCouponRequestModel.ExistsInOrder);
+        testCoupon!.TriggerEvent.Should().NotBeNull().And.Be("OnSignUp");
+        testCoupon!.StartDate.Should().BeNull();
+        testCoupon!.ExpirationDate.Should().BeNull();
+        _chosenUserSpecificCouponId = testCoupon.Id!;
+    }
+
+    [Test, Order(60)]
+    public async Task GetCoupons_ShouldFailAndReturnUnauthorized_IfAPIKeyIsInvalid()
+    {
+        //Arrange
+        httpClient.DefaultRequestHeaders.Remove("X-API-KEY");
+        httpClient.DefaultRequestHeaders.Add("X-API-KEY", "bogusKey");
+
+        //Act
+        HttpResponseMessage response = await httpClient.GetAsync("api/coupon/amount/10/includeDeactivated/true"); //here 10 is just an arbitraty value for the amount
+        string? errorMessage = await TestUtilitiesLibrary.JsonUtilities.GetSingleStringValueFromBody(response, "errorMessage");
+
+        //Assert
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+        errorMessage.Should().NotBeNull().And.Contain("Invalid");
+    }
+
+    [Test, Order(70)]
+    public async Task GetCoupons_ShouldSucceedAndReturnCoupons()
+    {
+        //Arrange
+        httpClient.DefaultRequestHeaders.Remove("X-API-KEY");
+        httpClient.DefaultRequestHeaders.Add("X-API-KEY", _chosenApiKey);
+
+        //Act
+        HttpResponseMessage response = await httpClient.GetAsync("api/coupon/amount/10/includeDeactivated/true");
+        string? responseBody = await response.Content.ReadAsStringAsync();
+        List<TestCoupon>? testCoupons = JsonSerializer.Deserialize<List<TestCoupon>>(responseBody, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+
+        //Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        testCoupons.Should().NotBeNull().And.HaveCount(3); //one we created on the setup and one in the previous tests
+    }
+
+    [Test, Order(80)]
+    public async Task GetCoupon_ShouldFailAndReturnUnauthorized_IfAPIKeyIsInvalid()
+    {
+        //Arrange
+        httpClient.DefaultRequestHeaders.Remove("X-API-KEY");
+        httpClient.DefaultRequestHeaders.Add("X-API-KEY", "bogusKey");
+        string? couponId = _chosenUniversalCouponId;
+
+        //Act
+        HttpResponseMessage response = await httpClient.GetAsync($"api/coupon/{couponId}/includeDeactivated/true");
+        string? errorMessage = await TestUtilitiesLibrary.JsonUtilities.GetSingleStringValueFromBody(response, "errorMessage");
+
+        //Assert
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+        errorMessage.Should().NotBeNull().And.Contain("Invalid");
+    }
+
+    [Test, Order(90)]
+    public async Task GetCoupon_ShouldFailAndReturnNotFound_IfCouponNotInSystem()
+    {
+        //Arrange
+        httpClient.DefaultRequestHeaders.Remove("X-API-KEY");
+        httpClient.DefaultRequestHeaders.Add("X-API-KEY", _chosenApiKey);
+        string bogusCouponId = "bogusCouponId";
+
+        //Act
+        HttpResponseMessage response = await httpClient.GetAsync($"api/coupon/{bogusCouponId}/includeDeactivated/true");
+
+        //Assert
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Test, Order(100)]
+    public async Task GetCoupon_ShouldSucceedAndReturnCoupon()
+    {
+        //Arrange
+        httpClient.DefaultRequestHeaders.Remove("X-API-KEY");
+        httpClient.DefaultRequestHeaders.Add("X-API-KEY", _chosenApiKey);
+        string couponId = _chosenUniversalCouponId!;
+
+        //Act
+        HttpResponseMessage response = await httpClient.GetAsync($"api/coupon/{couponId}/includeDeactivated/true");
+        string? responseBody = await response.Content.ReadAsStringAsync();
+        TestCoupon? testCoupon = JsonSerializer.Deserialize<TestCoupon>(responseBody, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+
+        //Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        testCoupon.Should().NotBeNull();
+        testCoupon!.Id.Should().NotBeNull().And.Be(couponId);
+        testCoupon.Code.Should().NotBeNull();
+        testCoupon.Description.Should().NotBeNull();
+        testCoupon.DiscountPercentage.Should().NotBeNull();
+        testCoupon.UsageLimit.Should().NotBeNull();
+        testCoupon.DefaultDateIntervalInDays.Should().BeNull();
+        testCoupon.IsUserSpecific.Should().NotBeNull().And.Be(false);
+        testCoupon.IsDeactivated.Should().NotBeNull();
+        testCoupon.ExistsInOrder.Should().NotBeNull();
+        testCoupon.TriggerEvent.Should().NotBeNull().And.Be("NoTrigger");
+        testCoupon.StartDate.Should().NotBeNull();
+        testCoupon.ExpirationDate.Should().NotBeNull();
+    }
+
+    [Test, Order(110)]
+    public async Task UpdateCoupon_ShouldFailAndReturnUnauthorized_IfAPIKeyIsInvalid()
+    {
+        //Arrange
+        httpClient.DefaultRequestHeaders.Remove("X-API-KEY");
+        httpClient.DefaultRequestHeaders.Add("X-API-KEY", "bogusKey");
+        TestUpdateCouponRequestModel testUpdateCouponRequestModel = new TestUpdateCouponRequestModel();
+        testUpdateCouponRequestModel.Id = _chosenUniversalCouponId;
+        testUpdateCouponRequestModel.Code = "MyNewCouponCode";
+        testUpdateCouponRequestModel.Description = "My coupon description updated";
+        testUpdateCouponRequestModel.DiscountPercentage = 30;
+        testUpdateCouponRequestModel.UsageLimit = 3;
+        testUpdateCouponRequestModel.DefaultDateIntervalInDays = 5; //this should be ignored because the event is universal
+        testUpdateCouponRequestModel.TriggerEvent = "OnSignUp"; //this should be ignored because the event is universal
+        testUpdateCouponRequestModel.ExpirationDate = DateTime.Now.AddDays(3);
+
+        //Act
+        HttpResponseMessage response = await httpClient.PutAsJsonAsync("api/coupon", testUpdateCouponRequestModel);
+        string? errorMessage = await TestUtilitiesLibrary.JsonUtilities.GetSingleStringValueFromBody(response, "errorMessage");
+
+        //Assert
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+        errorMessage.Should().NotBeNull().And.Contain("Invalid");
+    }
+
+    [Test, Order(120)]
+    public async Task UpdateCoupon_ShouldFailAndReturnNotFound_IfInvalidRequestModelFormat()
+    {
+        //Arrange
+        httpClient.DefaultRequestHeaders.Remove("X-API-KEY");
+        httpClient.DefaultRequestHeaders.Add("X-API-KEY", _chosenApiKey);
+        TestUpdateCouponRequestModel testUpdateCouponRequestModel = new TestUpdateCouponRequestModel();
+        testUpdateCouponRequestModel.Code = "MyNewCouponCode";
+        testUpdateCouponRequestModel.Description = "My coupon description updated";
+        testUpdateCouponRequestModel.DiscountPercentage = 30;
+        testUpdateCouponRequestModel.UsageLimit = 3;
+        testUpdateCouponRequestModel.DefaultDateIntervalInDays = 5; //this should be ignored because the event is universal
+        testUpdateCouponRequestModel.TriggerEvent = "OnSignUp"; //this should be ignored because the event is universal
+        testUpdateCouponRequestModel.ExpirationDate = DateTime.Now.AddDays(3);
+
+        //Act
+        HttpResponseMessage response = await httpClient.PutAsJsonAsync("api/coupon", testUpdateCouponRequestModel); //here the id is missing, which is required for the update
+
+        //Assert
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Test, Order(130)]
+    public async Task UpdateCoupon_ShouldFailAndReturnNotFound_IfCouponNotInSystem()
+    {
+        //Arrange
+        httpClient.DefaultRequestHeaders.Remove("X-API-KEY");
+        httpClient.DefaultRequestHeaders.Add("X-API-KEY", _chosenApiKey);
+        TestUpdateCouponRequestModel testUpdateCouponRequestModel = new TestUpdateCouponRequestModel();
+        testUpdateCouponRequestModel.Id = "bogusCouponId";
+        testUpdateCouponRequestModel.Code = "MyNewCouponCode";
+        testUpdateCouponRequestModel.Description = "My coupon description updated";
+        testUpdateCouponRequestModel.DiscountPercentage = 30;
+        testUpdateCouponRequestModel.UsageLimit = 3;
+        testUpdateCouponRequestModel.DefaultDateIntervalInDays = 5; //this should be ignored because the event is universal
+        testUpdateCouponRequestModel.TriggerEvent = "OnSignUp"; //this should be ignored because the event is universal
+        testUpdateCouponRequestModel.ExpirationDate = DateTime.Now.AddDays(3);
+
+        //Act
+        HttpResponseMessage response = await httpClient.PutAsJsonAsync("api/coupon", testUpdateCouponRequestModel);
+        string? errorMessage = await TestUtilitiesLibrary.JsonUtilities.GetSingleStringValueFromBody(response, "errorMessage");
+
+        //Assert
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+        errorMessage.Should().NotBeNull().And.Be("EntityNotFoundWithGivenId");
+    }
+
+    [Test, Order(140)]
+    public async Task UpdateCoupon_ShouldFailAndReturnBadRequest_IfDuplicateCouponCode()
+    {
+        //Arrange
+        httpClient.DefaultRequestHeaders.Remove("X-API-KEY");
+        httpClient.DefaultRequestHeaders.Add("X-API-KEY", _chosenApiKey);
+        TestUpdateCouponRequestModel testUpdateCouponRequestModel = new TestUpdateCouponRequestModel();
+        testUpdateCouponRequestModel.Id = _chosenUniversalCouponId;
+        testUpdateCouponRequestModel.Code = _otherCouponCode;
+        testUpdateCouponRequestModel.Description = "My coupon description updated";
+        testUpdateCouponRequestModel.DiscountPercentage = 30;
+        testUpdateCouponRequestModel.UsageLimit = 3;
+        testUpdateCouponRequestModel.DefaultDateIntervalInDays = 5; //this should be ignored because the event is universal
+        testUpdateCouponRequestModel.TriggerEvent = "OnSignUp"; //this should be ignored because the event is universal
+        testUpdateCouponRequestModel.ExpirationDate = DateTime.Now.AddDays(3);
+
+        //Act
+        HttpResponseMessage response = await httpClient.PutAsJsonAsync("api/coupon", testUpdateCouponRequestModel);
+        string? errorMessage = await TestUtilitiesLibrary.JsonUtilities.GetSingleStringValueFromBody(response, "errorMessage");
+
+        //Assert
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        errorMessage.Should().NotBeNull().And.Be("DuplicateEntityCode");
+    }
+
+    [Test, Order(150)]
+    public async Task UpdateCoupon_ShouldSucceedAndUpdateUniversalCoupon()
+    {
+        //Arrange
+        httpClient.DefaultRequestHeaders.Remove("X-API-KEY");
+        httpClient.DefaultRequestHeaders.Add("X-API-KEY", _chosenApiKey);
+        TestUpdateCouponRequestModel testUpdateCouponRequestModel = new TestUpdateCouponRequestModel();
+        testUpdateCouponRequestModel.Id = _chosenUniversalCouponId;
+        testUpdateCouponRequestModel.Code = "MyNewCouponCode";
+        testUpdateCouponRequestModel.Description = "My coupon description updated";
+        testUpdateCouponRequestModel.DiscountPercentage = 30;
+        testUpdateCouponRequestModel.UsageLimit = 3;
+        testUpdateCouponRequestModel.DefaultDateIntervalInDays = 3; //this should be ignored because the event is universal
+        testUpdateCouponRequestModel.TriggerEvent = "OnSignUp"; //this should be ignored because the event is universal
+        testUpdateCouponRequestModel.ExpirationDate = DateTime.Now.AddDays(3);
+
+        //Act
+        HttpResponseMessage response = await httpClient.PutAsJsonAsync("api/coupon", testUpdateCouponRequestModel);
+        HttpResponseMessage getResponse = await httpClient.GetAsync($"api/coupon/{_chosenUniversalCouponId}/includeDeactivated/true");
+        string? responseBody = await getResponse.Content.ReadAsStringAsync();
+        TestCoupon? testCoupon = JsonSerializer.Deserialize<TestCoupon>(responseBody, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+
+        //Assert
+        response.StatusCode.Should().Be(HttpStatusCode.NoContent);
+        testCoupon!.Code.Should().NotBeNull().And.Be(testUpdateCouponRequestModel.Code);
+        testCoupon!.Description.Should().NotBeNull().And.Be(testUpdateCouponRequestModel.Description);
+        testCoupon!.DiscountPercentage.Should().NotBeNull().And.Be(testUpdateCouponRequestModel.DiscountPercentage);
+        testCoupon!.UsageLimit.Should().NotBeNull().And.Be(testUpdateCouponRequestModel.UsageLimit);
+        testCoupon!.DefaultDateIntervalInDays.Should().BeNull();
+        testCoupon!.TriggerEvent.Should().NotBeNull().And.Be("NoTrigger");
+        testCoupon!.ExpirationDate.Should().NotBeNull().And.Be(testUpdateCouponRequestModel.ExpirationDate);
+    }
+
+    [Test, Order(150)]
+    public async Task UpdateCoupon_ShouldSucceedAndUpdateUserSpecificCoupon()
+    {
+        //Arrange
+        httpClient.DefaultRequestHeaders.Remove("X-API-KEY");
+        httpClient.DefaultRequestHeaders.Add("X-API-KEY", _chosenApiKey);
+        TestUpdateCouponRequestModel testUpdateCouponRequestModel = new TestUpdateCouponRequestModel();
+        testUpdateCouponRequestModel.Id = _chosenUserSpecificCouponId;
+        testUpdateCouponRequestModel.Code = "MyNewUserSpecificCouponCode";
+        testUpdateCouponRequestModel.Description = "My user specific coupon description updated";
+        testUpdateCouponRequestModel.DiscountPercentage = 50;
+        testUpdateCouponRequestModel.UsageLimit = 5;
+        testUpdateCouponRequestModel.DefaultDateIntervalInDays = 5;
+        testUpdateCouponRequestModel.TriggerEvent = "OnFirstOrder";
+        testUpdateCouponRequestModel.StartDate = DateTime.Now.AddDays(1); //this should be ignored because the event is user specific
+        testUpdateCouponRequestModel.ExpirationDate = DateTime.Now.AddDays(3); //this should be ignored because the event is user specific
+
+        //Act
+        HttpResponseMessage response = await httpClient.PutAsJsonAsync("api/coupon", testUpdateCouponRequestModel);
+        HttpResponseMessage getResponse = await httpClient.GetAsync($"api/coupon/{_chosenUserSpecificCouponId}/includeDeactivated/true");
+        string? responseBody = await getResponse.Content.ReadAsStringAsync();
+        TestCoupon? testCoupon = JsonSerializer.Deserialize<TestCoupon>(responseBody, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+
+        //Assert
+        response.StatusCode.Should().Be(HttpStatusCode.NoContent);
+        testCoupon!.Code.Should().NotBeNull().And.Be(testUpdateCouponRequestModel.Code);
+        testCoupon!.Description.Should().NotBeNull().And.Be(testUpdateCouponRequestModel.Description);
+        testCoupon!.DiscountPercentage.Should().NotBeNull().And.Be(testUpdateCouponRequestModel.DiscountPercentage);
+        testCoupon!.UsageLimit.Should().NotBeNull().And.Be(testUpdateCouponRequestModel.UsageLimit);
+        testCoupon!.DefaultDateIntervalInDays.Should().NotBeNull().And.Be(testUpdateCouponRequestModel.DefaultDateIntervalInDays);
+        testCoupon!.TriggerEvent.Should().NotBeNull().And.Be(testUpdateCouponRequestModel.TriggerEvent);
+        testCoupon!.StartDate.Should().BeNull();
+        testCoupon!.ExpirationDate.Should().BeNull();
+    }
+
+    [Test, Order(160)]
+    public async Task AddCouponToUser_ShouldFailAndReturnUnauthorized_IfXAPIKEYHeaderIsMissing()
+    {
+        //Arrange
+        httpClient.DefaultRequestHeaders.Remove("X-API-KEY");
+        TestAddCouponToUserRequestModel testAddCouponToUserRequestModel = new TestAddCouponToUserRequestModel();
+        testAddCouponToUserRequestModel.Code = "MyUserCode"; //since the coupon is universal the code will be the same as the code of the coupon(the code that I am giving here will be overriden)
+        testAddCouponToUserRequestModel.UserId = _chosenUserId;
+        testAddCouponToUserRequestModel.CouponId = _chosenUniversalCouponId;
+        testAddCouponToUserRequestModel.StartDate = DateTime.Now.AddDays(1); //since the coupon is universal the start dates and expiration dates will be overriden
+        testAddCouponToUserRequestModel.ExpirationDate = DateTime.Now.AddDays(3);
+
+        //Act
+        HttpResponseMessage response = await httpClient.PostAsJsonAsync("api/coupon/addCouponToUser", testAddCouponToUserRequestModel);
+        string? errorMessage = await TestUtilitiesLibrary.JsonUtilities.GetSingleStringValueFromBody(response, "errorMessage");
+
+        //Assert
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+        errorMessage.Should().NotBeNull().And.Contain("X-API-KEY");
+    }
+
+    [Test, Order(170)]
+    public async Task AddCouponToUser_ShouldFailAndReturnUnauthorized_IfAPIKeyIsInvalid()
+    {
+        //Arrange
+        httpClient.DefaultRequestHeaders.Remove("X-API-KEY");
+        httpClient.DefaultRequestHeaders.Add("X-API-KEY", "bogusKey");
+        //the code can be autogenerated so I do not need to set it here and timesused, because it is null will become 0
+        TestAddCouponToUserRequestModel testAddCouponToUserRequestModel = new TestAddCouponToUserRequestModel();
+        testAddCouponToUserRequestModel.Code = "MyUserCode"; //since the coupon is universal the code will be the same as the code of the coupon(the code that I am giving here will be overriden)
+        testAddCouponToUserRequestModel.UserId = _chosenUserId;
+        testAddCouponToUserRequestModel.CouponId = _chosenUniversalCouponId;
+        testAddCouponToUserRequestModel.StartDate = DateTime.Now.AddDays(1); //since the coupon is universal the start dates and expiration dates will be overriden
+        testAddCouponToUserRequestModel.ExpirationDate = DateTime.Now.AddDays(3);
+
+        //Act
+        HttpResponseMessage response = await httpClient.PostAsJsonAsync("api/coupon/addCouponToUser", testAddCouponToUserRequestModel);
+        string? errorMessage = await TestUtilitiesLibrary.JsonUtilities.GetSingleStringValueFromBody(response, "errorMessage");
+
+        //Assert
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+        errorMessage.Should().NotBeNull().And.Contain("Invalid");
+    }
+
+    [Test, Order(180)]
+    public async Task AddCouponToUser_ShouldFailAndReturnBadRequest_IfInvalidRequestModelFormatInUserCouponEntity()
+    {
+        //Arrange
+        httpClient.DefaultRequestHeaders.Remove("X-API-KEY");
+        httpClient.DefaultRequestHeaders.Add("X-API-KEY", _chosenApiKey);
+        TestAddCouponToUserRequestModel testAddCouponToUserRequestModel = new TestAddCouponToUserRequestModel();
+        testAddCouponToUserRequestModel.Code = "MyUserCode"; //since the coupon is universal the code will be the same as the code of the coupon(the code that I am giving here will be overriden)
+        testAddCouponToUserRequestModel.CouponId = _chosenUniversalCouponId;
+        testAddCouponToUserRequestModel.StartDate = DateTime.Now.AddDays(1); //since the coupon is universal the start dates and expiration dates will be overriden
+        testAddCouponToUserRequestModel.ExpirationDate = DateTime.Now.AddDays(3);
+
+        //Act
+        HttpResponseMessage response = await httpClient.PostAsJsonAsync("api/coupon/addCouponToUser", testAddCouponToUserRequestModel); //The userId of the user coupon is missing and thus the request model is not valid
+
+        //Assert
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Test, Order(190)]
+    public async Task AddCouponToUser_ShouldFailAndReturnNotFound_IfCouponNotInSystem()
+    {
+        //Arrange
+        httpClient.DefaultRequestHeaders.Remove("X-API-KEY");
+        httpClient.DefaultRequestHeaders.Add("X-API-KEY", _chosenApiKey);
+        TestAddCouponToUserRequestModel testAddCouponToUserRequestModel = new TestAddCouponToUserRequestModel();
+        testAddCouponToUserRequestModel.Code = "MyUserCode"; //since the coupon is universal the code will be the same as the code of the coupon(the code that I am giving here will be overriden)
+        testAddCouponToUserRequestModel.UserId = _chosenUserId;
+        testAddCouponToUserRequestModel.CouponId = "bogusCouponId";
+        testAddCouponToUserRequestModel.StartDate = DateTime.Now.AddDays(1); //since the coupon is universal the start dates and expiration dates will be overriden
+        testAddCouponToUserRequestModel.ExpirationDate = DateTime.Now.AddDays(3);
+
+        //Act
+        HttpResponseMessage response = await httpClient.PostAsJsonAsync("api/coupon/addCouponToUser", testAddCouponToUserRequestModel);
+        string? errorMessage = await TestUtilitiesLibrary.JsonUtilities.GetSingleStringValueFromBody(response, "errorMessage");
+
+        //Assert
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+        errorMessage.Should().NotBeNull().And.Be("InvalidCouponIdWasGiven");
+    }
+
+    [Test, Order(200)]
+    public async Task AddCouponToUser_ShouldSucceedAndAddUniversalCouponToUser()
+    {
+        //Arrange
+        httpClient.DefaultRequestHeaders.Remove("X-API-KEY");
+        httpClient.DefaultRequestHeaders.Add("X-API-KEY", _chosenApiKey);
+        TestAddCouponToUserRequestModel testAddCouponToUserRequestModel = new TestAddCouponToUserRequestModel();
+        testAddCouponToUserRequestModel.Code = "MyUserCode"; //since the coupon is universal the code will be the same as the code of the coupon(the code that I am giving here will be overriden)
+        testAddCouponToUserRequestModel.UserId = _chosenUserId;
+        testAddCouponToUserRequestModel.CouponId = _chosenUniversalCouponId;
+        testAddCouponToUserRequestModel.StartDate = DateTime.Now.AddDays(1); //since the coupon is universal the start dates and expiration dates will be overriden
+        testAddCouponToUserRequestModel.ExpirationDate = DateTime.Now.AddDays(3);
+
+        //Act
+        HttpResponseMessage response = await httpClient.PostAsJsonAsync("api/coupon/addCouponToUser", testAddCouponToUserRequestModel);
+        string? responseBody = await response.Content.ReadAsStringAsync();
+        TestUserCoupon? testUserCoupon = JsonSerializer.Deserialize<TestUserCoupon>(responseBody, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+        HttpResponseMessage getResponse = await httpClient.GetAsync($"api/coupon/{testAddCouponToUserRequestModel.CouponId}/includeDeactivated/true");
+        string? getResponseBody = await getResponse.Content.ReadAsStringAsync();
+        TestCoupon? testCoupon = JsonSerializer.Deserialize<TestCoupon>(getResponseBody, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+
+        //Assert
+        response.StatusCode.Should().Be(HttpStatusCode.Created);
+        testUserCoupon.Should().NotBeNull();
+        testUserCoupon!.Id.Should().NotBeNull();
+        testUserCoupon!.Code.Should().NotBeNull().And.NotBe(testAddCouponToUserRequestModel.Code);
+        testUserCoupon!.TimesUsed.Should().Be(0);
+        testUserCoupon!.StartDate.Should().NotBeNull().And.NotBe(testAddCouponToUserRequestModel.StartDate);
+        testUserCoupon!.ExpirationDate.Should().NotBeNull().And.NotBe(testAddCouponToUserRequestModel.ExpirationDate);
+        testUserCoupon!.UserId = testAddCouponToUserRequestModel.UserId;
+        testUserCoupon!.CouponId = testAddCouponToUserRequestModel.CouponId;
+        testCoupon!.UserCoupons.Should().NotBeNull().And.HaveCount(1);
+        _chosenUniversalUserCouponId = testUserCoupon!.Id;
+    }
+
+    [Test, Order(210)]
+    public async Task AddCouponToUser_ShouldSucceedAndAddUserSpecificCouponToUser()
+    {
+        //Arrange
+        httpClient.DefaultRequestHeaders.Remove("X-API-KEY");
+        httpClient.DefaultRequestHeaders.Add("X-API-KEY", _chosenApiKey);
+        TestAddCouponToUserRequestModel testAddCouponToUserRequestModel = new TestAddCouponToUserRequestModel();
+        testAddCouponToUserRequestModel.UserId = _chosenUserId;
+        testAddCouponToUserRequestModel.CouponId = _chosenUserSpecificCouponId;
+        //since the coupon is user specific the dates will be created using the date interval property of the coupon
+
+        //Act
+        HttpResponseMessage response = await httpClient.PostAsJsonAsync("api/coupon/addCouponToUser", testAddCouponToUserRequestModel);
+        string? responseBody = await response.Content.ReadAsStringAsync();
+        TestUserCoupon? testUserCoupon = JsonSerializer.Deserialize<TestUserCoupon>(responseBody, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+        HttpResponseMessage getResponse = await httpClient.GetAsync($"api/coupon/{testAddCouponToUserRequestModel.CouponId}/includeDeactivated/true");
+        string? getResponseBody = await getResponse.Content.ReadAsStringAsync();
+        TestCoupon? testCoupon = JsonSerializer.Deserialize<TestCoupon>(getResponseBody, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+
+        //Assert
+        response.StatusCode.Should().Be(HttpStatusCode.Created);
+        testUserCoupon.Should().NotBeNull();
+        testUserCoupon!.Id.Should().NotBeNull();
+        testUserCoupon!.Code.Should().NotBeNull();
+        testUserCoupon!.TimesUsed.Should().Be(0);
+        testUserCoupon!.UserId = testAddCouponToUserRequestModel.UserId;
+        testUserCoupon!.CouponId = testAddCouponToUserRequestModel.CouponId;
+        testCoupon!.UserCoupons.Should().NotBeNull().And.HaveCount(1);
+        _chosenUserSpecificUserCouponId = testUserCoupon!.Id;
+    }
+
+    [Test, Order(220)]
+    public async Task AddCouponToUser_ShouldSucceedAndAddUserSpecificCouponToUserWithCustomDatesAndCode()
+    {
+        //Arrange
+        httpClient.DefaultRequestHeaders.Remove("X-API-KEY");
+        httpClient.DefaultRequestHeaders.Add("X-API-KEY", _chosenApiKey);
+        TestAddCouponToUserRequestModel testAddCouponToUserRequestModel = new TestAddCouponToUserRequestModel();
+        testAddCouponToUserRequestModel.Code = "MyUserCouponCode";
+        testAddCouponToUserRequestModel.StartDate = DateTime.Now.AddMonths(1);
+        testAddCouponToUserRequestModel.ExpirationDate = DateTime.Now.AddMonths(2);
+        testAddCouponToUserRequestModel.UserId = _chosenUserId;
+        testAddCouponToUserRequestModel.CouponId = _chosenUserSpecificCouponId;
+
+        //Act
+        HttpResponseMessage response = await httpClient.PostAsJsonAsync("api/coupon/addCouponToUser", testAddCouponToUserRequestModel);
+        string? responseBody = await response.Content.ReadAsStringAsync();
+        TestUserCoupon? testUserCoupon = JsonSerializer.Deserialize<TestUserCoupon>(responseBody, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+        HttpResponseMessage getResponse = await httpClient.GetAsync($"api/coupon/{testAddCouponToUserRequestModel.CouponId}/includeDeactivated/true");
+        string? getResponseBody = await getResponse.Content.ReadAsStringAsync();
+        TestCoupon? testCoupon = JsonSerializer.Deserialize<TestCoupon>(getResponseBody, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+
+        //Assert
+        response.StatusCode.Should().Be(HttpStatusCode.Created);
+        testUserCoupon.Should().NotBeNull();
+        testUserCoupon!.Id.Should().NotBeNull();
+        testUserCoupon!.Code.Should().NotBeNull();
+        testUserCoupon!.TimesUsed.Should().Be(0);
+        testUserCoupon!.UserId = testAddCouponToUserRequestModel.UserId;
+        testUserCoupon!.CouponId = testAddCouponToUserRequestModel.CouponId;
+        testCoupon!.UserCoupons.Should().NotBeNull().And.HaveCount(2);
+        TestUserCoupon? currentlyAddedUserCoupon = testCoupon!.UserCoupons.FirstOrDefault(userCoupon => userCoupon.Code == testAddCouponToUserRequestModel.Code);
+        currentlyAddedUserCoupon!.StartDate.Should().NotBeNull().And.Be(testAddCouponToUserRequestModel.StartDate);
+        currentlyAddedUserCoupon!.ExpirationDate.Should().NotBeNull().And.Be(testAddCouponToUserRequestModel.ExpirationDate);
+    }
+
+    [Test, Order(230)]
+    public async Task UpdateUserCoupon_ShouldFailAndReturnUnauthorized_IfAPIKeyIsInvalid()
+    {
+        //Arrange
+        httpClient.DefaultRequestHeaders.Remove("X-API-KEY");
+        httpClient.DefaultRequestHeaders.Add("X-API-KEY", "bogusKey");
+        TestUpdateUserCouponRequestModel testUpdateUserCouponRequestModel = new TestUpdateUserCouponRequestModel();
+        testUpdateUserCouponRequestModel.Id = _chosenUniversalUserCouponId;
+        testUpdateUserCouponRequestModel.Code = "MyNewUniversalUserCouponCode"; //this will be overriden, because the coupon is universal
+        testUpdateUserCouponRequestModel.TimesUsed = 1; //this is the main reason why this endpoint exists to begin with 
+        testUpdateUserCouponRequestModel.StartDate = DateTime.Now.AddMonths(1); //the dates will be overriden, because the coupon is universal
+        testUpdateUserCouponRequestModel.ExpirationDate = DateTime.Now.AddMonths(2);
+
+        //Act
+        HttpResponseMessage response = await httpClient.PutAsJsonAsync("api/coupon/updateUserCoupon", testUpdateUserCouponRequestModel);
+        string? errorMessage = await TestUtilitiesLibrary.JsonUtilities.GetSingleStringValueFromBody(response, "errorMessage");
+
+        //Assert
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+        errorMessage.Should().NotBeNull().And.Contain("Invalid");
+    }
+
+    [Test, Order(240)]
+    public async Task UpdateUserCoupon_ShouldFailAndReturnNotFound_IfInvalidRequestModelFormat()
+    {
+        //Arrange
+        httpClient.DefaultRequestHeaders.Remove("X-API-KEY");
+        httpClient.DefaultRequestHeaders.Add("X-API-KEY", _chosenApiKey);
+        TestUpdateUserCouponRequestModel testUpdateUserCouponRequestModel = new TestUpdateUserCouponRequestModel();
+        testUpdateUserCouponRequestModel.Code = "MyNewUniversalUserCouponCode"; //this will be overriden, because the coupon is universal
+        testUpdateUserCouponRequestModel.TimesUsed = 1; //this is the main reason why this endpoint exists to begin with 
+        testUpdateUserCouponRequestModel.StartDate = DateTime.Now.AddMonths(1); //the dates will be overriden, because the coupon is universal
+        testUpdateUserCouponRequestModel.ExpirationDate = DateTime.Now.AddMonths(2);
+
+        //Act
+        HttpResponseMessage response = await httpClient.PutAsJsonAsync("api/coupon/updateUserCoupon", testUpdateUserCouponRequestModel); //here the id is missing, which is required for the update
+
+        //Assert
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Test, Order(250)]
+    public async Task UpdateUserCoupon_ShouldFailAndReturnNotFound_IfUserCouponNotInSystem()
+    {
+        //Arrange
+        httpClient.DefaultRequestHeaders.Remove("X-API-KEY");
+        httpClient.DefaultRequestHeaders.Add("X-API-KEY", _chosenApiKey);
+        TestUpdateUserCouponRequestModel testUpdateUserCouponRequestModel = new TestUpdateUserCouponRequestModel();
+        testUpdateUserCouponRequestModel.Id = "bogusUserCouponId";
+        testUpdateUserCouponRequestModel.Code = "MyNewUniversalUserCouponCode"; //this will be overriden, because the coupon is universal
+        testUpdateUserCouponRequestModel.TimesUsed = 1; //this is the main reason why this endpoint exists to begin with 
+        testUpdateUserCouponRequestModel.StartDate = DateTime.Now.AddMonths(1); //the dates will be overriden, because the coupon is universal
+        testUpdateUserCouponRequestModel.ExpirationDate = DateTime.Now.AddMonths(2);
+
+        //Act
+        HttpResponseMessage response = await httpClient.PutAsJsonAsync("api/coupon/updateUserCoupon", testUpdateUserCouponRequestModel);
+        string? errorMessage = await TestUtilitiesLibrary.JsonUtilities.GetSingleStringValueFromBody(response, "errorMessage");
+
+        //Assert
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+        errorMessage.Should().NotBeNull().And.Be("EntityNotFoundWithGivenId");
+    }
+
+    [Test, Order(260)]
+    public async Task UpdateUserCoupon_ShouldSucceedAndUpdateUniversalUserCoupon()
+    {
+        //Arrange
+        httpClient.DefaultRequestHeaders.Remove("X-API-KEY");
+        httpClient.DefaultRequestHeaders.Add("X-API-KEY", _chosenApiKey);
+        TestUpdateUserCouponRequestModel testUpdateUserCouponRequestModel = new TestUpdateUserCouponRequestModel();
+        testUpdateUserCouponRequestModel.Id = _chosenUniversalUserCouponId;
+        testUpdateUserCouponRequestModel.Code = "MyNewUniversalUserCouponCode"; //this will be overriden, because the coupon is universal
+        testUpdateUserCouponRequestModel.TimesUsed = 1; //this is the main reason why this endpoint exists to begin with 
+        testUpdateUserCouponRequestModel.StartDate = DateTime.Now.AddMonths(1); //the dates will be overriden, because the coupon is universal
+        testUpdateUserCouponRequestModel.ExpirationDate = DateTime.Now.AddMonths(2);
+
+        //Act
+        HttpResponseMessage response = await httpClient.PutAsJsonAsync("api/coupon/updateUserCoupon", testUpdateUserCouponRequestModel);
+        HttpResponseMessage getResponse = await httpClient.GetAsync($"api/coupon/{_chosenUniversalCouponId}/includeDeactivated/true");
+        string? getResponseBody = await getResponse.Content.ReadAsStringAsync();
+        TestCoupon? testCoupon = JsonSerializer.Deserialize<TestCoupon>(getResponseBody, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+
+        //Assert
+        response.StatusCode.Should().Be(HttpStatusCode.NoContent);
+        testCoupon!.UserCoupons.Should().NotBeNull().And.HaveCount(1);
+        testCoupon!.UserCoupons[0].Code.Should().NotBeNull().And.NotBe(testUpdateUserCouponRequestModel.Code);
+        testCoupon!.UserCoupons[0].TimesUsed.Should().NotBeNull().And.Be(testUpdateUserCouponRequestModel.TimesUsed);
+        testCoupon!.UserCoupons[0].StartDate.Should().NotBeNull().And.NotBe(testUpdateUserCouponRequestModel.StartDate);
+        testCoupon!.UserCoupons[0].ExpirationDate.Should().NotBeNull().And.NotBe(testUpdateUserCouponRequestModel.ExpirationDate);
+    }
+
+    [Test, Order(270)]
+    public async Task UpdateUserCoupon_ShouldSucceedAndUpdateUserSpecificUserCoupon()
+    {
+        //Arrange
+        httpClient.DefaultRequestHeaders.Remove("X-API-KEY");
+        httpClient.DefaultRequestHeaders.Add("X-API-KEY", _chosenApiKey);
+        //when it comes to user specific user coupons all the properties can be adjusted, so nothing will be overriden below
+        TestUpdateUserCouponRequestModel testUpdateUserCouponRequestModel = new TestUpdateUserCouponRequestModel();
+        testUpdateUserCouponRequestModel.Id = _chosenUserSpecificUserCouponId;
+        testUpdateUserCouponRequestModel.Code = "MyNewUserSpecificUserCouponCode";
+        testUpdateUserCouponRequestModel.TimesUsed = 1;
+        testUpdateUserCouponRequestModel.StartDate = DateTime.Now.AddMonths(4);
+        testUpdateUserCouponRequestModel.ExpirationDate = DateTime.Now.AddMonths(5);
+
+        //Act
+        HttpResponseMessage response = await httpClient.PutAsJsonAsync("api/coupon/updateUserCoupon", testUpdateUserCouponRequestModel);
+        HttpResponseMessage getResponse = await httpClient.GetAsync($"api/coupon/{_chosenUserSpecificCouponId}/includeDeactivated/true");
+        string? getResponseBody = await getResponse.Content.ReadAsStringAsync();
+        TestCoupon? testCoupon = JsonSerializer.Deserialize<TestCoupon>(getResponseBody, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+
+        //Assert
+        response.StatusCode.Should().Be(HttpStatusCode.NoContent);
+        testCoupon!.UserCoupons.Should().NotBeNull().And.HaveCount(2);
+        TestUserCoupon? currentlyUpdatedUserCoupon = testCoupon!.UserCoupons.FirstOrDefault(userCoupon => userCoupon.Code == testUpdateUserCouponRequestModel.Code);
+        currentlyUpdatedUserCoupon!.Code.Should().NotBeNull().And.Be(testUpdateUserCouponRequestModel.Code);
+        currentlyUpdatedUserCoupon!.TimesUsed.Should().NotBeNull().And.Be(testUpdateUserCouponRequestModel.TimesUsed);
+        currentlyUpdatedUserCoupon!.StartDate.Should().NotBeNull().And.Be(testUpdateUserCouponRequestModel.StartDate);
+        currentlyUpdatedUserCoupon!.ExpirationDate.Should().NotBeNull().And.Be(testUpdateUserCouponRequestModel.ExpirationDate);
+    }
+
+    [Test, Order(280)]
+    public async Task RemoveCouponFromUser_ShouldFailAndReturnUnauthorized_IfAPIKeyIsInvalid()
+    {
+        //Arrange
+        httpClient.DefaultRequestHeaders.Remove("X-API-KEY");
+        httpClient.DefaultRequestHeaders.Add("X-API-KEY", "bogusKey");
+        string? userCouponId = _chosenUniversalUserCouponId;
+
+        //Act
+        HttpResponseMessage response = await httpClient.DeleteAsync($"api/coupon/removeCouponFromUser/userCouponId/{userCouponId}");
+        string? errorMessage = await TestUtilitiesLibrary.JsonUtilities.GetSingleStringValueFromBody(response, "errorMessage");
+
+        //Assert
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+        errorMessage.Should().NotBeNull().And.Contain("Invalid");
+    }
+
+    [Test, Order(290)]
+    public async Task RemoveCouponFromUser_ShouldFailAndReturnNotFound_IfUserCouponNotInSystem()
+    {
+        //Arrange
+        httpClient.DefaultRequestHeaders.Remove("X-API-KEY");
+        httpClient.DefaultRequestHeaders.Add("X-API-KEY", _chosenApiKey);
+        string bogusUserCouponId = "bogusCouponId";
+
+        //Act
+        HttpResponseMessage response = await httpClient.DeleteAsync($"api/coupon/removeCouponFromUser/userCouponId/{bogusUserCouponId}");
+
+        //Assert
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Test, Order(300)]
+    public async Task RemoveCouponFromUser_ShouldSucceedAndRemoveCouponFromUser()
+    {
+        //Arrange
+        httpClient.DefaultRequestHeaders.Remove("X-API-KEY");
+        httpClient.DefaultRequestHeaders.Add("X-API-KEY", _chosenApiKey);
+        string? userCouponId = _chosenUniversalUserCouponId;
+
+        //Act
+        HttpResponseMessage response = await httpClient.DeleteAsync($"api/coupon/removeCouponFromUser/userCouponId/{userCouponId}");
+        HttpResponseMessage secondResponse = await httpClient.DeleteAsync($"api/coupon/removeCouponFromUser/userCouponId/{userCouponId}");
+
+        //Assert
+        response.StatusCode.Should().Be(HttpStatusCode.NoContent);
+        secondResponse.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Test, Order(310)]
+    public async Task DeleteCoupon_ShouldFailAndReturnUnauthorized_IfAPIKeyIsInvalid()
+    {
+        //Arrange
+        httpClient.DefaultRequestHeaders.Remove("X-API-KEY");
+        httpClient.DefaultRequestHeaders.Add("X-API-KEY", "bogusKey");
+        string couponId = _chosenUniversalCouponId!;
+
+        //Act
+        HttpResponseMessage response = await httpClient.DeleteAsync($"api/coupon/{couponId}");
+        string? errorMessage = await TestUtilitiesLibrary.JsonUtilities.GetSingleStringValueFromBody(response, "errorMessage");
+
+        //Assert
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+        errorMessage.Should().NotBeNull().And.Contain("Invalid");
+    }
+
+    [Test, Order(320)]
+    public async Task DeleteCoupon_ShouldFailAndReturnNotFound_IfCouponNotInSystem()
+    {
+        //Arrange
+        httpClient.DefaultRequestHeaders.Remove("X-API-KEY");
+        httpClient.DefaultRequestHeaders.Add("X-API-KEY", _chosenApiKey);
+        string bogusCouponId = "bogusCouponId";
+
+        //Act
+        HttpResponseMessage response = await httpClient.DeleteAsync($"api/coupon/{bogusCouponId}");
+
+        //Assert
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Test, Order(330)]
+    public async Task DeleteCoupon_ShouldSucceedAndDeleteCoupon()
+    {
+        //Arrange
+        httpClient.DefaultRequestHeaders.Remove("X-API-KEY");
+        httpClient.DefaultRequestHeaders.Add("X-API-KEY", _chosenApiKey);
+        string couponId = _chosenUniversalCouponId!;
+
+        //Act
+        HttpResponseMessage response = await httpClient.DeleteAsync($"api/coupon/{couponId}");
+        HttpResponseMessage secondResponse = await httpClient.DeleteAsync($"api/coupon/{couponId}");
+
+        //Assert
+        response.StatusCode.Should().Be(HttpStatusCode.NoContent);
+        secondResponse.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    //Rate Limit Test
+    [Test, Order(400)]
+    public async Task GetCoupons_ShouldFail_IfRateLimitIsExceededAndBypassHeaderNotFilledCorrectly()
+    {
+        //Arrange
+        httpClient.DefaultRequestHeaders.Remove("X-Bypass-Rate-Limiting");
+        httpClient.DefaultRequestHeaders.Remove("X-API-KEY");
+        httpClient.DefaultRequestHeaders.Add("X-API-KEY", _chosenApiKey);
+
+        //Act
+        HttpResponseMessage response = new();
+        for (int i = 0; i < 101; i++)
+            response = await httpClient.GetAsync("api/coupon/amount/10/includeDeactivated/true");
+
+        //Assert
+        response.StatusCode.Should().Be(HttpStatusCode.TooManyRequests);
+    }
+
+    [OneTimeTearDown]
+    public void OnTimeTearDown()
+    {
+        httpClient.Dispose();
+        TestUtilitiesLibrary.DatabaseUtilities.ResetSqlAuthDatabase(
+            "Data Source=(localdb)\\MSSQLLocalDB;Initial Catalog=EshopAppDataDb;Integrated Security=True;Connect Timeout=30;Encrypt=False;TrustServerCertificate=False;ApplicationIntent=ReadWrite;MultiSubnetFailover=False",
+            new string[] { "dbo.Attributes", "dbo.Categories", "dbo.Products", "dbo.Variants", "dbo.Discounts", "dbo.Images", "dbo.VariantImages", "dbo.Coupons", "dbo.UserCoupons" },
+            "Data Database Successfully Cleared!"
+        );
+    }
+}

--- a/EshopApp.DataLibraryAPI.Tests/IntegrationTests/ControllerTests/DiscountControllerTests.cs
+++ b/EshopApp.DataLibraryAPI.Tests/IntegrationTests/ControllerTests/DiscountControllerTests.cs
@@ -34,7 +34,7 @@ internal class DiscountControllerTests
 
         TestUtilitiesLibrary.DatabaseUtilities.ResetSqlAuthDatabase(
             "Data Source=(localdb)\\MSSQLLocalDB;Initial Catalog=EshopAppDataDb;Integrated Security=True;Connect Timeout=30;Encrypt=False;TrustServerCertificate=False;ApplicationIntent=ReadWrite;MultiSubnetFailover=False",
-            new string[] { "dbo.Attributes", "dbo.Categories", "dbo.Products", "dbo.Variants", "dbo.Discounts", "dbo.Images", "dbo.VariantImages" },
+            new string[] { "dbo.Attributes", "dbo.Categories", "dbo.Products", "dbo.Variants", "dbo.Discounts", "dbo.Images", "dbo.VariantImages", "dbo.Coupons", "dbo.UserCoupons" },
             "Data Database Successfully Cleared!"
         );
 
@@ -183,7 +183,7 @@ internal class DiscountControllerTests
         httpClient.DefaultRequestHeaders.Add("X-API-KEY", _chosenApiKey);
 
         //Act
-        HttpResponseMessage response = await httpClient.GetAsync("api/discount/amount/10");
+        HttpResponseMessage response = await httpClient.GetAsync("api/discount/amount/10/includeDeactivated/true");
         string? responseBody = await response.Content.ReadAsStringAsync();
         List<TestDiscount>? testDiscounts = JsonSerializer.Deserialize<List<TestDiscount>>(responseBody, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
 
@@ -219,7 +219,7 @@ internal class DiscountControllerTests
         string bogusDiscountId = "bogusDiscountId";
 
         //Act
-        HttpResponseMessage response = await httpClient.GetAsync($"api/discount/{bogusDiscountId}");
+        HttpResponseMessage response = await httpClient.GetAsync($"api/discount/{bogusDiscountId}/includeDeactivated/true");
 
         //Assert
         response.StatusCode.Should().Be(HttpStatusCode.NotFound);
@@ -234,7 +234,7 @@ internal class DiscountControllerTests
         string discountId = _chosenDiscountId!;
 
         //Act
-        HttpResponseMessage response = await httpClient.GetAsync($"api/discount/{discountId}");
+        HttpResponseMessage response = await httpClient.GetAsync($"api/discount/{discountId}/includeDeactivated/true");
         string? responseBody = await response.Content.ReadAsStringAsync();
         TestDiscount? testDiscount = JsonSerializer.Deserialize<TestDiscount>(responseBody, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
 
@@ -340,7 +340,7 @@ internal class DiscountControllerTests
 
         //Act
         HttpResponseMessage response = await httpClient.PutAsJsonAsync("api/discount", testUpdateDiscountRequestModel);
-        HttpResponseMessage getResponse = await httpClient.GetAsync($"api/discount/{_chosenDiscountId}");
+        HttpResponseMessage getResponse = await httpClient.GetAsync($"api/discount/{_chosenDiscountId}/includeDeactivated/true");
         string? responseBody = await getResponse.Content.ReadAsStringAsync();
         TestDiscount? testDiscount = JsonSerializer.Deserialize<TestDiscount>(responseBody, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
 
@@ -364,7 +364,7 @@ internal class DiscountControllerTests
 
         //Act
         HttpResponseMessage response = await httpClient.PutAsJsonAsync("api/discount", testUpdateDiscountRequestModel);
-        HttpResponseMessage getResponse = await httpClient.GetAsync($"api/discount/{_chosenDiscountId}");
+        HttpResponseMessage getResponse = await httpClient.GetAsync($"api/discount/{_chosenDiscountId}/includeDeactivated/true");
         string? responseBody = await getResponse.Content.ReadAsStringAsync();
         TestDiscount? testDiscount = JsonSerializer.Deserialize<TestDiscount>(responseBody, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
 
@@ -434,7 +434,7 @@ internal class DiscountControllerTests
         //Act
         HttpResponseMessage response = new();
         for (int i = 0; i < 101; i++)
-            response = await httpClient.GetAsync("api/discount/amount/10");
+            response = await httpClient.GetAsync("api/discount/amount/10/includeDeactivated/true");
 
         //Assert
         response.StatusCode.Should().Be(HttpStatusCode.TooManyRequests);
@@ -446,7 +446,7 @@ internal class DiscountControllerTests
         httpClient.Dispose();
         TestUtilitiesLibrary.DatabaseUtilities.ResetSqlAuthDatabase(
             "Data Source=(localdb)\\MSSQLLocalDB;Initial Catalog=EshopAppDataDb;Integrated Security=True;Connect Timeout=30;Encrypt=False;TrustServerCertificate=False;ApplicationIntent=ReadWrite;MultiSubnetFailover=False",
-            new string[] { "dbo.Attributes", "dbo.Categories", "dbo.Products", "dbo.Variants", "dbo.Discounts", "dbo.Images", "dbo.VariantImages" },
+            new string[] { "dbo.Attributes", "dbo.Categories", "dbo.Products", "dbo.Variants", "dbo.Discounts", "dbo.Images", "dbo.VariantImages", "dbo.Coupons", "dbo.UserCoupons" },
             "Data Database Successfully Cleared!"
         );
     }

--- a/EshopApp.DataLibraryAPI.Tests/IntegrationTests/ControllerTests/ImageControllerTests.cs
+++ b/EshopApp.DataLibraryAPI.Tests/IntegrationTests/ControllerTests/ImageControllerTests.cs
@@ -29,7 +29,7 @@ internal class ImageControllerTests
 
         TestUtilitiesLibrary.DatabaseUtilities.ResetSqlAuthDatabase(
             "Data Source=(localdb)\\MSSQLLocalDB;Initial Catalog=EshopAppDataDb;Integrated Security=True;Connect Timeout=30;Encrypt=False;TrustServerCertificate=False;ApplicationIntent=ReadWrite;MultiSubnetFailover=False",
-            new string[] { "dbo.Attributes", "dbo.Categories", "dbo.Products", "dbo.Variants", "dbo.Discounts", "dbo.Images", "dbo.VariantImages" },
+            new string[] { "dbo.Attributes", "dbo.Categories", "dbo.Products", "dbo.Variants", "dbo.Discounts", "dbo.Images", "dbo.VariantImages", "dbo.Coupons", "dbo.UserCoupons" },
             "Data Database Successfully Cleared!"
         );
 
@@ -400,7 +400,7 @@ internal class ImageControllerTests
         httpClient.Dispose();
         TestUtilitiesLibrary.DatabaseUtilities.ResetSqlAuthDatabase(
             "Data Source=(localdb)\\MSSQLLocalDB;Initial Catalog=EshopAppDataDb;Integrated Security=True;Connect Timeout=30;Encrypt=False;TrustServerCertificate=False;ApplicationIntent=ReadWrite;MultiSubnetFailover=False",
-            new string[] { "dbo.Attributes", "dbo.Categories", "dbo.Products", "dbo.Variants", "dbo.Discounts", "dbo.Images", "dbo.VariantImages" },
+            new string[] { "dbo.Attributes", "dbo.Categories", "dbo.Products", "dbo.Variants", "dbo.Discounts", "dbo.Images", "dbo.VariantImages", "dbo.Coupons", "dbo.UserCoupons" },
             "Data Database Successfully Cleared!"
         );
     }

--- a/EshopApp.DataLibraryAPI.Tests/IntegrationTests/ControllerTests/ProductControllerTests.cs
+++ b/EshopApp.DataLibraryAPI.Tests/IntegrationTests/ControllerTests/ProductControllerTests.cs
@@ -41,7 +41,7 @@ internal class ProductControllerTests
 
         TestUtilitiesLibrary.DatabaseUtilities.ResetSqlAuthDatabase(
             "Data Source=(localdb)\\MSSQLLocalDB;Initial Catalog=EshopAppDataDb;Integrated Security=True;Connect Timeout=30;Encrypt=False;TrustServerCertificate=False;ApplicationIntent=ReadWrite;MultiSubnetFailover=False",
-            new string[] { "dbo.Attributes", "dbo.Categories", "dbo.Products", "dbo.Variants", "dbo.Discounts", "dbo.Images", "dbo.VariantImages" },
+            new string[] { "dbo.Attributes", "dbo.Categories", "dbo.Products", "dbo.Variants", "dbo.Discounts", "dbo.Images", "dbo.VariantImages", "dbo.Coupons", "dbo.UserCoupons" },
             "Data Database Successfully Cleared!"
         );
 
@@ -730,7 +730,7 @@ internal class ProductControllerTests
         httpClient.Dispose();
         TestUtilitiesLibrary.DatabaseUtilities.ResetSqlAuthDatabase(
             "Data Source=(localdb)\\MSSQLLocalDB;Initial Catalog=EshopAppDataDb;Integrated Security=True;Connect Timeout=30;Encrypt=False;TrustServerCertificate=False;ApplicationIntent=ReadWrite;MultiSubnetFailover=False",
-            new string[] { "dbo.Attributes", "dbo.Categories", "dbo.Products", "dbo.Variants", "dbo.Discounts", "dbo.Images", "dbo.VariantImages" },
+            new string[] { "dbo.Attributes", "dbo.Categories", "dbo.Products", "dbo.Variants", "dbo.Discounts", "dbo.Images", "dbo.VariantImages", "dbo.Coupons", "dbo.UserCoupons" },
             "Data Database Successfully Cleared!"
         );
     }

--- a/EshopApp.DataLibraryAPI.Tests/IntegrationTests/ControllerTests/VariantControllerTests.cs
+++ b/EshopApp.DataLibraryAPI.Tests/IntegrationTests/ControllerTests/VariantControllerTests.cs
@@ -42,7 +42,7 @@ internal class VariantControllerTests
 
         TestUtilitiesLibrary.DatabaseUtilities.ResetSqlAuthDatabase(
             "Data Source=(localdb)\\MSSQLLocalDB;Initial Catalog=EshopAppDataDb;Integrated Security=True;Connect Timeout=30;Encrypt=False;TrustServerCertificate=False;ApplicationIntent=ReadWrite;MultiSubnetFailover=False",
-            new string[] { "dbo.Attributes", "dbo.Categories", "dbo.Products", "dbo.Variants", "dbo.Discounts", "dbo.Images", "dbo.VariantImages" },
+            new string[] { "dbo.Attributes", "dbo.Categories", "dbo.Products", "dbo.Variants", "dbo.Discounts", "dbo.Images", "dbo.VariantImages", "dbo.Coupons", "dbo.UserCoupons" },
             "Data Database Successfully Cleared!"
         );
 
@@ -742,7 +742,7 @@ internal class VariantControllerTests
         httpClient.Dispose();
         TestUtilitiesLibrary.DatabaseUtilities.ResetSqlAuthDatabase(
             "Data Source=(localdb)\\MSSQLLocalDB;Initial Catalog=EshopAppDataDb;Integrated Security=True;Connect Timeout=30;Encrypt=False;TrustServerCertificate=False;ApplicationIntent=ReadWrite;MultiSubnetFailover=False",
-            new string[] { "dbo.Attributes", "dbo.Categories", "dbo.Products", "dbo.Variants", "dbo.Discounts", "dbo.Images", "dbo.VariantImages" },
+            new string[] { "dbo.Attributes", "dbo.Categories", "dbo.Products", "dbo.Variants", "dbo.Discounts", "dbo.Images", "dbo.VariantImages", "dbo.Coupons", "dbo.UserCoupons" },
             "Data Database Successfully Cleared!"
         );
     }

--- a/EshopApp.DataLibraryAPI.Tests/IntegrationTests/Models/CouponModels/TestAddCouponToUserRequestModel.cs
+++ b/EshopApp.DataLibraryAPI.Tests/IntegrationTests/Models/CouponModels/TestAddCouponToUserRequestModel.cs
@@ -1,0 +1,11 @@
+﻿namespace EshopApp.DataLibraryAPI.Tests.IntegrationTests.Models.CouponModels;
+internal class TestAddCouponToUserRequestModel
+{
+    public string? Code { get; set; }
+    public int? TimesUsed { get; set; }
+    public DateTime? StartDate { get; set; }
+    public DateTime? ExpirationDate { get; set; }
+    public string? UserId { get; set; }
+    public string? CouponId { get; set; }
+
+}

--- a/EshopApp.DataLibraryAPI.Tests/IntegrationTests/Models/CouponModels/TestCreateCouponRequestModel.cs
+++ b/EshopApp.DataLibraryAPI.Tests/IntegrationTests/Models/CouponModels/TestCreateCouponRequestModel.cs
@@ -1,0 +1,15 @@
+﻿namespace EshopApp.DataLibraryAPI.Tests.IntegrationTests.Models.CouponModels;
+internal class TestCreateCouponRequestModel
+{
+    public string? Code { get; set; }
+    public string? Description { get; set; }
+    public int? DiscountPercentage { get; set; }
+    public int? UsageLimit { get; set; }
+    public int? DefaultDateIntervalInDays { get; set; }
+    public bool? IsUserSpecific { get; set; }
+    public bool? IsDeactivated { get; set; }
+    public bool? ExistsInOrder { get; set; }
+    public string? TriggerEvent { get; set; } //OnSignUp - OnFirstOrder - OnEveryFiveOrders - OnEveryTenOrders - NoTrigger
+    public DateTime? StartDate { get; set; }
+    public DateTime? ExpirationDate { get; set; }
+}

--- a/EshopApp.DataLibraryAPI.Tests/IntegrationTests/Models/CouponModels/TestUpdateCouponRequestModel.cs
+++ b/EshopApp.DataLibraryAPI.Tests/IntegrationTests/Models/CouponModels/TestUpdateCouponRequestModel.cs
@@ -1,0 +1,17 @@
+﻿namespace EshopApp.DataLibraryAPI.Tests.IntegrationTests.Models.CouponModels;
+internal class TestUpdateCouponRequestModel
+{
+    public string? Id { get; set; }
+    public string? Code { get; set; }
+    public string? Description { get; set; }
+    public int? DiscountPercentage { get; set; }
+    public int? UsageLimit { get; set; }
+    public int? DefaultDateIntervalInDays { get; set; }
+    public bool? IsDeactivated { get; set; }
+    public bool? ExistsInOrder { get; set; }
+    public string? TriggerEvent { get; set; } //OnSignUp - OnFirstOrder - OnEveryFiveOrders - OnEveryTenOrders - NoTrigger
+    public DateTime? StartDate { get; set; }
+    public DateTime? ExpirationDate { get; set; }
+    public List<string>? UserCouponIds { get; set; }
+
+}

--- a/EshopApp.DataLibraryAPI.Tests/IntegrationTests/Models/CouponModels/TestUpdateUserCouponRequestModel.cs
+++ b/EshopApp.DataLibraryAPI.Tests/IntegrationTests/Models/CouponModels/TestUpdateUserCouponRequestModel.cs
@@ -1,0 +1,9 @@
+﻿namespace EshopApp.DataLibraryAPI.Tests.IntegrationTests.Models.CouponModels;
+internal class TestUpdateUserCouponRequestModel
+{
+    public string? Id { get; set; }
+    public string? Code { get; set; }
+    public int? TimesUsed { get; set; }
+    public DateTime? StartDate { get; set; }
+    public DateTime? ExpirationDate { get; set; }
+}

--- a/EshopApp.DataLibraryAPI.Tests/IntegrationTests/Models/TestCoupon.cs
+++ b/EshopApp.DataLibraryAPI.Tests/IntegrationTests/Models/TestCoupon.cs
@@ -1,0 +1,19 @@
+﻿namespace EshopApp.DataLibraryAPI.Tests.IntegrationTests.Models;
+internal class TestCoupon
+{
+    public string? Id { get; set; }
+    public string? Code { get; set; }
+    public string? Description { get; set; }
+    public int? DiscountPercentage { get; set; }
+    public int? UsageLimit { get; set; }
+    public int? DefaultDateIntervalInDays { get; set; }
+    public bool? IsUserSpecific { get; set; }
+    public bool? IsDeactivated { get; set; }
+    public bool? ExistsInOrder { get; set; }
+    public string? TriggerEvent { get; set; } //OnSignUp - OnFirstOrder - OnEveryFiveOrders - OnEveryTenOrders - NoTrigger
+    public DateTime? StartDate { get; set; }
+    public DateTime? ExpirationDate { get; set; }
+    public DateTime CreatedAt { get; set; }
+    public DateTime ModifiedAt { get; set; }
+    public List<TestUserCoupon> UserCoupons { get; set; } = new List<TestUserCoupon>();
+}

--- a/EshopApp.DataLibraryAPI.Tests/IntegrationTests/Models/TestUserCoupon.cs
+++ b/EshopApp.DataLibraryAPI.Tests/IntegrationTests/Models/TestUserCoupon.cs
@@ -1,0 +1,14 @@
+﻿namespace EshopApp.DataLibraryAPI.Tests.IntegrationTests.Models;
+internal class TestUserCoupon
+{
+    public string? Id { get; set; }
+    public string? Code { get; set; }
+    public int? TimesUsed { get; set; }
+    public DateTime? StartDate { get; set; } //nullable for implementation StartDate & ExpirationDate will always be filled
+    public DateTime? ExpirationDate { get; set; }
+    public DateTime CreatedAt { get; set; }
+    public DateTime ModifiedAt { get; set; }
+    public string? UserId { get; set; }
+    public string? CouponId { get; set; }
+    public TestCoupon? Coupon { get; set; }
+}

--- a/EshopApp.DataLibraryAPI/Controllers/CouponController.cs
+++ b/EshopApp.DataLibraryAPI/Controllers/CouponController.cs
@@ -1,0 +1,232 @@
+﻿using EshopApp.DataLibrary.DataAccess;
+using EshopApp.DataLibrary.Models;
+using EshopApp.DataLibrary.Models.ResponseModels;
+using EshopApp.DataLibrary.Models.ResponseModels.CouponModels;
+using EshopApp.DataLibraryAPI.Models.RequestModels.CouponModels;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.RateLimiting;
+
+namespace EshopApp.DataLibraryAPI.Controllers;
+
+[ApiController]
+[EnableRateLimiting("DefaultWindowLimiter")]
+[Route("api/[controller]")]
+public class CouponController : ControllerBase
+{
+    private readonly ICouponDataAccess _couponDataAccess;
+
+    public CouponController(ICouponDataAccess couponDataAccess)
+    {
+        _couponDataAccess = couponDataAccess;
+    }
+
+    [HttpGet("Amount/{amount}/includeDeactivated/{includeDeactivated}")]
+    public async Task<IActionResult> GetCoupons(int amount, bool includeDeactivated)
+    {
+        try
+        {
+            ReturnCouponsAndCodeResponseModel response = await _couponDataAccess.GetCouponsAsync(amount, includeDeactivated);
+            return Ok(response.Coupons);
+        }
+        catch (Exception)
+        {
+            return StatusCode(500);
+        }
+    }
+
+    [HttpGet("{id}/includeDeactivated/{includeDeactivated}")]
+    public async Task<IActionResult> GetCouponById(string id, bool includeDeactivated)
+    {
+        try
+        {
+            ReturnCouponAndCodeResponseModel response = await _couponDataAccess.GetCouponByIdAsync(id, includeDeactivated);
+            if (response.Coupon is null)
+                return NotFound();
+
+            return Ok(response.Coupon);
+        }
+        catch (Exception)
+        {
+            return StatusCode(500);
+        }
+    }
+
+    [HttpPost]
+    public async Task<IActionResult> CreateCoupon(CreateCouponRequestModel createCouponRequestModel)
+    {
+        try
+        {
+            Coupon coupon = new Coupon();
+            coupon.Code = createCouponRequestModel.Code;
+            coupon.Description = createCouponRequestModel.Description;
+            coupon.DiscountPercentage = createCouponRequestModel.DiscountPercentage;
+            coupon.UsageLimit = createCouponRequestModel.UsageLimit;
+            coupon.DefaultDateIntervalInDays = createCouponRequestModel.DefaultDateIntervalInDays;
+            coupon.IsUserSpecific = createCouponRequestModel.IsUserSpecific;
+            coupon.IsDeactivated = createCouponRequestModel.IsDeactivated;
+            coupon.ExistsInOrder = createCouponRequestModel.ExistsInOrder;
+            coupon.TriggerEvent = createCouponRequestModel.TriggerEvent;
+            coupon.StartDate = createCouponRequestModel.StartDate;
+            coupon.ExpirationDate = createCouponRequestModel.ExpirationDate;
+
+            ReturnCouponAndCodeResponseModel response = await _couponDataAccess.CreateCouponAsync(coupon);
+            if (response.ReturnedCode == DataLibraryReturnedCodes.StartAndExpirationDatesCanNotBeNullForUniversalCoupons)
+                return BadRequest(new { ErrorMessage = "StartAndExpirationDatesCanNotBeNullForUniversalCoupons" });
+            else if (response.ReturnedCode == DataLibraryReturnedCodes.DefaultDateIntervalInDaysCanNotBeNullForUserSpecificCoupons)
+                return BadRequest(new { ErrorMessage = "DefaultDateIntervalInDaysCanNotBeNullForUserSpecificCoupons" });
+
+            return CreatedAtAction(nameof(GetCouponById), new { id = response.Coupon!.Id, includeDeactivated = true }, response.Coupon);
+        }
+        catch (Exception)
+        {
+            return StatusCode(500);
+        }
+    }
+
+    [HttpPut]
+    public async Task<IActionResult> UpdateCoupon(UpdateCouponRequestModel updateCouponRequestModel)
+    {
+        try
+        {
+            Coupon updatedCoupon = new Coupon();
+            updatedCoupon.Id = updateCouponRequestModel.Id;
+            updatedCoupon.Code = updateCouponRequestModel.Code;
+            updatedCoupon.Description = updateCouponRequestModel.Description;
+            updatedCoupon.DiscountPercentage = updateCouponRequestModel.DiscountPercentage;
+            updatedCoupon.UsageLimit = updateCouponRequestModel.UsageLimit;
+            updatedCoupon.DefaultDateIntervalInDays = updateCouponRequestModel.DefaultDateIntervalInDays;
+            updatedCoupon.IsDeactivated = updateCouponRequestModel.IsDeactivated;
+            updatedCoupon.ExistsInOrder = updateCouponRequestModel.ExistsInOrder;
+            updatedCoupon.TriggerEvent = updateCouponRequestModel.TriggerEvent;
+            updatedCoupon.StartDate = updateCouponRequestModel.StartDate;
+            updatedCoupon.ExpirationDate = updateCouponRequestModel.ExpirationDate;
+            updatedCoupon.UserCoupons = updateCouponRequestModel.UserCouponIds?.Select(userCouponId => new UserCoupon { Id = userCouponId }).ToList()!;
+
+            DataLibraryReturnedCodes returnedCode = await _couponDataAccess.UpdateCouponAsync(updatedCoupon);
+            if (returnedCode == DataLibraryReturnedCodes.TheIdOfTheEntityCanNotBeNull)
+                return BadRequest(new { ErrorMessage = "TheIdOfTheEntityCanNotBeNull" });
+            else if (returnedCode == DataLibraryReturnedCodes.EntityNotFoundWithGivenId)
+                return NotFound(new { ErrorMessage = "EntityNotFoundWithGivenId" });
+            else if (returnedCode == DataLibraryReturnedCodes.DuplicateEntityCode)
+                return BadRequest(new { ErrorMessage = "DuplicateEntityCode" });
+
+            return NoContent();
+        }
+        catch (Exception)
+        {
+            return StatusCode(500);
+        }
+    }
+
+    [HttpDelete("{id}")]
+    public async Task<IActionResult> DeleteCoupon(string id)
+    {
+        try
+        {
+            DataLibraryReturnedCodes returnedCode = await _couponDataAccess.DeleteCouponAsync(id);
+            if (returnedCode == DataLibraryReturnedCodes.TheIdOfTheEntityCanNotBeNull)
+                return BadRequest(new { ErrorMessage = "TheIdOfTheEntityCanNotBeNull" });
+            else if (returnedCode == DataLibraryReturnedCodes.EntityNotFoundWithGivenId)
+                return NotFound();
+            else if (returnedCode == DataLibraryReturnedCodes.NoErrorButNotFullyDeleted)
+                return Ok(new { WarningMessage = "NoErrorButNotFullyDeleted" });
+
+            return NoContent();
+        }
+        catch (Exception)
+        {
+            return StatusCode(500);
+        }
+    }
+
+    [HttpGet("userId/{userId}/includeDeactivated/{includeDeactivated}")]
+    public async Task<IActionResult> GetCouponsOfUser(string userId, bool includeDeactivated)
+    {
+        try
+        {
+            ReturnUserCouponsAndCodeResponseModel response = await _couponDataAccess.GetCouponsOfUserAsync(userId, includeDeactivated);
+            return Ok(response.UserCoupons);
+        }
+        catch (Exception)
+        {
+            return StatusCode(500);
+        }
+    }
+
+    [HttpPost("AddCouponToUser")]
+    public async Task<IActionResult> AddCouponToUser(AddCouponToUserRequestModel addCouponToUserRequestModel)
+    {
+        try
+        {
+            UserCoupon userCoupon = new UserCoupon();
+            userCoupon.Code = addCouponToUserRequestModel.Code;
+            userCoupon.TimesUsed = addCouponToUserRequestModel.TimesUsed;
+            userCoupon.StartDate = addCouponToUserRequestModel.StartDate;
+            userCoupon.ExpirationDate = addCouponToUserRequestModel.ExpirationDate;
+            userCoupon.UserId = addCouponToUserRequestModel.UserId;
+            userCoupon.CouponId = addCouponToUserRequestModel.CouponId;
+
+            ReturnUserCouponAndCodeResponseModel response = await _couponDataAccess.AddCouponToUserAsync(userCoupon);
+            if (response.ReturnedCode == DataLibraryReturnedCodes.TheIdOfTheCouponCanNotBeNull)
+                return BadRequest(new { ErrorMessage = "TheIdOfTheCouponCanNotBeNull" });
+            else if (response.ReturnedCode == DataLibraryReturnedCodes.TheIdOfTheUserCanNotBeNull)
+                return BadRequest(new { ErrorMessage = "TheIdOfTheUserCanNotBeNull" });
+            else if (response.ReturnedCode == DataLibraryReturnedCodes.InvalidCouponIdWasGiven)
+                return NotFound(new { ErrorMessage = "InvalidCouponIdWasGiven" });
+
+            return Created("", response.UserCoupon);
+        }
+        catch (Exception)
+        {
+            return StatusCode(500);
+        }
+    }
+
+    [HttpPut("UpdateUserCoupon")]
+    public async Task<IActionResult> UpdateUserCoupon(UpdateUserCouponRequestModel updateUserCouponRequestModel)
+    {
+        try
+        {
+            UserCoupon updatedUserCoupon = new UserCoupon();
+            updatedUserCoupon.Id = updateUserCouponRequestModel.Id;
+            updatedUserCoupon.Code = updateUserCouponRequestModel.Code;
+            updatedUserCoupon.TimesUsed = updateUserCouponRequestModel.TimesUsed;
+            updatedUserCoupon.StartDate = updateUserCouponRequestModel.StartDate;
+            updatedUserCoupon.ExpirationDate = updateUserCouponRequestModel.ExpirationDate;
+
+            DataLibraryReturnedCodes returnedCode = await _couponDataAccess.UpdateUserCouponAsync(updatedUserCoupon);
+            if (returnedCode == DataLibraryReturnedCodes.TheIdOfTheEntityCanNotBeNull)
+                return BadRequest(new { ErrorMessage = "TheIdOfTheEntityCanNotBeNull" });
+            else if (returnedCode == DataLibraryReturnedCodes.EntityNotFoundWithGivenId)
+                return NotFound(new { ErrorMessage = "EntityNotFoundWithGivenId" });
+            else if (returnedCode == DataLibraryReturnedCodes.DuplicateEntityCode)
+                return BadRequest(new { ErrorMessage = "DuplicateEntityCode" });
+
+            return NoContent();
+        }
+        catch (Exception)
+        {
+            return StatusCode(500);
+        }
+    }
+
+    [HttpDelete("RemoveCouponFromUser/userCouponId/{userCouponId}")]
+    public async Task<IActionResult> RemoveCouponFromUser(string userCouponId)
+    {
+        try
+        {
+            DataLibraryReturnedCodes returnedCode = await _couponDataAccess.RemoveCouponFromUser(userCouponId);
+            if (returnedCode == DataLibraryReturnedCodes.TheIdOfTheEntityCanNotBeNull)
+                return BadRequest(new { ErrorMessage = "TheIdOfTheEntityCanNotBeNull" });
+            else if (returnedCode == DataLibraryReturnedCodes.EntityNotFoundWithGivenId)
+                return NotFound();
+
+            return NoContent();
+        }
+        catch (Exception)
+        {
+            return StatusCode(500);
+        }
+    }
+
+}

--- a/EshopApp.DataLibraryAPI/Controllers/ProductController.cs
+++ b/EshopApp.DataLibraryAPI/Controllers/ProductController.cs
@@ -99,7 +99,7 @@ public class ProductController : ControllerBase
             ReturnProductAndCodeResponseModel response = await _productDataAccess.CreateProductAsync(product);
             if (response.ReturnedCode == DataLibraryReturnedCodes.NoVariantWasProvidedForProductCreation)
                 return BadRequest(new { ErrorMessage = "NoVariantWasProvidedForProductCreation" });
-            else if (response.ReturnedCode == DataLibraryReturnedCodes.DuplicateProductCode)
+            else if (response.ReturnedCode == DataLibraryReturnedCodes.DuplicateEntityCode)
                 return BadRequest(new { ErrorMessage = "DuplicateProductCode" });
             else if (response.ReturnedCode == DataLibraryReturnedCodes.DuplicateEntityName)
                 return BadRequest(new { ErrorMessage = "DuplicateEntityName" });
@@ -133,7 +133,7 @@ public class ProductController : ControllerBase
             DataLibraryReturnedCodes returnedCode = await _productDataAccess.UpdateProductAsync(product);
             if (returnedCode == DataLibraryReturnedCodes.EntityNotFoundWithGivenId)
                 return NotFound(new { ErrorMessage = "EntityNotFoundWithGivenId" });
-            else if (returnedCode == DataLibraryReturnedCodes.DuplicateProductCode)
+            else if (returnedCode == DataLibraryReturnedCodes.DuplicateEntityCode)
                 return BadRequest(new { ErrorMessage = "DuplicateProductCode" });
             else if (returnedCode == DataLibraryReturnedCodes.DuplicateEntityName)
                 return BadRequest(new { ErrorMessage = "DuplicateEntityName" });

--- a/EshopApp.DataLibraryAPI/Models/RequestModels/CouponModels/AddCouponToUserRequestModel.cs
+++ b/EshopApp.DataLibraryAPI/Models/RequestModels/CouponModels/AddCouponToUserRequestModel.cs
@@ -1,0 +1,19 @@
+﻿using System.ComponentModel.DataAnnotations;
+
+namespace EshopApp.DataLibraryAPI.Models.RequestModels.CouponModels;
+
+public class AddCouponToUserRequestModel
+{
+    [MaxLength(50)]
+    public string? Code { get; set; }
+    [Range(0, int.MaxValue, ErrorMessage = "The times used property must be a non-negative integer.")]
+    public int? TimesUsed { get; set; }
+    public DateTime? StartDate { get; set; }
+    public DateTime? ExpirationDate { get; set; }
+    [Required]
+    [MaxLength(50)]
+    public string? UserId { get; set; }
+    [Required]
+    [MaxLength(50)]
+    public string? CouponId { get; set; }
+}

--- a/EshopApp.DataLibraryAPI/Models/RequestModels/CouponModels/CreateCouponRequestModel.cs
+++ b/EshopApp.DataLibraryAPI/Models/RequestModels/CouponModels/CreateCouponRequestModel.cs
@@ -1,0 +1,26 @@
+﻿using System.ComponentModel.DataAnnotations;
+
+namespace EshopApp.DataLibraryAPI.Models.RequestModels.CouponModels;
+
+public class CreateCouponRequestModel
+{
+    [MaxLength(50)]
+    public string? Code { get; set; }
+    public string? Description { get; set; }
+    [Required]
+    [Range(0, 99, ErrorMessage = "The discount percentage must be an integer value between 0 and 99.")]
+    public int? DiscountPercentage { get; set; }
+    [Required]
+    [Range(0, int.MaxValue, ErrorMessage = "The usage limit must be a non-negative integer.")]
+    public int? UsageLimit { get; set; }
+    [Range(0, int.MaxValue, ErrorMessage = "The default date interval in days must be a non-negative integer.")]
+    public int? DefaultDateIntervalInDays { get; set; }
+    public bool? IsUserSpecific { get; set; }
+    public bool? IsDeactivated { get; set; }
+    public bool? ExistsInOrder { get; set; }
+    [RegularExpression("OnSignUp|OnFirstOrder|OnEveryFiveOrders|OnEveryTenOrders|NoTrigger",
+    ErrorMessage = "The trigger event must have one of the following values: OnSignUp, OnFirstOrder, OnEveryFiveOrders, OnEveryTenOrders, NoTrigger.")]
+    public string? TriggerEvent { get; set; } //OnSignUp - OnFirstOrder - OnEveryFiveOrders - OnEveryTenOrders - NoTrigger
+    public DateTime? StartDate { get; set; }
+    public DateTime? ExpirationDate { get; set; }
+}

--- a/EshopApp.DataLibraryAPI/Models/RequestModels/CouponModels/UpdateCouponRequestModel.cs
+++ b/EshopApp.DataLibraryAPI/Models/RequestModels/CouponModels/UpdateCouponRequestModel.cs
@@ -1,0 +1,29 @@
+﻿using System.ComponentModel.DataAnnotations;
+
+namespace EshopApp.DataLibraryAPI.Models.RequestModels.CouponModels;
+
+public class UpdateCouponRequestModel
+{
+    [Required]
+    [MaxLength(50)]
+    public string? Id { get; set; }
+    [MaxLength(50)]
+    public string? Code { get; set; }
+    public string? Description { get; set; }
+    [Required]
+    [Range(0, 99, ErrorMessage = "The discount percentage must be an integer value between 0 and 99.")]
+    public int? DiscountPercentage { get; set; }
+    [Required]
+    [Range(0, int.MaxValue, ErrorMessage = "The usage limit must be a non-negative integer.")]
+    public int? UsageLimit { get; set; }
+    [Range(0, int.MaxValue, ErrorMessage = "The default date interval in days must be a non-negative integer.")]
+    public int? DefaultDateIntervalInDays { get; set; }
+    public bool? IsDeactivated { get; set; }
+    public bool? ExistsInOrder { get; set; }
+    [RegularExpression("OnSignUp|OnFirstOrder|OnEveryFiveOrders|OnEveryTenOrders|NoTrigger",
+    ErrorMessage = "The trigger event must have one of the following values: OnSignUp, OnFirstOrder, OnEveryFiveOrders, OnEveryTenOrders, NoTrigger.")]
+    public string? TriggerEvent { get; set; } //OnSignUp - OnFirstOrder - OnEveryFiveOrders - OnEveryTenOrders - NoTrigger
+    public DateTime? StartDate { get; set; }
+    public DateTime? ExpirationDate { get; set; }
+    public List<string>? UserCouponIds { get; set; }
+}

--- a/EshopApp.DataLibraryAPI/Models/RequestModels/CouponModels/UpdateUserCouponRequestModel.cs
+++ b/EshopApp.DataLibraryAPI/Models/RequestModels/CouponModels/UpdateUserCouponRequestModel.cs
@@ -1,0 +1,16 @@
+﻿using System.ComponentModel.DataAnnotations;
+
+namespace EshopApp.DataLibraryAPI.Models.RequestModels.CouponModels;
+
+public class UpdateUserCouponRequestModel
+{
+    [Required]
+    [MaxLength(50)]
+    public string? Id { get; set; }
+    [MaxLength(50)]
+    public string? Code { get; set; }
+    [Range(0, int.MaxValue, ErrorMessage = "The times used property must be a non-negative integer.")]
+    public int? TimesUsed { get; set; }
+    public DateTime? StartDate { get; set; }
+    public DateTime? ExpirationDate { get; set; }
+}

--- a/EshopApp.DataLibraryAPI/Models/RequestModels/DiscountModels/CreateDiscountRequestModel.cs
+++ b/EshopApp.DataLibraryAPI/Models/RequestModels/DiscountModels/CreateDiscountRequestModel.cs
@@ -10,4 +10,6 @@ public class CreateDiscountRequestModel
     [Required]
     [Range(1, 99, ErrorMessage = "Percentage must be between 1 and 99")]
     public int? Percentage { get; set; }
+    public bool? IsDeactivated { get; set; }
+    public bool? ExistsInOrder { get; set; }
 }

--- a/EshopApp.DataLibraryAPI/Models/RequestModels/DiscountModels/UpdateDiscountRequestModel.cs
+++ b/EshopApp.DataLibraryAPI/Models/RequestModels/DiscountModels/UpdateDiscountRequestModel.cs
@@ -11,5 +11,7 @@ public class UpdateDiscountRequestModel
     public string? Name { get; set; }
     [Range(1, 99, ErrorMessage = "Percentage must be between 1 and 99")]
     public int? Percentage { get; set; }
+    public bool? IsDeactivated { get; set; }
+    public bool? ExistsInOrder { get; set; }
     public List<string>? VariantIds { get; set; }
 }

--- a/EshopApp.DataLibraryAPI/Program.cs
+++ b/EshopApp.DataLibraryAPI/Program.cs
@@ -48,6 +48,7 @@ public class Program()
         builder.Services.AddScoped<IImageDataAccess, ImageDataAccess>();
         builder.Services.AddScoped<IDiscountDataAccess, DiscountDataAccess>();
         builder.Services.AddScoped<IAttributeDataAccess, AttributeDataAccess>();
+        builder.Services.AddScoped<ICouponDataAccess, CouponDataAccess>();
 
         var app = builder.Build();
 


### PR DESCRIPTION
… API For Them And Tests For The Endpoints

I had already added a first implemetnation of the discounts entity in the previous commit, so in this commit I made sure that it now works better with the future orders entity, which will be added in a future commit. That means that it now has soft deleted/deactivated functionality. Additionally I added the Coupons entity and its bridge entity UserCoupons. I mistakenly also added in this update the endpoints for the the CRUD operations and the tests to them. Theoretically I should had split them, but I misread the issue and thus after this commit is done I will close the other 2 issues manually. So after this update the Discount Entity and Coupon Entity should be fully supported and they have also been thoroughly tested.