### PR TITLE
Added API Endpoints For The CRUD Operations In Of The PaymentOption, …

### DIFF
--- a/EshopApp.DataLibrary/AppDataDbContext.cs
+++ b/EshopApp.DataLibrary/AppDataDbContext.cs
@@ -270,9 +270,6 @@ public class AppDataDbContext : DbContext
         modelBuilder.Entity<Order>()
             .Property(order => order.FinalPrice).IsRequired();
 
-        modelBuilder.Entity<Order>()
-            .Property(order => order.OrderDate).IsRequired();
-
         /******************* OrderItems *******************/
         //orderItem can have one image and a image can have many orders(one to many)
         modelBuilder.Entity<OrderItem>()
@@ -304,6 +301,9 @@ public class AppDataDbContext : DbContext
             .HasOne(paymentDetails => paymentDetails.PaymentOption)
             .WithMany(paymentOption => paymentOption.PaymentDetails)
             .HasForeignKey(paymentDetails => paymentDetails.PaymentOptionId);
+
+        modelBuilder.Entity<PaymentDetails>()
+            .Property(paymentDetails => paymentDetails.PaymentCurrency).HasMaxLength(5);
 
         modelBuilder.Entity<PaymentDetails>()
             .Property(paymentDetails => paymentDetails.PaymentProcessorSessionId).HasMaxLength(50).IsRequired();

--- a/EshopApp.DataLibrary/DataAccess/IOrderDataAccess.cs
+++ b/EshopApp.DataLibrary/DataAccess/IOrderDataAccess.cs
@@ -1,0 +1,15 @@
+﻿using EshopApp.DataLibrary.Models;
+using EshopApp.DataLibrary.Models.ResponseModels;
+using EshopApp.DataLibrary.Models.ResponseModels.OrderModels;
+
+namespace EshopApp.DataLibrary.DataAccess;
+public interface IOrderDataAccess
+{
+    Task<ReturnOrderAndCodeResponseModel> CreateOrderAsync(Order order);
+    Task<DataLibraryReturnedCodes> DeleteOrderAsync(string orderId);
+    Task<ReturnOrderAndCodeResponseModel> GetOrderByIdAsync(string id);
+    Task<ReturnOrdersAndCodeResponseModel> GetOrdersAsync(int amount);
+    Task<ReturnOrdersAndCodeResponseModel> GetUserOrdersAsync(int amount, string userId);
+    Task<DataLibraryReturnedCodes> UpdateOrderAsync(Order updatedOrder);
+    Task<DataLibraryReturnedCodes> UpdateOrderStatusAsync(string newOrderStatus, string orderId);
+}

--- a/EshopApp.DataLibrary/DataAccess/IPaymentOptionDataAccess.cs
+++ b/EshopApp.DataLibrary/DataAccess/IPaymentOptionDataAccess.cs
@@ -1,0 +1,13 @@
+﻿using EshopApp.DataLibrary.Models;
+using EshopApp.DataLibrary.Models.ResponseModels;
+using EshopApp.DataLibrary.Models.ResponseModels.PaymentOptionModels;
+
+namespace EshopApp.DataLibrary.DataAccess;
+public interface IPaymentOptionDataAccess
+{
+    Task<ReturnPaymentOptionAndCodeResponseModel> CreatePaymentOptionAsync(PaymentOption paymentOption);
+    Task<DataLibraryReturnedCodes> DeletePaymentOptionAsync(string paymentOptionId);
+    Task<ReturnPaymentOptionAndCodeResponseModel> GetPaymentOptionByIdAsync(string id, bool includeDeactivated);
+    Task<ReturnPaymentOptionsAndCodeResponseModel> GetPaymentOptionsAsync(int amount, bool includeDeactivated);
+    Task<DataLibraryReturnedCodes> UpdatePaymentOptionAsync(PaymentOption updatedPaymentOption);
+}

--- a/EshopApp.DataLibrary/DataAccess/IShippingOptionDataAccess.cs
+++ b/EshopApp.DataLibrary/DataAccess/IShippingOptionDataAccess.cs
@@ -1,0 +1,13 @@
+﻿using EshopApp.DataLibrary.Models;
+using EshopApp.DataLibrary.Models.ResponseModels;
+using EshopApp.DataLibrary.Models.ResponseModels.ShippingOptionModels;
+
+namespace EshopApp.DataLibrary.DataAccess;
+public interface IShippingOptionDataAccess
+{
+    Task<ReturnShippingOptionAndCodeResponseModel> CreateShippingOptionAsync(ShippingOption shippingOption);
+    Task<DataLibraryReturnedCodes> DeleteShippingOptionAsync(string shippingOptionId);
+    Task<ReturnShippingOptionAndCodeResponseModel> GetShippingOptionByIdAsync(string id, bool includeDeactivated);
+    Task<ReturnShippingOptionsAndCodeResponseModel> GetShippingOptionsAsync(int amount, bool includeDeactivated);
+    Task<DataLibraryReturnedCodes> UpdateShippingOptionAsync(ShippingOption updatedShippingOption);
+}

--- a/EshopApp.DataLibrary/DataAccess/PaymentOptionDataAccess.cs
+++ b/EshopApp.DataLibrary/DataAccess/PaymentOptionDataAccess.cs
@@ -6,7 +6,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 
 namespace EshopApp.DataLibrary.DataAccess;
-public class PaymentOptionDataAccess
+public class PaymentOptionDataAccess : IPaymentOptionDataAccess
 {
     private readonly AppDataDbContext _appDataDbContext;
     private readonly ILogger<PaymentOptionDataAccess> _logger;

--- a/EshopApp.DataLibrary/DataAccess/ShippingOptionDataAccess.cs
+++ b/EshopApp.DataLibrary/DataAccess/ShippingOptionDataAccess.cs
@@ -6,7 +6,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 
 namespace EshopApp.DataLibrary.DataAccess;
-public class ShippingOptionDataAccess
+public class ShippingOptionDataAccess : IShippingOptionDataAccess
 {
     private readonly AppDataDbContext _appDataDbContext;
     private readonly ILogger<ShippingOptionDataAccess> _logger;
@@ -17,7 +17,7 @@ public class ShippingOptionDataAccess
         _logger = logger ?? NullLogger<ShippingOptionDataAccess>.Instance;
     }
 
-    public async Task<ReturnShippingOptionsAndCodeResponseModel> GetShippingOptionsOptionsAsync(int amount, bool includeDeactivated)
+    public async Task<ReturnShippingOptionsAndCodeResponseModel> GetShippingOptionsAsync(int amount, bool includeDeactivated)
     {
         try
         {

--- a/EshopApp.DataLibrary/Migrations/20241129083037_RemovedModifiedAtAndCreatedAtColumnsFromOrderSupportingEntities.Designer.cs
+++ b/EshopApp.DataLibrary/Migrations/20241129083037_RemovedModifiedAtAndCreatedAtColumnsFromOrderSupportingEntities.Designer.cs
@@ -4,6 +4,7 @@ using EshopApp.DataLibrary;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace EshopApp.DataLibrary.Migrations
 {
     [DbContext(typeof(AppDataDbContext))]
-    partial class AppDataDbContextModelSnapshot : ModelSnapshot
+    [Migration("20241129083037_RemovedModifiedAtAndCreatedAtColumnsFromOrderSupportingEntities")]
+    partial class RemovedModifiedAtAndCreatedAtColumnsFromOrderSupportingEntities
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -251,6 +254,10 @@ namespace EshopApp.DataLibrary.Migrations
                     b.Property<DateTime>("ModifiedAt")
                         .HasColumnType("datetime2");
 
+                    b.Property<DateTime?>("OrderDate")
+                        .IsRequired()
+                        .HasColumnType("datetime2");
+
                     b.Property<string>("OrderStatus")
                         .IsRequired()
                         .HasMaxLength(50)
@@ -427,8 +434,7 @@ namespace EshopApp.DataLibrary.Migrations
                         .HasColumnType("nvarchar(450)");
 
                     b.Property<string>("PaymentCurrency")
-                        .HasMaxLength(5)
-                        .HasColumnType("nvarchar(5)");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<decimal?>("PaymentOptionExtraCostAtOrder")
                         .IsRequired()

--- a/EshopApp.DataLibrary/Migrations/20241129083037_RemovedModifiedAtAndCreatedAtColumnsFromOrderSupportingEntities.cs
+++ b/EshopApp.DataLibrary/Migrations/20241129083037_RemovedModifiedAtAndCreatedAtColumnsFromOrderSupportingEntities.cs
@@ -1,0 +1,63 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace EshopApp.DataLibrary.Migrations
+{
+    /// <inheritdoc />
+    public partial class RemovedModifiedAtAndCreatedAtColumnsFromOrderSupportingEntities : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "CreatedAt",
+                table: "PaymentDetails");
+
+            migrationBuilder.DropColumn(
+                name: "ModifiedAt",
+                table: "PaymentDetails");
+
+            migrationBuilder.DropColumn(
+                name: "CreatedAt",
+                table: "OrderAddresses");
+
+            migrationBuilder.DropColumn(
+                name: "ModifiedAt",
+                table: "OrderAddresses");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<DateTime>(
+                name: "CreatedAt",
+                table: "PaymentDetails",
+                type: "datetime2",
+                nullable: false,
+                defaultValue: new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified));
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "ModifiedAt",
+                table: "PaymentDetails",
+                type: "datetime2",
+                nullable: false,
+                defaultValue: new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified));
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "CreatedAt",
+                table: "OrderAddresses",
+                type: "datetime2",
+                nullable: false,
+                defaultValue: new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified));
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "ModifiedAt",
+                table: "OrderAddresses",
+                type: "datetime2",
+                nullable: false,
+                defaultValue: new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified));
+        }
+    }
+}

--- a/EshopApp.DataLibrary/Migrations/20241129102242_JustRemovedSomeNotNeededColumns.Designer.cs
+++ b/EshopApp.DataLibrary/Migrations/20241129102242_JustRemovedSomeNotNeededColumns.Designer.cs
@@ -4,6 +4,7 @@ using EshopApp.DataLibrary;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace EshopApp.DataLibrary.Migrations
 {
     [DbContext(typeof(AppDataDbContext))]
-    partial class AppDataDbContextModelSnapshot : ModelSnapshot
+    [Migration("20241129102242_JustRemovedSomeNotNeededColumns")]
+    partial class JustRemovedSomeNotNeededColumns
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/EshopApp.DataLibrary/Migrations/20241129102242_JustRemovedSomeNotNeededColumns.cs
+++ b/EshopApp.DataLibrary/Migrations/20241129102242_JustRemovedSomeNotNeededColumns.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace EshopApp.DataLibrary.Migrations
+{
+    /// <inheritdoc />
+    public partial class JustRemovedSomeNotNeededColumns : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "OrderDate",
+                table: "Orders");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "PaymentCurrency",
+                table: "PaymentDetails",
+                type: "nvarchar(5)",
+                maxLength: 5,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(max)",
+                oldNullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "PaymentCurrency",
+                table: "PaymentDetails",
+                type: "nvarchar(max)",
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(5)",
+                oldMaxLength: 5,
+                oldNullable: true);
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "OrderDate",
+                table: "Orders",
+                type: "datetime2",
+                nullable: false,
+                defaultValue: new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified));
+        }
+    }
+}

--- a/EshopApp.DataLibrary/Models/Order.cs
+++ b/EshopApp.DataLibrary/Models/Order.cs
@@ -7,7 +7,6 @@ public class Order
     public decimal? FinalPrice { get; set; }
     public decimal? ShippingCostAtOrder { get; set; }
     public int? CouponDiscountPercentageAtOrder { get; set; }
-    public DateTime? OrderDate { get; set; }
     public DateTime CreatedAt { get; set; }
     public DateTime ModifiedAt { get; set; }
     public string? UserId { get; set; }
@@ -16,7 +15,7 @@ public class Order
     public PaymentDetails? PaymentDetails { get; set; }
     public string? ShippingOptionId { get; set; }
     public ShippingOption? ShippingOption { get; set; }
-    public string? UserCouponId { get; set; } //TODO change this to usercoupon
+    public string? UserCouponId { get; set; }
     public UserCoupon? UserCoupon { get; set; }
 }
 

--- a/EshopApp.DataLibrary/Models/OrderAddress.cs
+++ b/EshopApp.DataLibrary/Models/OrderAddress.cs
@@ -20,7 +20,5 @@ public class OrderAddress
     public string? AltPhoneNumber { get; set; }
     public string? OrderId { get; set; }
     public Order? Order { get; set; }
-    public DateTime CreatedAt { get; set; }
-    public DateTime ModifiedAt { get; set; }
 }
 

--- a/EshopApp.DataLibrary/Models/PaymentDetails.cs
+++ b/EshopApp.DataLibrary/Models/PaymentDetails.cs
@@ -3,13 +3,11 @@ public class PaymentDetails
 {
     public string? Id { get; set; }
     public string? PaymentStatus { get; set; } //paid, unpaid, pending
-    public string? PaymentCurrency { get; set; }
+    public string? PaymentCurrency { get; set; } //usd, eur, gbp, aud, cad
     public decimal? AmountPaidInCustomerCurrency { get; set; }
     public decimal? AmountPaidInEuro { get; set; }
     public decimal? NetAmountPaidInEuro { get; set; } //this is amount paid in euro - stripe fees
     public decimal? PaymentOptionExtraCostAtOrder { get; set; }
-    public DateTime CreatedAt { get; set; }
-    public DateTime ModifiedAt { get; set; }
     public string? PaymentProcessorSessionId { get; set; }
     public string? PaymentOptionId { get; set; }
     public PaymentOption? PaymentOption { get; set; }

--- a/EshopApp.DataLibrary/Models/ResponseModels/DataLibraryReturnedCodes.cs
+++ b/EshopApp.DataLibrary/Models/ResponseModels/DataLibraryReturnedCodes.cs
@@ -33,5 +33,6 @@ public enum DataLibraryReturnedCodes
     InvalidOrderStatus,
     OrderStatusHasBeenFinalizedAndThusOrderStatusCanNotBeAltered,
     ThisOrderDoesNotContainShippingAndThusTheShippedStatusIsInvalid,
-    InvalidNewOrderState
+    InvalidNewOrderState,
+    TheOrderIdAndThePaymentProcessorSessionIdCanNotBeBothNull
 }

--- a/EshopApp.DataLibraryAPI/Controllers/OrderController.cs
+++ b/EshopApp.DataLibraryAPI/Controllers/OrderController.cs
@@ -1,0 +1,233 @@
+﻿using EshopApp.DataLibrary.DataAccess;
+using EshopApp.DataLibrary.Models;
+using EshopApp.DataLibrary.Models.ResponseModels;
+using EshopApp.DataLibrary.Models.ResponseModels.OrderModels;
+using EshopApp.DataLibraryAPI.Models.RequestModels.OrderModels;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.RateLimiting;
+
+namespace EshopApp.DataLibraryAPI.Controllers;
+
+[ApiController]
+[EnableRateLimiting("DefaultWindowLimiter")]
+[Route("api/[controller]")]
+public class OrderController : ControllerBase
+{
+    private readonly IOrderDataAccess _orderDataAccess;
+
+    public OrderController(IOrderDataAccess orderDataAccess)
+    {
+        _orderDataAccess = orderDataAccess;
+    }
+
+    [HttpGet("Amount/{amount}")]
+    public async Task<IActionResult> GetOrders(int amount)
+    {
+        try
+        {
+            ReturnOrdersAndCodeResponseModel response = await _orderDataAccess.GetOrdersAsync(amount);
+            return Ok(response.Orders);
+        }
+        catch (Exception)
+        {
+            return StatusCode(500);
+        }
+    }
+
+    [HttpGet("{id}")]
+    public async Task<IActionResult> GetOrderById(string id)
+    {
+        try
+        {
+            ReturnOrderAndCodeResponseModel response = await _orderDataAccess.GetOrderByIdAsync(id);
+            if (response.Order is null)
+                return NotFound();
+
+            return Ok(response.Order);
+        }
+        catch (Exception)
+        {
+            return StatusCode(500);
+        }
+    }
+
+    [HttpPost]
+    public async Task<IActionResult> CreateOrder(CreateOrderRequestModel createOrderRequestModel)
+    {
+        try
+        {
+            Order order = new Order();
+            order.Comment = createOrderRequestModel.Comment;
+            order.UserId = createOrderRequestModel.UserId;
+            order.ShippingOptionId = createOrderRequestModel.ShippingOptionId;
+            order.UserCouponId = createOrderRequestModel.UserCouponId;
+
+            OrderAddress orderAddress = new OrderAddress();
+            orderAddress.Email = createOrderRequestModel.Email;
+            orderAddress.FirstName = createOrderRequestModel.FirstName;
+            orderAddress.LastName = createOrderRequestModel.LastName;
+            orderAddress.Country = createOrderRequestModel.Country;
+            orderAddress.City = createOrderRequestModel.City;
+            orderAddress.PostalCode = createOrderRequestModel.PostalCode;
+            orderAddress.Address = createOrderRequestModel.Address;
+            orderAddress.PhoneNumber = createOrderRequestModel.PhoneNumber;
+            orderAddress.IsShippingAddressDifferent = createOrderRequestModel.IsShippingAddressDifferent;
+            orderAddress.AltFirstName = createOrderRequestModel.AltFirstName;
+            orderAddress.AltLastName = createOrderRequestModel.AltLastName;
+            orderAddress.AltCountry = createOrderRequestModel.AltCountry;
+            orderAddress.AltCity = createOrderRequestModel.AltCity;
+            orderAddress.AltPostalCode = createOrderRequestModel.AltPostalCode;
+            orderAddress.AltAddress = createOrderRequestModel.AltAddress;
+            orderAddress.AltPhoneNumber = createOrderRequestModel.AltPhoneNumber;
+
+            PaymentDetails paymentDetails = new PaymentDetails()
+            {
+                PaymentProcessorSessionId = createOrderRequestModel.PaymentProcessorSessionId,
+                PaymentOptionId = createOrderRequestModel.PaymentOptionId
+            };
+
+            foreach (OrderItemRequestModel createOrderItemRequestModel in createOrderRequestModel.CreateOrderItemRequestModels)
+            {
+                OrderItem orderItem = new OrderItem();
+                orderItem.Quantity = createOrderItemRequestModel.Quantity;
+                orderItem.VariantId = createOrderItemRequestModel.VariantId;
+                order.OrderItems.Add(orderItem);
+            }
+
+            order.OrderAddress = orderAddress;
+            order.PaymentDetails = paymentDetails;
+
+            ReturnOrderAndCodeResponseModel response = await _orderDataAccess.CreateOrderAsync(order);
+            if (response.ReturnedCode == DataLibraryReturnedCodes.TheOrderMustHaveAtLeastOneOrderItem)
+                return BadRequest(new { ErrorMessage = "TheOrderMustHaveAtLeastOneOrderItem" });
+            else if (response.ReturnedCode == DataLibraryReturnedCodes.AllTheAltFieldsNeedToBeFilledIfDifferentShippingAddress)
+                return BadRequest(new { ErrorMessage = "AllTheAltFieldsNeedToBeFilledIfDifferentShippingAddress" });
+            else if (response.ReturnedCode == DataLibraryReturnedCodes.InvalidPaymentOption)
+                return NotFound(new { ErrorMessage = "InvalidPaymentOption" });
+            else if (response.ReturnedCode == DataLibraryReturnedCodes.InvalidShippingOption)
+                return NotFound(new { ErrorMessage = "InvalidShippingOption" });
+            else if (response.ReturnedCode == DataLibraryReturnedCodes.InvalidCouponIdWasGiven)
+                return NotFound(new { ErrorMessage = "InvalidCouponIdWasGiven" });
+            else if (response.ReturnedCode == DataLibraryReturnedCodes.CouponCodeCurrentlyDeactivated)
+                return BadRequest(new { ErrorMessage = "CouponCodeCurrentlyDeactivated" });
+            else if (response.ReturnedCode == DataLibraryReturnedCodes.TheOrderItemsOfTheOrderWereAllInvalid)
+                return BadRequest(new { ErrorMessage = "TheOrderItemsOfTheOrderWereAllInvalid" });
+
+            return CreatedAtAction(nameof(GetOrderById), new { id = response.Order!.Id }, response.Order);
+        }
+        catch (Exception)
+        {
+            return StatusCode(500);
+        }
+    }
+
+    [HttpPut]
+    public async Task<IActionResult> UpdateOrder(UpdateOrderRequestModel updateOrderRequestModel)
+    {
+        try
+        {
+            Order order = new Order();
+            order.Id = updateOrderRequestModel.Id;
+            order.UserCouponId = updateOrderRequestModel.UserCouponId;
+
+            OrderAddress orderAddress = new OrderAddress();
+            orderAddress.Email = updateOrderRequestModel.Email;
+            orderAddress.FirstName = updateOrderRequestModel.FirstName;
+            orderAddress.LastName = updateOrderRequestModel.LastName;
+            orderAddress.Country = updateOrderRequestModel.Country;
+            orderAddress.City = updateOrderRequestModel.City;
+            orderAddress.PostalCode = updateOrderRequestModel.PostalCode;
+            orderAddress.Address = updateOrderRequestModel.Address;
+            orderAddress.PhoneNumber = updateOrderRequestModel.PhoneNumber;
+            orderAddress.IsShippingAddressDifferent = updateOrderRequestModel.IsShippingAddressDifferent;
+            orderAddress.AltFirstName = updateOrderRequestModel.AltFirstName;
+            orderAddress.AltLastName = updateOrderRequestModel.AltLastName;
+            orderAddress.AltCountry = updateOrderRequestModel.AltCountry;
+            orderAddress.AltCity = updateOrderRequestModel.AltCity;
+            orderAddress.AltPostalCode = updateOrderRequestModel.AltPostalCode;
+            orderAddress.AltAddress = updateOrderRequestModel.AltAddress;
+            orderAddress.AltPhoneNumber = updateOrderRequestModel.AltPhoneNumber;
+
+            PaymentDetails paymentDetails = new PaymentDetails()
+            {
+                PaymentProcessorSessionId = updateOrderRequestModel.PaymentProcessorSessionId,
+                PaymentStatus = updateOrderRequestModel.PaymentStatus,
+                PaymentCurrency = updateOrderRequestModel.PaymentCurrency,
+                AmountPaidInCustomerCurrency = updateOrderRequestModel.AmountPaidInCustomerCurrency,
+                AmountPaidInEuro = updateOrderRequestModel.AmountPaidInEuro,
+                NetAmountPaidInEuro = updateOrderRequestModel.NetAmountPaidInEuro
+            };
+
+            foreach (OrderItemRequestModel createOrderItemRequestModel in updateOrderRequestModel.CreateOrderItemRequestModels ?? Enumerable.Empty<OrderItemRequestModel>())
+            {
+                OrderItem orderItem = new OrderItem();
+                orderItem.Quantity = createOrderItemRequestModel.Quantity;
+                orderItem.VariantId = createOrderItemRequestModel.VariantId;
+                order.OrderItems.Add(orderItem);
+            }
+
+            order.OrderAddress = orderAddress;
+            order.PaymentDetails = paymentDetails;
+
+            DataLibraryReturnedCodes returnedCode = await _orderDataAccess.UpdateOrderAsync(order);
+            if (returnedCode == DataLibraryReturnedCodes.EntityNotFoundWithGivenId)
+                return NotFound(new { ErrorMessage = "EntityNotFoundWithGivenId" });
+            else if (returnedCode == DataLibraryReturnedCodes.OrderNotFoundWithGivenPaymentProcessorSessionId)
+                return NotFound(new { ErrorMessage = "OrderNotFoundWithGivenPaymentProcessorSessionId" });
+            else if (returnedCode == DataLibraryReturnedCodes.TheOrderIdAndThePaymentProcessorSessionIdCanNotBeBothNull)
+                return BadRequest(new { ErrorMessage = "TheOrderIdAndThePaymentProcessorSessionIdCanNotBeBothNull" });
+            else if (returnedCode == DataLibraryReturnedCodes.OrderStatusHasBeenFinalizedAndThusTheOrderCanNotBeAltered)
+                return BadRequest(new { ErrorMessage = "OrderStatusHasBeenFinalizedAndThusTheOrderCanNotBeAltered" });
+            else if (returnedCode == DataLibraryReturnedCodes.TheOrderItemsOfTheOrderWereAllInvalid)
+                return BadRequest(new { ErrorMessage = "TheOrderItemsOfTheOrderWereAllInvalid" });
+
+            return NoContent();
+        }
+        catch (Exception)
+        {
+            return StatusCode(500);
+        }
+    }
+
+    [HttpPut]
+    public async Task<IActionResult> UpdateOrderStatus(UpdateOrderStatusRequestModels updateOrderStatusRequestModels)
+    {
+        try
+        {
+            DataLibraryReturnedCodes returnedCode = await _orderDataAccess.UpdateOrderStatusAsync(updateOrderStatusRequestModels.NewOrderStatus!, updateOrderStatusRequestModels.OrderId!);
+            if (returnedCode == DataLibraryReturnedCodes.EntityNotFoundWithGivenId)
+                return NotFound(new { ErrorMessage = "EntityNotFoundWithGivenId" });
+            else if (returnedCode == DataLibraryReturnedCodes.OrderStatusHasBeenFinalizedAndThusOrderStatusCanNotBeAltered)
+                return BadRequest(new { ErrorMessage = "OrderStatusHasBeenFinalizedAndThusOrderStatusCanNotBeAltered" });
+            else if (returnedCode == DataLibraryReturnedCodes.InvalidOrderStatus)
+                return BadRequest(new { ErrorMessage = "InvalidOrderState" });
+            else if (returnedCode == DataLibraryReturnedCodes.ThisOrderDoesNotContainShippingAndThusTheShippedStatusIsInvalid)
+                return BadRequest(new { ErrorMessage = "ThisOrderDoesNotContainShippingAndThusTheShippedStatusIsInvalid" });
+
+            return NoContent();
+        }
+        catch (Exception)
+        {
+            return StatusCode(500);
+        }
+    }
+
+    [HttpDelete("{id}")]
+    public async Task<IActionResult> DeleteOrder(string id)
+    {
+        try
+        {
+            DataLibraryReturnedCodes returnedCode = await _orderDataAccess.DeleteOrderAsync(id);
+            if (returnedCode == DataLibraryReturnedCodes.TheIdOfTheEntityCanNotBeNull)
+                return BadRequest(new { ErrorMessage = "TheIdOfTheEntityCanNotBeNull" });
+            else if (returnedCode == DataLibraryReturnedCodes.EntityNotFoundWithGivenId)
+                return NotFound();
+
+            return NoContent();
+        }
+        catch (Exception)
+        {
+            return StatusCode(500);
+        }
+    }
+}

--- a/EshopApp.DataLibraryAPI/Controllers/PaymentOptionController.cs
+++ b/EshopApp.DataLibraryAPI/Controllers/PaymentOptionController.cs
@@ -1,0 +1,135 @@
+﻿using EshopApp.DataLibrary.DataAccess;
+using EshopApp.DataLibrary.Models;
+using EshopApp.DataLibrary.Models.ResponseModels;
+using EshopApp.DataLibrary.Models.ResponseModels.PaymentOptionModels;
+using EshopApp.DataLibraryAPI.Models.RequestModels.PaymentOptionModels;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.RateLimiting;
+
+namespace EshopApp.DataLibraryAPI.Controllers;
+
+[ApiController]
+[EnableRateLimiting("DefaultWindowLimiter")]
+[Route("api/[controller]")]
+
+public class PaymentOptionController : ControllerBase
+{
+    private readonly IPaymentOptionDataAccess _paymentOptionDataAccess;
+
+    public PaymentOptionController(IPaymentOptionDataAccess paymentOptionDataAccess)
+    {
+        _paymentOptionDataAccess = paymentOptionDataAccess;
+    }
+
+    [HttpGet("Amount/{amount}/includeDeactivated/{includeDeactivated}")]
+    public async Task<IActionResult> GetPaymentOptions(int amount, bool includeDeactivated)
+    {
+        try
+        {
+            ReturnPaymentOptionsAndCodeResponseModel response = await _paymentOptionDataAccess.GetPaymentOptionsAsync(amount, includeDeactivated);
+            return Ok(response.PaymentOptions);
+        }
+        catch (Exception)
+        {
+            return StatusCode(500);
+        }
+    }
+
+    [HttpGet("{id}/includeDeactivated/{includeDeactivated}")]
+    public async Task<IActionResult> GetPaymentOptionById(string id, bool includeDeactivated)
+    {
+        try
+        {
+            ReturnPaymentOptionAndCodeResponseModel response = await _paymentOptionDataAccess.GetPaymentOptionByIdAsync(id, includeDeactivated);
+            if (response.PaymentOption is null)
+                return NotFound();
+
+            return Ok(response.PaymentOption);
+        }
+        catch (Exception)
+        {
+            return StatusCode(500);
+        }
+    }
+
+    [HttpPost]
+    public async Task<IActionResult> CreatePaymentOption(CreatePaymentOptionRequestModel createPaymentOptionRequestModel)
+    {
+        try
+        {
+            PaymentOption paymentOption = new PaymentOption();
+            paymentOption.Name = createPaymentOptionRequestModel.Name;
+            paymentOption.NameAlias = createPaymentOptionRequestModel.NameAlias;
+            paymentOption.Description = createPaymentOptionRequestModel.Description;
+            paymentOption.ExtraCost = createPaymentOptionRequestModel.ExtraCost;
+            paymentOption.IsDeactivated = createPaymentOptionRequestModel.IsDeactivated;
+            paymentOption.ExistsInOrder = createPaymentOptionRequestModel.ExistsInOrder;
+
+            ReturnPaymentOptionAndCodeResponseModel response = await _paymentOptionDataAccess.CreatePaymentOptionAsync(paymentOption);
+            if (response.ReturnedCode == DataLibraryReturnedCodes.DuplicateEntityName)
+                return BadRequest(new { ErrorMessage = "DuplicateEntityName" });
+            else if (response.ReturnedCode == DataLibraryReturnedCodes.DuplicateEntityNameAlias)
+                return BadRequest(new { ErrorMessage = "DuplicateEntityNameAlias" });
+
+            return CreatedAtAction(nameof(GetPaymentOptionById), new { id = response.PaymentOption!.Id, includeDeactivated = true }, response.PaymentOption);
+        }
+        catch (Exception)
+        {
+            return StatusCode(500);
+        }
+    }
+
+    [HttpPut]
+    public async Task<IActionResult> UpdatePaymentOption(UpdatePaymentOptionRequestModel updatePaymentOptionRequestModel)
+    {
+        try
+        {
+            PaymentOption paymentOption = new PaymentOption();
+            paymentOption.Id = updatePaymentOptionRequestModel.Id;
+            paymentOption.Name = updatePaymentOptionRequestModel.Name;
+            paymentOption.NameAlias = updatePaymentOptionRequestModel.NameAlias;
+            paymentOption.Description = updatePaymentOptionRequestModel.Description;
+            paymentOption.ExtraCost = updatePaymentOptionRequestModel.ExtraCost;
+            paymentOption.IsDeactivated = updatePaymentOptionRequestModel.IsDeactivated;
+            paymentOption.ExistsInOrder = updatePaymentOptionRequestModel.ExistsInOrder;
+            paymentOption.PaymentDetails = updatePaymentOptionRequestModel.PaymentDetailsIds?.Select(paymentDetailId => new PaymentDetails { Id = paymentDetailId }).ToList()!;
+
+            DataLibraryReturnedCodes returnedCode = await _paymentOptionDataAccess.UpdatePaymentOptionAsync(paymentOption);
+            if (returnedCode == DataLibraryReturnedCodes.TheIdOfTheEntityCanNotBeNull)
+                return BadRequest(new { ErrorMessage = "TheIdOfTheEntityCanNotBeNull" });
+            else if (returnedCode == DataLibraryReturnedCodes.EntityNotFoundWithGivenId)
+                return NotFound(new { ErrorMessage = "EntityNotFoundWithGivenId" });
+            else if (returnedCode == DataLibraryReturnedCodes.DuplicateEntityName)
+                return BadRequest(new { ErrorMessage = "DuplicateEntityName" });
+            else if (returnedCode == DataLibraryReturnedCodes.DuplicateEntityNameAlias)
+                return BadRequest(new { ErrorMessage = "DuplicateEntityNameAlias" });
+
+            return NoContent();
+        }
+        catch (Exception)
+        {
+            return StatusCode(500);
+        }
+    }
+
+    [HttpDelete("{id}")]
+    public async Task<IActionResult> DeletePaymentOption(string id)
+    {
+        try
+        {
+            DataLibraryReturnedCodes returnedCode = await _paymentOptionDataAccess.DeletePaymentOptionAsync(id);
+            if (returnedCode == DataLibraryReturnedCodes.TheIdOfTheEntityCanNotBeNull)
+                return BadRequest(new { ErrorMessage = "TheIdOfTheEntityCanNotBeNull" });
+            else if (returnedCode == DataLibraryReturnedCodes.EntityNotFoundWithGivenId)
+                return NotFound();
+            else if (returnedCode == DataLibraryReturnedCodes.NoErrorButNotFullyDeleted)
+                return Ok(new { WarningMessage = "NoErrorButNotFullyDeleted" });
+
+            return NoContent();
+        }
+        catch (Exception)
+        {
+            return StatusCode(500);
+        }
+    }
+}

--- a/EshopApp.DataLibraryAPI/Controllers/ShippingOptionController.cs
+++ b/EshopApp.DataLibraryAPI/Controllers/ShippingOptionController.cs
@@ -1,0 +1,131 @@
+﻿using EshopApp.DataLibrary.DataAccess;
+using EshopApp.DataLibrary.Models;
+using EshopApp.DataLibrary.Models.ResponseModels;
+using EshopApp.DataLibrary.Models.ResponseModels.ShippingOptionModels;
+using EshopApp.DataLibraryAPI.Models.RequestModels.ShippingOptionModels;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.RateLimiting;
+
+namespace EshopApp.DataLibraryAPI.Controllers;
+
+[ApiController]
+[EnableRateLimiting("DefaultWindowLimiter")]
+[Route("api/[controller]")]
+
+public class ShippingOptionController : ControllerBase
+{
+    private readonly IShippingOptionDataAccess _shippingOptionDataAccess;
+
+    public ShippingOptionController(IShippingOptionDataAccess shippingOptionDataAccess)
+    {
+        _shippingOptionDataAccess = shippingOptionDataAccess;
+    }
+
+    [HttpGet("Amount/{amount}/includeDeactivated/{includeDeactivated}")]
+    public async Task<IActionResult> GetShippingOptions(int amount, bool includeDeactivated)
+    {
+        try
+        {
+            ReturnShippingOptionsAndCodeResponseModel response = await _shippingOptionDataAccess.GetShippingOptionsAsync(amount, includeDeactivated);
+            return Ok(response.ShippingOptions);
+        }
+        catch (Exception)
+        {
+            return StatusCode(500);
+        }
+    }
+
+    [HttpGet("{id}/includeDeactivated/{includeDeactivated}")]
+    public async Task<IActionResult> GetShippingOptionById(string id, bool includeDeactivated)
+    {
+        try
+        {
+            ReturnShippingOptionAndCodeResponseModel response = await _shippingOptionDataAccess.GetShippingOptionByIdAsync(id, includeDeactivated);
+            if (response.ShippingOption is null)
+                return NotFound();
+
+            return Ok(response.ShippingOption);
+        }
+        catch (Exception)
+        {
+            return StatusCode(500);
+        }
+    }
+
+    [HttpPost]
+    public async Task<IActionResult> CreateShippingOption(CreateShippingOptionRequestModel createShippingOptionRequestModel)
+    {
+        try
+        {
+            ShippingOption shippingOption = new ShippingOption();
+            shippingOption.Name = createShippingOptionRequestModel.Name;
+            shippingOption.Description = createShippingOptionRequestModel.Description;
+            shippingOption.ExtraCost = createShippingOptionRequestModel.ExtraCost;
+            shippingOption.ContainsDelivery = createShippingOptionRequestModel.ContainsDelivery;
+            shippingOption.IsDeactivated = createShippingOptionRequestModel.IsDeactivated;
+            shippingOption.ExistsInOrder = createShippingOptionRequestModel.ExistsInOrder;
+
+            ReturnShippingOptionAndCodeResponseModel response = await _shippingOptionDataAccess.CreateShippingOptionAsync(shippingOption);
+            if (response.ReturnedCode == DataLibraryReturnedCodes.DuplicateEntityName)
+                return BadRequest(new { ErrorMessage = "DuplicateEntityName" });
+
+            return CreatedAtAction(nameof(GetShippingOptionById), new { id = response.ShippingOption!.Id, includeDeactivated = true }, response.ShippingOption);
+        }
+        catch (Exception)
+        {
+            return StatusCode(500);
+        }
+    }
+
+    [HttpPut]
+    public async Task<IActionResult> UpdateShippingOption(UpdateShippingOptionRequestModel updateShippingOptionRequestModel)
+    {
+        try
+        {
+            ShippingOption shippingOption = new ShippingOption();
+            shippingOption.Id = updateShippingOptionRequestModel.Id;
+            shippingOption.Name = updateShippingOptionRequestModel.Name;
+            shippingOption.Description = updateShippingOptionRequestModel.Description;
+            shippingOption.ExtraCost = updateShippingOptionRequestModel.ExtraCost;
+            shippingOption.ContainsDelivery = updateShippingOptionRequestModel.ContainsDelivery;
+            shippingOption.IsDeactivated = updateShippingOptionRequestModel.IsDeactivated;
+            shippingOption.ExistsInOrder = updateShippingOptionRequestModel.ExistsInOrder;
+            shippingOption.Orders = updateShippingOptionRequestModel.OrderIds?.Select(orderId => new Order { Id = orderId }).ToList()!;
+
+            DataLibraryReturnedCodes returnedCode = await _shippingOptionDataAccess.UpdateShippingOptionAsync(shippingOption);
+            if (returnedCode == DataLibraryReturnedCodes.TheIdOfTheEntityCanNotBeNull)
+                return BadRequest(new { ErrorMessage = "TheIdOfTheEntityCanNotBeNull" });
+            else if (returnedCode == DataLibraryReturnedCodes.EntityNotFoundWithGivenId)
+                return NotFound(new { ErrorMessage = "EntityNotFoundWithGivenId" });
+            else if (returnedCode == DataLibraryReturnedCodes.DuplicateEntityName)
+                return BadRequest(new { ErrorMessage = "DuplicateEntityName" });
+
+            return NoContent();
+        }
+        catch (Exception)
+        {
+            return StatusCode(500);
+        }
+    }
+
+    [HttpDelete("{id}")]
+    public async Task<IActionResult> DeleteShippingOption(string id)
+    {
+        try
+        {
+            DataLibraryReturnedCodes returnedCode = await _shippingOptionDataAccess.DeleteShippingOptionAsync(id);
+            if (returnedCode == DataLibraryReturnedCodes.TheIdOfTheEntityCanNotBeNull)
+                return BadRequest(new { ErrorMessage = "TheIdOfTheEntityCanNotBeNull" });
+            else if (returnedCode == DataLibraryReturnedCodes.EntityNotFoundWithGivenId)
+                return NotFound();
+            else if (returnedCode == DataLibraryReturnedCodes.NoErrorButNotFullyDeleted)
+                return Ok(new { WarningMessage = "NoErrorButNotFullyDeleted" });
+
+            return NoContent();
+        }
+        catch (Exception)
+        {
+            return StatusCode(500);
+        }
+    }
+}

--- a/EshopApp.DataLibraryAPI/Models/RequestModels/OrderModels/CreateOrderRequestModel.cs
+++ b/EshopApp.DataLibraryAPI/Models/RequestModels/OrderModels/CreateOrderRequestModel.cs
@@ -1,0 +1,59 @@
+﻿using System.ComponentModel.DataAnnotations;
+
+namespace EshopApp.DataLibraryAPI.Models.RequestModels.OrderModels;
+
+public class CreateOrderRequestModel
+{
+    public string? Comment { get; set; }
+    [Required]
+    [EmailAddress]
+    public string? Email { get; set; }
+    [Required]
+    [MaxLength(50)]
+    public string? FirstName { get; set; }
+    [Required]
+    [MaxLength(50)]
+    public string? LastName { get; set; }
+    [Required]
+    [MaxLength(50)]
+    public string? Country { get; set; }
+    [Required]
+    [MaxLength(50)]
+    public string? City { get; set; }
+    [Required]
+    [MaxLength(50)]
+    public string? PostalCode { get; set; }
+    [Required]
+    [MaxLength(50)]
+    public string? Address { get; set; }
+    [Required]
+    [MaxLength(50)]
+    public string? PhoneNumber { get; set; }
+    public bool? IsShippingAddressDifferent { get; set; }
+    [MaxLength(50)]
+    public string? AltFirstName { get; set; }
+    [MaxLength(50)]
+    public string? AltLastName { get; set; }
+    [MaxLength(50)]
+    public string? AltCountry { get; set; }
+    [MaxLength(50)]
+    public string? AltCity { get; set; }
+    [MaxLength(50)]
+    public string? AltPostalCode { get; set; }
+    [MaxLength(50)]
+    public string? AltAddress { get; set; }
+    [MaxLength(50)]
+    public string? AltPhoneNumber { get; set; }
+    [Required]
+    public string? UserId { get; set; }
+    [Required]
+    public List<OrderItemRequestModel> CreateOrderItemRequestModels { get; set; } = new List<OrderItemRequestModel>();
+    [Required]
+    public string? PaymentProcessorSessionId { get; set; }
+    [Required]
+    [MaxLength(50)]
+    public string? PaymentOptionId { get; set; }
+    [Required]
+    public string? ShippingOptionId { get; set; }
+    public string? UserCouponId { get; set; }
+}

--- a/EshopApp.DataLibraryAPI/Models/RequestModels/OrderModels/OrderItemRequestModel.cs
+++ b/EshopApp.DataLibraryAPI/Models/RequestModels/OrderModels/OrderItemRequestModel.cs
@@ -1,0 +1,13 @@
+﻿using System.ComponentModel.DataAnnotations;
+
+namespace EshopApp.DataLibraryAPI.Models.RequestModels.OrderModels;
+
+public class OrderItemRequestModel
+{
+    [Required]
+    [Range(0, int.MaxValue, ErrorMessage = "The quantity value must be a non-negative integer.")]
+    public int? Quantity { get; set; }
+    [Required]
+    [MaxLength(50)]
+    public string? VariantId { get; set; }
+}

--- a/EshopApp.DataLibraryAPI/Models/RequestModels/OrderModels/UpdateOrderRequestModel.cs
+++ b/EshopApp.DataLibraryAPI/Models/RequestModels/OrderModels/UpdateOrderRequestModel.cs
@@ -1,0 +1,62 @@
+﻿using System.ComponentModel.DataAnnotations;
+
+namespace EshopApp.DataLibraryAPI.Models.RequestModels.OrderModels;
+
+public class UpdateOrderRequestModel
+{
+    [MaxLength(50)]
+    public string? Id { get; set; }
+    public string? PaymentProcessorSessionId { get; set; }
+    [Required]
+    [EmailAddress]
+    public string? Email { get; set; }
+    [Required]
+    [MaxLength(50)]
+    public string? FirstName { get; set; }
+    [Required]
+    [MaxLength(50)]
+    public string? LastName { get; set; }
+    [Required]
+    [MaxLength(50)]
+    public string? Country { get; set; }
+    [Required]
+    [MaxLength(50)]
+    public string? City { get; set; }
+    [Required]
+    [MaxLength(50)]
+    public string? PostalCode { get; set; }
+    [Required]
+    [MaxLength(50)]
+    public string? Address { get; set; }
+    [Required]
+    [MaxLength(50)]
+    public string? PhoneNumber { get; set; }
+    public bool? IsShippingAddressDifferent { get; set; }
+    [MaxLength(50)]
+    public string? AltFirstName { get; set; }
+    [MaxLength(50)]
+    public string? AltLastName { get; set; }
+    [MaxLength(50)]
+    public string? AltCountry { get; set; }
+    [MaxLength(50)]
+    public string? AltCity { get; set; }
+    [MaxLength(50)]
+    public string? AltPostalCode { get; set; }
+    [MaxLength(50)]
+    public string? AltAddress { get; set; }
+    [MaxLength(50)]
+    public string? AltPhoneNumber { get; set; }
+
+    [MaxLength(50)]
+    public string? PaymentStatus { get; set; }
+    [MaxLength(5)]
+    public string? PaymentCurrency { get; set; }
+    [Range(0, int.MaxValue, ErrorMessage = "The AmountPaidInCustomerCurrency property can not be negative")]
+    public decimal? AmountPaidInCustomerCurrency { get; set; }
+    [Range(0, int.MaxValue, ErrorMessage = "The AmountPaidInEuro property can not be negative")]
+    public decimal? AmountPaidInEuro { get; set; }
+    [Range(0, int.MaxValue, ErrorMessage = "The NetAmountPaidInEuro property can not be negative")]
+    public decimal? NetAmountPaidInEuro { get; set; }
+    public List<OrderItemRequestModel>? CreateOrderItemRequestModels { get; set; }
+    public string? UserCouponId { get; set; }
+}

--- a/EshopApp.DataLibraryAPI/Models/RequestModels/OrderModels/UpdateOrderStatusRequestModels.cs
+++ b/EshopApp.DataLibraryAPI/Models/RequestModels/OrderModels/UpdateOrderStatusRequestModels.cs
@@ -1,0 +1,15 @@
+﻿using System.ComponentModel.DataAnnotations;
+
+namespace EshopApp.DataLibraryAPI.Models.RequestModels.OrderModels;
+
+public class UpdateOrderStatusRequestModels
+{
+    [Required]
+    [MaxLength(50)]
+    [RegularExpression("Pending|Confirmed|Processed|Canceled|Shipped|NoShow|Completed|Refunded|Failed",
+    ErrorMessage = "The trigger event must have one of the following values: OnSignUp, OnFirstOrder, OnEveryFiveOrders, OnEveryTenOrders, NoTrigger.")]
+    public string? NewOrderStatus { get; set; }
+    [Required]
+    [MaxLength(50)]
+    public string? OrderId { get; set; }
+}

--- a/EshopApp.DataLibraryAPI/Models/RequestModels/PaymentOptionModels/CreatePaymentOptionRequestModel.cs
+++ b/EshopApp.DataLibraryAPI/Models/RequestModels/PaymentOptionModels/CreatePaymentOptionRequestModel.cs
@@ -1,0 +1,18 @@
+﻿using System.ComponentModel.DataAnnotations;
+
+namespace EshopApp.DataLibraryAPI.Models.RequestModels.PaymentOptionModels;
+
+public class CreatePaymentOptionRequestModel
+{
+    [MaxLength(50)]
+    [Required]
+    public string? Name { get; set; }
+    [MaxLength(50)]
+    [Required]
+    public string? NameAlias { get; set; }
+    public string? Description { get; set; }
+    [Range(0, int.MaxValue, ErrorMessage = "The extra cost property must be a non-negative integer.")]
+    public decimal? ExtraCost { get; set; }
+    public bool? IsDeactivated { get; set; }
+    public bool? ExistsInOrder { get; set; }
+}

--- a/EshopApp.DataLibraryAPI/Models/RequestModels/PaymentOptionModels/UpdatePaymentOptionRequestModel.cs
+++ b/EshopApp.DataLibraryAPI/Models/RequestModels/PaymentOptionModels/UpdatePaymentOptionRequestModel.cs
@@ -1,0 +1,20 @@
+﻿using System.ComponentModel.DataAnnotations;
+
+namespace EshopApp.DataLibraryAPI.Models.RequestModels.PaymentOptionModels;
+
+public class UpdatePaymentOptionRequestModel
+{
+    [Required]
+    [MaxLength(50)]
+    public string? Id { get; set; }
+    [MaxLength(50)]
+    public string? Name { get; set; }
+    [MaxLength(50)]
+    public string? NameAlias { get; set; }
+    public string? Description { get; set; }
+    [Range(0, int.MaxValue, ErrorMessage = "The extra cost property must be a non-negative integer.")]
+    public decimal? ExtraCost { get; set; }
+    public bool? IsDeactivated { get; set; }
+    public bool? ExistsInOrder { get; set; }
+    public List<string>? PaymentDetailsIds { get; set; }
+}

--- a/EshopApp.DataLibraryAPI/Models/RequestModels/ShippingOptionModels/CreateShippingOptionRequestModel.cs
+++ b/EshopApp.DataLibraryAPI/Models/RequestModels/ShippingOptionModels/CreateShippingOptionRequestModel.cs
@@ -1,0 +1,17 @@
+﻿using System.ComponentModel.DataAnnotations;
+
+namespace EshopApp.DataLibraryAPI.Models.RequestModels.ShippingOptionModels;
+
+public class CreateShippingOptionRequestModel
+{
+
+    [MaxLength(50)]
+    [Required]
+    public string? Name { get; set; }
+    public string? Description { get; set; }
+    [Range(0, int.MaxValue, ErrorMessage = "The extra cost property must be a non-negative integer.")]
+    public decimal? ExtraCost { get; set; }
+    public bool? ContainsDelivery { get; set; }
+    public bool? IsDeactivated { get; set; }
+    public bool? ExistsInOrder { get; set; }
+}

--- a/EshopApp.DataLibraryAPI/Models/RequestModels/ShippingOptionModels/UpdateShippingOptionRequestModel.cs
+++ b/EshopApp.DataLibraryAPI/Models/RequestModels/ShippingOptionModels/UpdateShippingOptionRequestModel.cs
@@ -1,0 +1,19 @@
+﻿using System.ComponentModel.DataAnnotations;
+
+namespace EshopApp.DataLibraryAPI.Models.RequestModels.ShippingOptionModels;
+
+public class UpdateShippingOptionRequestModel
+{
+    [Required]
+    [MaxLength(50)]
+    public string? Id { get; set; }
+    [MaxLength(50)]
+    public string? Name { get; set; }
+    public string? Description { get; set; }
+    [Range(0, int.MaxValue, ErrorMessage = "The extra cost property must be a non-negative integer.")]
+    public decimal? ExtraCost { get; set; }
+    public bool? ContainsDelivery { get; set; }
+    public bool? IsDeactivated { get; set; }
+    public bool? ExistsInOrder { get; set; }
+    public List<string>? OrderIds { get; set; }
+}

--- a/EshopApp.DataLibraryAPI/Program.cs
+++ b/EshopApp.DataLibraryAPI/Program.cs
@@ -49,6 +49,9 @@ public class Program()
         builder.Services.AddScoped<IDiscountDataAccess, DiscountDataAccess>();
         builder.Services.AddScoped<IAttributeDataAccess, AttributeDataAccess>();
         builder.Services.AddScoped<ICouponDataAccess, CouponDataAccess>();
+        builder.Services.AddScoped<IPaymentOptionDataAccess, PaymentOptionDataAccess>();
+        builder.Services.AddScoped<IShippingOptionDataAccess, ShippingOptionDataAccess>();
+        builder.Services.AddScoped<IOrderDataAccess, OrderDataAccess>();
 
         var app = builder.Build();
 


### PR DESCRIPTION
…ShippingOption and Order Entities

I added api endpoints for PaymentOption, ShippingOption and Order entities, which were added in the previous commit, to allow the user to access their corresponding CRUD operations in the dataaccess library. The necessary request models were added when they were needed to accomplish this goal. When it comes to the PaymentOption and ShippingOption the typical CRUD operations were added, but the Order entity also contains a change of state endpoint that is not typical. Finally some small changes were added to the schema to make these addition work as intented.