### PR TITLE
Added Integration Tests For The Order, PaymentOption And ShippingOpti…

### DIFF
--- a/EshopApp.DataLibrary/AppDataDbContext.cs
+++ b/EshopApp.DataLibrary/AppDataDbContext.cs
@@ -281,7 +281,8 @@ public class AppDataDbContext : DbContext
         modelBuilder.Entity<OrderItem>()
             .HasOne(orderItem => orderItem.Variant)
             .WithMany(variant => variant.OrderItems)
-            .HasForeignKey(orderItem => orderItem.VariantId);
+            .HasForeignKey(orderItem => orderItem.VariantId)
+            .OnDelete(DeleteBehavior.Cascade);
 
         //orderItem can have one discount and a discount can have many orders(one to many)
         modelBuilder.Entity<OrderItem>()

--- a/EshopApp.DataLibrary/DataAccess/VariantDataAccess.cs
+++ b/EshopApp.DataLibrary/DataAccess/VariantDataAccess.cs
@@ -294,6 +294,7 @@ public class VariantDataAccess : IVariantDataAccess
             //check if the variantImages is an empty list
             if (updatedVariant.VariantImages != null && !updatedVariant.VariantImages.Any())
             {
+                _appDataDbContext.VariantImages.RemoveRange(foundVariant.VariantImages);
                 foundVariant.VariantImages.Clear();
             }
             else if (updatedVariant.VariantImages != null)
@@ -305,6 +306,7 @@ public class VariantDataAccess : IVariantDataAccess
                     .Where(databaseImage => updatedImagesIds.Contains(databaseImage.Id!))
                     .ToListAsync();
 
+                _appDataDbContext.VariantImages.RemoveRange(foundVariant.VariantImages);
                 foundVariant.VariantImages.Clear(); //remove all the variantImages
                 //and then rebuild them
                 foreach (var filteredImage in filteredImages)

--- a/EshopApp.DataLibrary/Migrations/20241201185152_AddedCascadeDeleteOnVariantsAndOrderItemRelationship.Designer.cs
+++ b/EshopApp.DataLibrary/Migrations/20241201185152_AddedCascadeDeleteOnVariantsAndOrderItemRelationship.Designer.cs
@@ -4,6 +4,7 @@ using EshopApp.DataLibrary;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace EshopApp.DataLibrary.Migrations
 {
     [DbContext(typeof(AppDataDbContext))]
-    partial class AppDataDbContextModelSnapshot : ModelSnapshot
+    [Migration("20241201185152_AddedCascadeDeleteOnVariantsAndOrderItemRelationship")]
+    partial class AddedCascadeDeleteOnVariantsAndOrderItemRelationship
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/EshopApp.DataLibrary/Migrations/20241201185152_AddedCascadeDeleteOnVariantsAndOrderItemRelationship.cs
+++ b/EshopApp.DataLibrary/Migrations/20241201185152_AddedCascadeDeleteOnVariantsAndOrderItemRelationship.cs
@@ -1,0 +1,41 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace EshopApp.DataLibrary.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddedCascadeDeleteOnVariantsAndOrderItemRelationship : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_OrderItems_Variants_VariantId",
+                table: "OrderItems");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_OrderItems_Variants_VariantId",
+                table: "OrderItems",
+                column: "VariantId",
+                principalTable: "Variants",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_OrderItems_Variants_VariantId",
+                table: "OrderItems");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_OrderItems_Variants_VariantId",
+                table: "OrderItems",
+                column: "VariantId",
+                principalTable: "Variants",
+                principalColumn: "Id");
+        }
+    }
+}

--- a/EshopApp.DataLibrary/Migrations/20241202200456_AddedClientCascadeInsteadOfCascadeToVariantImagesAndOrderItemsEntities.Designer.cs
+++ b/EshopApp.DataLibrary/Migrations/20241202200456_AddedClientCascadeInsteadOfCascadeToVariantImagesAndOrderItemsEntities.Designer.cs
@@ -4,6 +4,7 @@ using EshopApp.DataLibrary;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace EshopApp.DataLibrary.Migrations
 {
     [DbContext(typeof(AppDataDbContext))]
-    partial class AppDataDbContextModelSnapshot : ModelSnapshot
+    [Migration("20241202200456_AddedClientCascadeInsteadOfCascadeToVariantImagesAndOrderItemsEntities")]
+    partial class AddedClientCascadeInsteadOfCascadeToVariantImagesAndOrderItemsEntities
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -783,7 +786,7 @@ namespace EshopApp.DataLibrary.Migrations
                     b.HasOne("EshopApp.DataLibrary.Models.Order", "Order")
                         .WithMany("OrderItems")
                         .HasForeignKey("OrderId")
-                        .OnDelete(DeleteBehavior.Cascade);
+                        .OnDelete(DeleteBehavior.ClientCascade);
 
                     b.HasOne("EshopApp.DataLibrary.Models.Variant", "Variant")
                         .WithMany("OrderItems")

--- a/EshopApp.DataLibrary/Migrations/20241202200456_AddedClientCascadeInsteadOfCascadeToVariantImagesAndOrderItemsEntities.cs
+++ b/EshopApp.DataLibrary/Migrations/20241202200456_AddedClientCascadeInsteadOfCascadeToVariantImagesAndOrderItemsEntities.cs
@@ -1,0 +1,41 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace EshopApp.DataLibrary.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddedClientCascadeInsteadOfCascadeToVariantImagesAndOrderItemsEntities : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_OrderItems_Orders_OrderId",
+                table: "OrderItems");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_OrderItems_Orders_OrderId",
+                table: "OrderItems",
+                column: "OrderId",
+                principalTable: "Orders",
+                principalColumn: "Id");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_OrderItems_Orders_OrderId",
+                table: "OrderItems");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_OrderItems_Orders_OrderId",
+                table: "OrderItems",
+                column: "OrderId",
+                principalTable: "Orders",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+        }
+    }
+}

--- a/EshopApp.DataLibrary/Migrations/20241202201456_MovedBackToCascadeBecaudeClientCascadeDoesNotWork.Designer.cs
+++ b/EshopApp.DataLibrary/Migrations/20241202201456_MovedBackToCascadeBecaudeClientCascadeDoesNotWork.Designer.cs
@@ -4,6 +4,7 @@ using EshopApp.DataLibrary;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace EshopApp.DataLibrary.Migrations
 {
     [DbContext(typeof(AppDataDbContext))]
-    partial class AppDataDbContextModelSnapshot : ModelSnapshot
+    [Migration("20241202201456_MovedBackToCascadeBecaudeClientCascadeDoesNotWork")]
+    partial class MovedBackToCascadeBecaudeClientCascadeDoesNotWork
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/EshopApp.DataLibrary/Migrations/20241202201456_MovedBackToCascadeBecaudeClientCascadeDoesNotWork.cs
+++ b/EshopApp.DataLibrary/Migrations/20241202201456_MovedBackToCascadeBecaudeClientCascadeDoesNotWork.cs
@@ -1,0 +1,41 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace EshopApp.DataLibrary.Migrations
+{
+    /// <inheritdoc />
+    public partial class MovedBackToCascadeBecaudeClientCascadeDoesNotWork : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_OrderItems_Orders_OrderId",
+                table: "OrderItems");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_OrderItems_Orders_OrderId",
+                table: "OrderItems",
+                column: "OrderId",
+                principalTable: "Orders",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_OrderItems_Orders_OrderId",
+                table: "OrderItems");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_OrderItems_Orders_OrderId",
+                table: "OrderItems",
+                column: "OrderId",
+                principalTable: "Orders",
+                principalColumn: "Id");
+        }
+    }
+}

--- a/EshopApp.DataLibrary/Models/ResponseModels/DataLibraryReturnedCodes.cs
+++ b/EshopApp.DataLibrary/Models/ResponseModels/DataLibraryReturnedCodes.cs
@@ -28,11 +28,13 @@ public enum DataLibraryReturnedCodes
     InvalidPaymentOption,
     InvalidShippingOption,
     CouponCodeCurrentlyDeactivated,
+    CouponUsageLimitExceeded,
     OrderStatusHasBeenFinalizedAndThusTheOrderCanNotBeAltered,
     AllTheAltFieldsNeedToBeFilledIfDifferentShippingAddress,
     InvalidOrderStatus,
     OrderStatusHasBeenFinalizedAndThusOrderStatusCanNotBeAltered,
     ThisOrderDoesNotContainShippingAndThusTheShippedStatusIsInvalid,
     InvalidNewOrderState,
-    TheOrderIdAndThePaymentProcessorSessionIdCanNotBeBothNull
+    TheOrderIdAndThePaymentProcessorSessionIdCanNotBeBothNull,
+    InsufficientStockForVariant
 }

--- a/EshopApp.DataLibraryAPI.Tests/IntegrationTests/ControllerTests/AttributeControllerTests.cs
+++ b/EshopApp.DataLibraryAPI.Tests/IntegrationTests/ControllerTests/AttributeControllerTests.cs
@@ -34,7 +34,7 @@ internal class AttributeControllerTests
 
         TestUtilitiesLibrary.DatabaseUtilities.ResetSqlAuthDatabase(
             "Data Source=(localdb)\\MSSQLLocalDB;Initial Catalog=EshopAppDataDb;Integrated Security=True;Connect Timeout=30;Encrypt=False;TrustServerCertificate=False;ApplicationIntent=ReadWrite;MultiSubnetFailover=False",
-            new string[] { "dbo.Attributes", "dbo.Categories", "dbo.Products", "dbo.Variants", "dbo.Discounts", "dbo.Images", "dbo.VariantImages", "dbo.Coupons", "dbo.UserCoupons" },
+            new string[] { "dbo.Attributes", "dbo.Categories", "dbo.Products", "dbo.Variants", "dbo.Discounts", "dbo.Images", "dbo.VariantImages", "dbo.Orders", "dbo.Coupons", "dbo.UserCoupons", "dbo.ShippingOptions", "dbo.PaymentOptions" },
             "Data Database Successfully Cleared!"
         );
 
@@ -432,7 +432,7 @@ internal class AttributeControllerTests
         httpClient.Dispose();
         TestUtilitiesLibrary.DatabaseUtilities.ResetSqlAuthDatabase(
             "Data Source=(localdb)\\MSSQLLocalDB;Initial Catalog=EshopAppDataDb;Integrated Security=True;Connect Timeout=30;Encrypt=False;TrustServerCertificate=False;ApplicationIntent=ReadWrite;MultiSubnetFailover=False",
-            new string[] { "dbo.Attributes", "dbo.Categories", "dbo.Products", "dbo.Variants", "dbo.Discounts", "dbo.Images", "dbo.VariantImages", "dbo.Coupons", "dbo.UserCoupons" },
+            new string[] { "dbo.Attributes", "dbo.Categories", "dbo.Products", "dbo.Variants", "dbo.Discounts", "dbo.Images", "dbo.VariantImages", "dbo.Orders", "dbo.Coupons", "dbo.UserCoupons", "dbo.ShippingOptions", "dbo.PaymentOptions" },
             "Data Database Successfully Cleared!"
         );
     }

--- a/EshopApp.DataLibraryAPI.Tests/IntegrationTests/ControllerTests/CategoriesControllerTests.cs
+++ b/EshopApp.DataLibraryAPI.Tests/IntegrationTests/ControllerTests/CategoriesControllerTests.cs
@@ -32,7 +32,7 @@ internal class CategoriesControllerTests
 
         TestUtilitiesLibrary.DatabaseUtilities.ResetSqlAuthDatabase(
             "Data Source=(localdb)\\MSSQLLocalDB;Initial Catalog=EshopAppDataDb;Integrated Security=True;Connect Timeout=30;Encrypt=False;TrustServerCertificate=False;ApplicationIntent=ReadWrite;MultiSubnetFailover=False",
-            new string[] { "dbo.Attributes", "dbo.Categories", "dbo.Products", "dbo.Variants", "dbo.Discounts", "dbo.Images", "dbo.VariantImages", "dbo.Coupons", "dbo.UserCoupons" },
+            new string[] { "dbo.Attributes", "dbo.Categories", "dbo.Products", "dbo.Variants", "dbo.Discounts", "dbo.Images", "dbo.VariantImages", "dbo.Orders", "dbo.Coupons", "dbo.UserCoupons", "dbo.ShippingOptions", "dbo.PaymentOptions" },
             "Data Database Successfully Cleared!"
         );
 
@@ -425,7 +425,7 @@ internal class CategoriesControllerTests
         httpClient.Dispose();
         TestUtilitiesLibrary.DatabaseUtilities.ResetSqlAuthDatabase(
             "Data Source=(localdb)\\MSSQLLocalDB;Initial Catalog=EshopAppDataDb;Integrated Security=True;Connect Timeout=30;Encrypt=False;TrustServerCertificate=False;ApplicationIntent=ReadWrite;MultiSubnetFailover=False",
-            new string[] { "dbo.Attributes", "dbo.Categories", "dbo.Products", "dbo.Variants", "dbo.Discounts", "dbo.Images", "dbo.VariantImages", "dbo.Coupons", "dbo.UserCoupons" },
+            new string[] { "dbo.Attributes", "dbo.Categories", "dbo.Products", "dbo.Variants", "dbo.Discounts", "dbo.Images", "dbo.VariantImages", "dbo.Orders", "dbo.Coupons", "dbo.UserCoupons", "dbo.ShippingOptions", "dbo.PaymentOptions" },
             "Data Database Successfully Cleared!"
         );
     }

--- a/EshopApp.DataLibraryAPI.Tests/IntegrationTests/ControllerTests/CouponControllerTests.cs
+++ b/EshopApp.DataLibraryAPI.Tests/IntegrationTests/ControllerTests/CouponControllerTests.cs
@@ -36,10 +36,11 @@ internal class CouponControllerTests
 
         TestUtilitiesLibrary.DatabaseUtilities.ResetSqlAuthDatabase(
             "Data Source=(localdb)\\MSSQLLocalDB;Initial Catalog=EshopAppDataDb;Integrated Security=True;Connect Timeout=30;Encrypt=False;TrustServerCertificate=False;ApplicationIntent=ReadWrite;MultiSubnetFailover=False",
-            new string[] { "dbo.Attributes", "dbo.Categories", "dbo.Products", "dbo.Variants", "dbo.Discounts", "dbo.Images", "dbo.VariantImages", "dbo.Coupons", "dbo.UserCoupons" },
+            new string[] { "dbo.Attributes", "dbo.Categories", "dbo.Products", "dbo.Variants", "dbo.Discounts", "dbo.Images", "dbo.VariantImages", "dbo.Orders", "dbo.Coupons", "dbo.UserCoupons", "dbo.ShippingOptions", "dbo.PaymentOptions" },
             "Data Database Successfully Cleared!"
         );
 
+        /*************** Other Coupon ***************/
         httpClient.DefaultRequestHeaders.Remove("X-API-KEY");
         httpClient.DefaultRequestHeaders.Add("X-API-KEY", _chosenApiKey);
         TestCreateCouponRequestModel testCreateCouponRequestModel = new TestCreateCouponRequestModel();
@@ -908,7 +909,7 @@ internal class CouponControllerTests
         httpClient.Dispose();
         TestUtilitiesLibrary.DatabaseUtilities.ResetSqlAuthDatabase(
             "Data Source=(localdb)\\MSSQLLocalDB;Initial Catalog=EshopAppDataDb;Integrated Security=True;Connect Timeout=30;Encrypt=False;TrustServerCertificate=False;ApplicationIntent=ReadWrite;MultiSubnetFailover=False",
-            new string[] { "dbo.Attributes", "dbo.Categories", "dbo.Products", "dbo.Variants", "dbo.Discounts", "dbo.Images", "dbo.VariantImages", "dbo.Coupons", "dbo.UserCoupons" },
+            new string[] { "dbo.Attributes", "dbo.Categories", "dbo.Products", "dbo.Variants", "dbo.Discounts", "dbo.Images", "dbo.VariantImages", "dbo.Orders", "dbo.Coupons", "dbo.UserCoupons", "dbo.ShippingOptions", "dbo.PaymentOptions" },
             "Data Database Successfully Cleared!"
         );
     }

--- a/EshopApp.DataLibraryAPI.Tests/IntegrationTests/ControllerTests/DiscountControllerTests.cs
+++ b/EshopApp.DataLibraryAPI.Tests/IntegrationTests/ControllerTests/DiscountControllerTests.cs
@@ -34,7 +34,7 @@ internal class DiscountControllerTests
 
         TestUtilitiesLibrary.DatabaseUtilities.ResetSqlAuthDatabase(
             "Data Source=(localdb)\\MSSQLLocalDB;Initial Catalog=EshopAppDataDb;Integrated Security=True;Connect Timeout=30;Encrypt=False;TrustServerCertificate=False;ApplicationIntent=ReadWrite;MultiSubnetFailover=False",
-            new string[] { "dbo.Attributes", "dbo.Categories", "dbo.Products", "dbo.Variants", "dbo.Discounts", "dbo.Images", "dbo.VariantImages", "dbo.Coupons", "dbo.UserCoupons" },
+            new string[] { "dbo.Attributes", "dbo.Categories", "dbo.Products", "dbo.Variants", "dbo.Discounts", "dbo.Images", "dbo.VariantImages", "dbo.Orders", "dbo.Coupons", "dbo.UserCoupons", "dbo.ShippingOptions", "dbo.PaymentOptions" },
             "Data Database Successfully Cleared!"
         );
 
@@ -446,7 +446,7 @@ internal class DiscountControllerTests
         httpClient.Dispose();
         TestUtilitiesLibrary.DatabaseUtilities.ResetSqlAuthDatabase(
             "Data Source=(localdb)\\MSSQLLocalDB;Initial Catalog=EshopAppDataDb;Integrated Security=True;Connect Timeout=30;Encrypt=False;TrustServerCertificate=False;ApplicationIntent=ReadWrite;MultiSubnetFailover=False",
-            new string[] { "dbo.Attributes", "dbo.Categories", "dbo.Products", "dbo.Variants", "dbo.Discounts", "dbo.Images", "dbo.VariantImages", "dbo.Coupons", "dbo.UserCoupons" },
+            new string[] { "dbo.Attributes", "dbo.Categories", "dbo.Products", "dbo.Variants", "dbo.Discounts", "dbo.Images", "dbo.VariantImages", "dbo.Orders", "dbo.Coupons", "dbo.UserCoupons", "dbo.ShippingOptions", "dbo.PaymentOptions" },
             "Data Database Successfully Cleared!"
         );
     }

--- a/EshopApp.DataLibraryAPI.Tests/IntegrationTests/ControllerTests/ImageControllerTests.cs
+++ b/EshopApp.DataLibraryAPI.Tests/IntegrationTests/ControllerTests/ImageControllerTests.cs
@@ -29,7 +29,7 @@ internal class ImageControllerTests
 
         TestUtilitiesLibrary.DatabaseUtilities.ResetSqlAuthDatabase(
             "Data Source=(localdb)\\MSSQLLocalDB;Initial Catalog=EshopAppDataDb;Integrated Security=True;Connect Timeout=30;Encrypt=False;TrustServerCertificate=False;ApplicationIntent=ReadWrite;MultiSubnetFailover=False",
-            new string[] { "dbo.Attributes", "dbo.Categories", "dbo.Products", "dbo.Variants", "dbo.Discounts", "dbo.Images", "dbo.VariantImages", "dbo.Coupons", "dbo.UserCoupons" },
+            new string[] { "dbo.Attributes", "dbo.Categories", "dbo.Products", "dbo.Variants", "dbo.Discounts", "dbo.Images", "dbo.VariantImages", "dbo.Orders", "dbo.Coupons", "dbo.UserCoupons", "dbo.ShippingOptions", "dbo.PaymentOptions" },
             "Data Database Successfully Cleared!"
         );
 
@@ -39,7 +39,7 @@ internal class ImageControllerTests
         testCreateImageRequestModel.ImagePath = "OtherPath";
         HttpResponseMessage response = await httpClient.PostAsJsonAsync("api/image", testCreateImageRequestModel);
         string responseBody = await response.Content.ReadAsStringAsync();
-        _otherImageName = JsonSerializer.Deserialize<TestProduct>(responseBody, new JsonSerializerOptions { PropertyNameCaseInsensitive = true })!.Name;
+        _otherImageName = JsonSerializer.Deserialize<TestAppImage>(responseBody, new JsonSerializerOptions { PropertyNameCaseInsensitive = true })!.Name;
     }
 
     [Test, Order(10)]
@@ -400,7 +400,7 @@ internal class ImageControllerTests
         httpClient.Dispose();
         TestUtilitiesLibrary.DatabaseUtilities.ResetSqlAuthDatabase(
             "Data Source=(localdb)\\MSSQLLocalDB;Initial Catalog=EshopAppDataDb;Integrated Security=True;Connect Timeout=30;Encrypt=False;TrustServerCertificate=False;ApplicationIntent=ReadWrite;MultiSubnetFailover=False",
-            new string[] { "dbo.Attributes", "dbo.Categories", "dbo.Products", "dbo.Variants", "dbo.Discounts", "dbo.Images", "dbo.VariantImages", "dbo.Coupons", "dbo.UserCoupons" },
+            new string[] { "dbo.Attributes", "dbo.Categories", "dbo.Products", "dbo.Variants", "dbo.Discounts", "dbo.Images", "dbo.VariantImages", "dbo.Orders", "dbo.Coupons", "dbo.UserCoupons", "dbo.ShippingOptions", "dbo.PaymentOptions" },
             "Data Database Successfully Cleared!"
         );
     }

--- a/EshopApp.DataLibraryAPI.Tests/IntegrationTests/ControllerTests/OrderControllerTests.cs
+++ b/EshopApp.DataLibraryAPI.Tests/IntegrationTests/ControllerTests/OrderControllerTests.cs
@@ -1,0 +1,1568 @@
+﻿using EshopApp.DataLibrary.Models;
+using EshopApp.DataLibraryAPI.Tests.IntegrationTests.Models;
+using EshopApp.DataLibraryAPI.Tests.IntegrationTests.Models.CouponModels;
+using EshopApp.DataLibraryAPI.Tests.IntegrationTests.Models.OrderModels;
+using EshopApp.DataLibraryAPI.Tests.IntegrationTests.Models.PaymentOptionModels;
+using EshopApp.DataLibraryAPI.Tests.IntegrationTests.Models.ShippingOptionModels;
+using EshopApp.EmailLibraryAPI.Tests.IntegrationTests.Models.RequestModels.DiscountModels;
+using EshopApp.EmailLibraryAPI.Tests.IntegrationTests.Models.RequestModels.ImageModels;
+using EshopApp.EmailLibraryAPI.Tests.IntegrationTests.Models.RequestModels.ProductModels;
+using EshopApp.EmailLibraryAPI.Tests.IntegrationTests.Models.RequestModels.VariantModels;
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc.Testing;
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+
+namespace EshopApp.DataLibraryAPI.Tests.IntegrationTests.ControllerTests;
+
+//TODO add discount to variant
+//TODO add the get, update, updatestatus and delete
+[TestFixture]
+[Category("Integration")]
+[Author("konstantinos kinnas", "kinnaskonstantinos0@gmail.com")]
+internal class OrderControllerTests
+{
+    private HttpClient httpClient;
+    private string? _chosenApiKey;
+    private string? _chosenOrderId;
+    private string? _chosenShippingOptionId;
+    private string? _chosenPaymentOptionId;
+    private string? _chosenProductId;
+    private string? _chosenVariantId;
+    private string? _otherChosenVariantId;
+    private string? _chosenDiscountId;
+    private string? _chosenImageId;
+    private string? _chosenCouponId;
+    private string? _chosenUserCouponId;
+    private string? _otherChosenUserCouponId;
+    private string? _otherUserCouponId;
+    private string? _chosenUserId = "MyUserId";
+
+    [OneTimeSetUp]
+    public async Task OnTimeSetup()
+    {
+        var webApplicationFactory = new WebApplicationFactory<Program>();
+        httpClient = webApplicationFactory.CreateClient();
+        httpClient.DefaultRequestHeaders.Add("X-Bypass-Rate-Limiting", "a7f3f1c6-3d2b-4e3a-8d70-4b6e8d6d53d8");
+        _chosenApiKey = "user_e1f7b8c0-3c79-4a1b-9e7a-9d8b1d4a5c6e";
+        httpClient.DefaultRequestHeaders.Add("X-API-KEY", _chosenApiKey);
+
+        TestUtilitiesLibrary.DatabaseUtilities.ResetSqlAuthDatabase(
+            "Data Source=(localdb)\\MSSQLLocalDB;Initial Catalog=EshopAppDataDb;Integrated Security=True;Connect Timeout=30;Encrypt=False;TrustServerCertificate=False;ApplicationIntent=ReadWrite;MultiSubnetFailover=False",
+            new string[] { "dbo.Attributes", "dbo.Categories", "dbo.Products", "dbo.Variants", "dbo.Discounts", "dbo.Images", "dbo.VariantImages", "dbo.Orders", "dbo.Coupons", "dbo.UserCoupons", "dbo.ShippingOptions", "dbo.PaymentOptions" },
+            "Data Database Successfully Cleared!"
+        );
+
+        /*************** Discount ***************/
+        TestCreateDiscountRequestModel testCreateDiscountRequestModel = new TestCreateDiscountRequestModel();
+        testCreateDiscountRequestModel.Name = "MyDiscount";
+        testCreateDiscountRequestModel.Percentage = 20;
+
+        //Act
+        HttpResponseMessage response = await httpClient.PostAsJsonAsync("api/discount", testCreateDiscountRequestModel);
+        string? responseBody = await response.Content.ReadAsStringAsync();
+        _chosenDiscountId = JsonSerializer.Deserialize<TestDiscount>(responseBody, new JsonSerializerOptions { PropertyNameCaseInsensitive = true })!.Id;
+
+        /*************** Product & Variant ***************/
+        TestCreateProductRequestModel testCreateProductRequestModel = new TestCreateProductRequestModel();
+        testCreateProductRequestModel.Name = "ProductName";
+        testCreateProductRequestModel.Code = "ProductCode";
+        TestCreateVariantRequestModel testCreateVariantRequestModel = new TestCreateVariantRequestModel();
+        testCreateVariantRequestModel.SKU = "ProductVariantSKU";
+        testCreateVariantRequestModel.Price = 50m;
+        testCreateVariantRequestModel.UnitsInStock = 10;
+        testCreateVariantRequestModel.ProductId = "IdWillBeOverriden"; //This will be overriden in the dataaccess
+        testCreateVariantRequestModel.DiscountId = _chosenDiscountId;
+        testCreateProductRequestModel.CreateVariantRequestModel = testCreateVariantRequestModel;
+        response = await httpClient.PostAsJsonAsync("api/product", testCreateProductRequestModel);
+        responseBody = await response.Content.ReadAsStringAsync();
+        TestProduct chosenProduct = JsonSerializer.Deserialize<TestProduct>(responseBody, new JsonSerializerOptions { PropertyNameCaseInsensitive = true })!;
+        _chosenProductId = chosenProduct.Id;
+        _chosenVariantId = chosenProduct.Variants.First().Id;
+
+        /*************** Other Chosen Variant ***************/
+        testCreateVariantRequestModel = new TestCreateVariantRequestModel();
+        testCreateVariantRequestModel.SKU = "OtherChosenVariantSKU";
+        testCreateVariantRequestModel.Price = 100m;
+        testCreateVariantRequestModel.UnitsInStock = 20;
+        testCreateVariantRequestModel.ProductId = _chosenProductId;
+
+        response = await httpClient.PostAsJsonAsync("api/variant", testCreateVariantRequestModel);
+        responseBody = await response.Content.ReadAsStringAsync();
+        _otherChosenVariantId = JsonSerializer.Deserialize<TestVariant>(responseBody, new JsonSerializerOptions { PropertyNameCaseInsensitive = true })!.Id;
+
+        /*************** Image ***************/
+        TestCreateImageRequestModels testCreateImageRequestModel = new TestCreateImageRequestModels();
+        testCreateImageRequestModel.Name = "MyImage";
+        testCreateImageRequestModel.ImagePath = "MyPath";
+        response = await httpClient.PostAsJsonAsync("api/image", testCreateImageRequestModel);
+        responseBody = await response.Content.ReadAsStringAsync();
+        _chosenImageId = JsonSerializer.Deserialize<TestAppImage>(responseBody, new JsonSerializerOptions { PropertyNameCaseInsensitive = true })!.Id;
+
+        /*************** VariantImage ***************/
+        TestUpdateVariantRequestModel testUpdateVariantRequestModel = new TestUpdateVariantRequestModel();
+        testUpdateVariantRequestModel.Id = _chosenVariantId;
+        testUpdateVariantRequestModel.ImagesIds = new() { _chosenImageId! };
+        response = await httpClient.PutAsJsonAsync("api/variant", testUpdateVariantRequestModel);
+
+        /*************** Universal Coupon ***************/
+        TestCreateCouponRequestModel testCreateCouponRequestModel = new TestCreateCouponRequestModel();
+        testCreateCouponRequestModel.Description = "My other coupon description";
+        testCreateCouponRequestModel.DiscountPercentage = 10;
+        testCreateCouponRequestModel.UsageLimit = 1;
+        testCreateCouponRequestModel.IsUserSpecific = false;
+        testCreateCouponRequestModel.IsDeactivated = false;
+        testCreateCouponRequestModel.StartDate = DateTime.Now;
+        testCreateCouponRequestModel.ExpirationDate = DateTime.Now.AddDays(2);
+
+        response = await httpClient.PostAsJsonAsync("api/coupon", testCreateCouponRequestModel);
+        responseBody = await response.Content.ReadAsStringAsync();
+        _chosenCouponId = JsonSerializer.Deserialize<TestCoupon>(responseBody, new JsonSerializerOptions { PropertyNameCaseInsensitive = true })!.Id;
+
+        /*************** UserCoupon ***************/
+        TestAddCouponToUserRequestModel testAddCouponToUserRequestModel = new TestAddCouponToUserRequestModel();
+        testAddCouponToUserRequestModel.UserId = _chosenUserId;
+        testAddCouponToUserRequestModel.CouponId = _chosenCouponId;
+
+        response = await httpClient.PostAsJsonAsync("api/coupon/addCouponToUser", testAddCouponToUserRequestModel);
+        responseBody = await response.Content.ReadAsStringAsync();
+        _chosenUserCouponId = JsonSerializer.Deserialize<TestUserCoupon>(responseBody, new JsonSerializerOptions { PropertyNameCaseInsensitive = true })!.Id;
+
+        /*************** Other Chosen UserCoupon ***************/
+        testAddCouponToUserRequestModel.UserId = _chosenUserId;
+        testAddCouponToUserRequestModel.CouponId = _chosenCouponId;
+
+        response = await httpClient.PostAsJsonAsync("api/coupon/addCouponToUser", testAddCouponToUserRequestModel);
+        responseBody = await response.Content.ReadAsStringAsync();
+        _otherChosenUserCouponId = JsonSerializer.Deserialize<TestUserCoupon>(responseBody, new JsonSerializerOptions { PropertyNameCaseInsensitive = true })!.Id;
+
+        /*************** Other UserCoupon(it belongs to another user) ***************/
+        testAddCouponToUserRequestModel.UserId = "otherUserId";
+        testAddCouponToUserRequestModel.CouponId = _chosenCouponId;
+
+        response = await httpClient.PostAsJsonAsync("api/coupon/addCouponToUser", testAddCouponToUserRequestModel);
+        responseBody = await response.Content.ReadAsStringAsync();
+        _otherUserCouponId = JsonSerializer.Deserialize<TestUserCoupon>(responseBody, new JsonSerializerOptions { PropertyNameCaseInsensitive = true })!.Id;
+
+        /*************** Shipping Option ***************/
+        TestCreateShippingOptionRequestModel testCreateShippingOptionRequestModel = new TestCreateShippingOptionRequestModel();
+        testCreateShippingOptionRequestModel.Name = "MyShippingOption";
+        testCreateShippingOptionRequestModel.ExtraCost = 5;
+        testCreateShippingOptionRequestModel.ContainsDelivery = true;
+
+        response = await httpClient.PostAsJsonAsync("api/shippingOption", testCreateShippingOptionRequestModel);
+        responseBody = await response.Content.ReadAsStringAsync();
+        _chosenShippingOptionId = JsonSerializer.Deserialize<TestShippingOption>(responseBody, new JsonSerializerOptions { PropertyNameCaseInsensitive = true })!.Id;
+
+        /*************** Payment Option ***************/
+        TestCreatePaymentOptionRequestModel testCreatePaymentOptionRequestModel = new TestCreatePaymentOptionRequestModel();
+        testCreatePaymentOptionRequestModel.Name = "MyPaymentOption";
+        testCreatePaymentOptionRequestModel.NameAlias = "cash";
+        testCreatePaymentOptionRequestModel.ExtraCost = 10;
+
+        response = await httpClient.PostAsJsonAsync("api/paymentOption", testCreatePaymentOptionRequestModel);
+        responseBody = await response.Content.ReadAsStringAsync();
+        _chosenPaymentOptionId = JsonSerializer.Deserialize<TestPaymentOption>(responseBody, new JsonSerializerOptions { PropertyNameCaseInsensitive = true })!.Id;
+    }
+
+    [Test, Order(10)]
+    public async Task CreateOrder_ShouldFailAndReturnUnauthorized_IfXAPIKEYHeaderIsMissing()
+    {
+        //Arrange
+        httpClient.DefaultRequestHeaders.Remove("X-API-KEY");
+        TestCreateOrderRequestModel testCreateOrderRequestModel = new TestCreateOrderRequestModel();
+        testCreateOrderRequestModel.Comment = "UserComment";
+        testCreateOrderRequestModel.Email = "user@gmail.com";
+        testCreateOrderRequestModel.FirstName = "UserFirstName";
+        testCreateOrderRequestModel.LastName = "UserLastName";
+        testCreateOrderRequestModel.Country = "UserCountry";
+        testCreateOrderRequestModel.City = "UserCity";
+        testCreateOrderRequestModel.PostalCode = "UserPostalCode";
+        testCreateOrderRequestModel.Address = "UserAddress";
+        testCreateOrderRequestModel.PhoneNumber = "UserPhoneNumber";
+        testCreateOrderRequestModel.IsShippingAddressDifferent = true;
+        testCreateOrderRequestModel.AltFirstName = "AltUserFirstName";
+        testCreateOrderRequestModel.AltLastName = "AltUserLastName";
+        testCreateOrderRequestModel.AltCountry = "AltUserCountry";
+        testCreateOrderRequestModel.AltCity = "AltUserCity";
+        testCreateOrderRequestModel.AltPostalCode = "AltUserPostalCode";
+        testCreateOrderRequestModel.AltAddress = "AltUserAddress";
+        testCreateOrderRequestModel.AltPhoneNumber = "AltUserPhoneNumber";
+        testCreateOrderRequestModel.UserId = _chosenUserId;
+        testCreateOrderRequestModel.PaymentProcessorSessionId = "paymentProcessorSessionId";
+        testCreateOrderRequestModel.OrderItemRequestModels.Add(new TestOrderItemRequestModel()
+        {
+            Quantity = 3,
+            VariantId = _chosenVariantId
+        });
+        testCreateOrderRequestModel.PaymentOptionId = _chosenPaymentOptionId;
+        testCreateOrderRequestModel.ShippingOptionId = _chosenShippingOptionId;
+        testCreateOrderRequestModel.UserCouponId = _chosenUserCouponId;
+
+        //Act
+        HttpResponseMessage response = await httpClient.PostAsJsonAsync("api/order", testCreateOrderRequestModel);
+        string? errorMessage = await TestUtilitiesLibrary.JsonUtilities.GetSingleStringValueFromBody(response, "errorMessage");
+
+        //Assert
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+        errorMessage.Should().NotBeNull().And.Contain("X-API-KEY");
+    }
+
+    [Test, Order(20)]
+    public async Task CreateOrder_ShouldFailAndReturnUnauthorized_IfAPIKeyIsInvalid()
+    {
+        //Arrange
+        httpClient.DefaultRequestHeaders.Remove("X-API-KEY");
+        httpClient.DefaultRequestHeaders.Add("X-API-KEY", "bogusKey");
+        TestCreateOrderRequestModel testCreateOrderRequestModel = new TestCreateOrderRequestModel();
+        testCreateOrderRequestModel.Comment = "UserComment";
+        testCreateOrderRequestModel.Email = "user@gmail.com";
+        testCreateOrderRequestModel.FirstName = "UserFirstName";
+        testCreateOrderRequestModel.LastName = "UserLastName";
+        testCreateOrderRequestModel.Country = "UserCountry";
+        testCreateOrderRequestModel.City = "UserCity";
+        testCreateOrderRequestModel.PostalCode = "UserPostalCode";
+        testCreateOrderRequestModel.Address = "UserAddress";
+        testCreateOrderRequestModel.PhoneNumber = "UserPhoneNumber";
+        testCreateOrderRequestModel.IsShippingAddressDifferent = true;
+        testCreateOrderRequestModel.AltFirstName = "AltUserFirstName";
+        testCreateOrderRequestModel.AltLastName = "AltUserLastName";
+        testCreateOrderRequestModel.AltCountry = "AltUserCountry";
+        testCreateOrderRequestModel.AltCity = "AltUserCity";
+        testCreateOrderRequestModel.AltPostalCode = "AltUserPostalCode";
+        testCreateOrderRequestModel.AltAddress = "AltUserAddress";
+        testCreateOrderRequestModel.AltPhoneNumber = "AltUserPhoneNumber";
+        testCreateOrderRequestModel.UserId = _chosenUserId;
+        testCreateOrderRequestModel.PaymentProcessorSessionId = "paymentProcessorSessionId";
+        testCreateOrderRequestModel.OrderItemRequestModels.Add(new TestOrderItemRequestModel()
+        {
+            Quantity = 3,
+            VariantId = _chosenVariantId
+        });
+        testCreateOrderRequestModel.PaymentOptionId = _chosenPaymentOptionId;
+        testCreateOrderRequestModel.ShippingOptionId = _chosenShippingOptionId;
+        testCreateOrderRequestModel.UserCouponId = _chosenUserCouponId;
+
+        //Act
+        HttpResponseMessage response = await httpClient.PostAsJsonAsync("api/order", testCreateOrderRequestModel);
+        string? errorMessage = await TestUtilitiesLibrary.JsonUtilities.GetSingleStringValueFromBody(response, "errorMessage");
+
+        //Assert
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+        errorMessage.Should().NotBeNull().And.Contain("Invalid");
+    }
+
+    [Test, Order(30)]
+    public async Task CreateOrder_ShouldFailAndReturnBadRequest_IfInvalidRequestModelFormat()
+    {
+        //Arrange
+        httpClient.DefaultRequestHeaders.Remove("X-API-KEY");
+        httpClient.DefaultRequestHeaders.Add("X-API-KEY", _chosenApiKey);
+        TestCreateOrderRequestModel testCreateOrderRequestModel = new TestCreateOrderRequestModel();
+        testCreateOrderRequestModel.Comment = "UserComment";
+        testCreateOrderRequestModel.FirstName = "UserFirstName";
+        testCreateOrderRequestModel.LastName = "UserLastName";
+        testCreateOrderRequestModel.Country = "UserCountry";
+        testCreateOrderRequestModel.City = "UserCity";
+        testCreateOrderRequestModel.PostalCode = "UserPostalCode";
+        testCreateOrderRequestModel.Address = "UserAddress";
+        testCreateOrderRequestModel.PhoneNumber = "UserPhoneNumber";
+        testCreateOrderRequestModel.IsShippingAddressDifferent = true;
+        testCreateOrderRequestModel.AltFirstName = "AltUserFirstName";
+        testCreateOrderRequestModel.AltLastName = "AltUserLastName";
+        testCreateOrderRequestModel.AltCountry = "AltUserCountry";
+        testCreateOrderRequestModel.AltCity = "AltUserCity";
+        testCreateOrderRequestModel.AltPostalCode = "AltUserPostalCode";
+        testCreateOrderRequestModel.AltAddress = "AltUserAddress";
+        testCreateOrderRequestModel.AltPhoneNumber = "AltUserPhoneNumber";
+        testCreateOrderRequestModel.UserId = _chosenUserId;
+        testCreateOrderRequestModel.PaymentProcessorSessionId = "paymentProcessorSessionId";
+        testCreateOrderRequestModel.OrderItemRequestModels.Add(new TestOrderItemRequestModel()
+        {
+            Quantity = 3,
+            VariantId = _chosenVariantId
+        });
+        testCreateOrderRequestModel.PaymentOptionId = _chosenPaymentOptionId;
+        testCreateOrderRequestModel.ShippingOptionId = _chosenShippingOptionId;
+        testCreateOrderRequestModel.UserCouponId = _chosenUserCouponId;
+
+        //Act
+        HttpResponseMessage response = await httpClient.PostAsJsonAsync("api/order", testCreateOrderRequestModel); //email property is missing and thus the request model is invalid
+
+        //Assert
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Test, Order(40)]
+    public async Task CreateOrder_ShouldFailAndReturnBadRequest_IfNoOrderItemsInRequestModel()
+    {
+        //Arrange
+        httpClient.DefaultRequestHeaders.Remove("X-API-KEY");
+        httpClient.DefaultRequestHeaders.Add("X-API-KEY", _chosenApiKey);
+        TestCreateOrderRequestModel testCreateOrderRequestModel = new TestCreateOrderRequestModel();
+        testCreateOrderRequestModel.Comment = "UserComment";
+        testCreateOrderRequestModel.Email = "user@gmail.com";
+        testCreateOrderRequestModel.FirstName = "UserFirstName";
+        testCreateOrderRequestModel.LastName = "UserLastName";
+        testCreateOrderRequestModel.Country = "UserCountry";
+        testCreateOrderRequestModel.City = "UserCity";
+        testCreateOrderRequestModel.PostalCode = "UserPostalCode";
+        testCreateOrderRequestModel.Address = "UserAddress";
+        testCreateOrderRequestModel.PhoneNumber = "UserPhoneNumber";
+        testCreateOrderRequestModel.IsShippingAddressDifferent = true;
+        testCreateOrderRequestModel.AltFirstName = "AltUserFirstName";
+        testCreateOrderRequestModel.AltLastName = "AltUserLastName";
+        testCreateOrderRequestModel.AltCountry = "AltUserCountry";
+        testCreateOrderRequestModel.AltCity = "AltUserCity";
+        testCreateOrderRequestModel.AltPostalCode = "AltUserPostalCode";
+        testCreateOrderRequestModel.AltAddress = "AltUserAddress";
+        testCreateOrderRequestModel.AltPhoneNumber = "AltUserPhoneNumber";
+        testCreateOrderRequestModel.UserId = _chosenUserId;
+        testCreateOrderRequestModel.PaymentProcessorSessionId = "paymentProcessorSessionId";
+        testCreateOrderRequestModel.PaymentOptionId = _chosenPaymentOptionId;
+        testCreateOrderRequestModel.ShippingOptionId = _chosenShippingOptionId;
+        testCreateOrderRequestModel.UserCouponId = _chosenUserCouponId;
+        testCreateOrderRequestModel.OrderItemRequestModels = new List<TestOrderItemRequestModel>();
+
+        //Act
+        HttpResponseMessage response = await httpClient.PostAsJsonAsync("api/order", testCreateOrderRequestModel);
+        string? errorMessage = await TestUtilitiesLibrary.JsonUtilities.GetSingleStringValueFromBody(response, "errorMessage");
+
+        //Assert
+        errorMessage.Should().NotBeNull().And.Be("TheOrderMustHaveAtLeastOneOrderItem");
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Test, Order(50)]
+    public async Task CreateOrder_ShouldFailAndReturnBadRequest_IfAlternateShippingAddressIsSelectedButNotAllAltPropertiesAreFilled()
+    {
+        //Arrange
+        httpClient.DefaultRequestHeaders.Remove("X-API-KEY");
+        httpClient.DefaultRequestHeaders.Add("X-API-KEY", _chosenApiKey);
+        TestCreateOrderRequestModel testCreateOrderRequestModel = new TestCreateOrderRequestModel();
+        testCreateOrderRequestModel.Comment = "UserComment";
+        testCreateOrderRequestModel.Email = "user@gmail.com";
+        testCreateOrderRequestModel.FirstName = "UserFirstName";
+        testCreateOrderRequestModel.LastName = "UserLastName";
+        testCreateOrderRequestModel.Country = "UserCountry";
+        testCreateOrderRequestModel.City = "UserCity";
+        testCreateOrderRequestModel.PostalCode = "UserPostalCode";
+        testCreateOrderRequestModel.Address = "UserAddress";
+        testCreateOrderRequestModel.PhoneNumber = "UserPhoneNumber";
+        testCreateOrderRequestModel.IsShippingAddressDifferent = true;
+        testCreateOrderRequestModel.AltCountry = "AltUserCountry";
+        testCreateOrderRequestModel.AltCity = "AltUserCity";
+        testCreateOrderRequestModel.AltPostalCode = "AltUserPostalCode";
+        testCreateOrderRequestModel.AltAddress = "AltUserAddress";
+        testCreateOrderRequestModel.AltPhoneNumber = "AltUserPhoneNumber";
+        testCreateOrderRequestModel.OrderItemRequestModels.Add(new TestOrderItemRequestModel()
+        {
+            Quantity = 3,
+            VariantId = _chosenVariantId
+        });
+        testCreateOrderRequestModel.UserId = _chosenUserId;
+        testCreateOrderRequestModel.PaymentProcessorSessionId = "paymentProcessorSessionId";
+        testCreateOrderRequestModel.PaymentOptionId = _chosenPaymentOptionId;
+        testCreateOrderRequestModel.ShippingOptionId = _chosenShippingOptionId;
+        testCreateOrderRequestModel.UserCouponId = _chosenUserCouponId;
+
+        //Act
+        HttpResponseMessage response = await httpClient.PostAsJsonAsync("api/order", testCreateOrderRequestModel); //AltFirstName and AltLastName are missing, while IsShippingAddressDifferent property is true
+        string? errorMessage = await TestUtilitiesLibrary.JsonUtilities.GetSingleStringValueFromBody(response, "errorMessage");
+
+        //Assert
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        errorMessage.Should().NotBeNull().And.Be("AllTheAltFieldsNeedToBeFilledIfDifferentShippingAddress");
+    }
+
+    [Test, Order(60)]
+    public async Task CreateOrder_ShouldFailAndReturnBadRequest_IfInvalidPaymentOption()
+    {
+        //Arrange
+        httpClient.DefaultRequestHeaders.Remove("X-API-KEY");
+        httpClient.DefaultRequestHeaders.Add("X-API-KEY", _chosenApiKey);
+        TestCreateOrderRequestModel testCreateOrderRequestModel = new TestCreateOrderRequestModel();
+        testCreateOrderRequestModel.Comment = "UserComment";
+        testCreateOrderRequestModel.Email = "user@gmail.com";
+        testCreateOrderRequestModel.FirstName = "UserFirstName";
+        testCreateOrderRequestModel.LastName = "UserLastName";
+        testCreateOrderRequestModel.Country = "UserCountry";
+        testCreateOrderRequestModel.City = "UserCity";
+        testCreateOrderRequestModel.PostalCode = "UserPostalCode";
+        testCreateOrderRequestModel.Address = "UserAddress";
+        testCreateOrderRequestModel.PhoneNumber = "UserPhoneNumber";
+        testCreateOrderRequestModel.IsShippingAddressDifferent = true;
+        testCreateOrderRequestModel.AltFirstName = "AltUserFirstName";
+        testCreateOrderRequestModel.AltLastName = "AltUserLastName";
+        testCreateOrderRequestModel.AltCountry = "AltUserCountry";
+        testCreateOrderRequestModel.AltCity = "AltUserCity";
+        testCreateOrderRequestModel.AltPostalCode = "AltUserPostalCode";
+        testCreateOrderRequestModel.AltAddress = "AltUserAddress";
+        testCreateOrderRequestModel.AltPhoneNumber = "AltUserPhoneNumber";
+        testCreateOrderRequestModel.UserId = _chosenUserId;
+        testCreateOrderRequestModel.PaymentProcessorSessionId = "paymentProcessorSessionId";
+        testCreateOrderRequestModel.OrderItemRequestModels.Add(new TestOrderItemRequestModel()
+        {
+            Quantity = 3,
+            VariantId = _chosenVariantId
+        });
+        testCreateOrderRequestModel.PaymentOptionId = "bogusPaymentOptionId";
+        testCreateOrderRequestModel.ShippingOptionId = _chosenShippingOptionId;
+        testCreateOrderRequestModel.UserCouponId = _chosenUserCouponId;
+
+        //Act
+        HttpResponseMessage response = await httpClient.PostAsJsonAsync("api/order", testCreateOrderRequestModel);
+        string? errorMessage = await TestUtilitiesLibrary.JsonUtilities.GetSingleStringValueFromBody(response, "errorMessage");
+
+        //Assert
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+        errorMessage.Should().NotBeNull().And.Be("InvalidPaymentOption");
+    }
+
+    [Test, Order(70)]
+    public async Task CreateOrder_ShouldFailAndReturnBadRequest_IfInvalidShippingOption()
+    {
+        //Arrange
+        httpClient.DefaultRequestHeaders.Remove("X-API-KEY");
+        httpClient.DefaultRequestHeaders.Add("X-API-KEY", _chosenApiKey);
+        TestCreateOrderRequestModel testCreateOrderRequestModel = new TestCreateOrderRequestModel();
+        testCreateOrderRequestModel.Comment = "UserComment";
+        testCreateOrderRequestModel.Email = "user@gmail.com";
+        testCreateOrderRequestModel.FirstName = "UserFirstName";
+        testCreateOrderRequestModel.LastName = "UserLastName";
+        testCreateOrderRequestModel.Country = "UserCountry";
+        testCreateOrderRequestModel.City = "UserCity";
+        testCreateOrderRequestModel.PostalCode = "UserPostalCode";
+        testCreateOrderRequestModel.Address = "UserAddress";
+        testCreateOrderRequestModel.PhoneNumber = "UserPhoneNumber";
+        testCreateOrderRequestModel.IsShippingAddressDifferent = true;
+        testCreateOrderRequestModel.AltFirstName = "AltUserFirstName";
+        testCreateOrderRequestModel.AltLastName = "AltUserLastName";
+        testCreateOrderRequestModel.AltCountry = "AltUserCountry";
+        testCreateOrderRequestModel.AltCity = "AltUserCity";
+        testCreateOrderRequestModel.AltPostalCode = "AltUserPostalCode";
+        testCreateOrderRequestModel.AltAddress = "AltUserAddress";
+        testCreateOrderRequestModel.AltPhoneNumber = "AltUserPhoneNumber";
+        testCreateOrderRequestModel.UserId = _chosenUserId;
+        testCreateOrderRequestModel.PaymentProcessorSessionId = "paymentProcessorSessionId";
+        testCreateOrderRequestModel.OrderItemRequestModels.Add(new TestOrderItemRequestModel()
+        {
+            Quantity = 3,
+            VariantId = _chosenVariantId
+        });
+        testCreateOrderRequestModel.PaymentOptionId = _chosenPaymentOptionId;
+        testCreateOrderRequestModel.ShippingOptionId = "bogusShippingOptionId";
+        testCreateOrderRequestModel.UserCouponId = _chosenUserCouponId;
+
+        //Act
+        HttpResponseMessage response = await httpClient.PostAsJsonAsync("api/order", testCreateOrderRequestModel);
+        string? errorMessage = await TestUtilitiesLibrary.JsonUtilities.GetSingleStringValueFromBody(response, "errorMessage");
+
+        //Assert
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+        errorMessage.Should().NotBeNull().And.Be("InvalidShippingOption");
+    }
+
+    [Test, Order(80)]
+    public async Task CreateOrder_ShouldFailAndReturnBadRequest_IfInvalidCouponId()
+    {
+        //Arrange
+        httpClient.DefaultRequestHeaders.Remove("X-API-KEY");
+        httpClient.DefaultRequestHeaders.Add("X-API-KEY", _chosenApiKey);
+        TestCreateOrderRequestModel testCreateOrderRequestModel = new TestCreateOrderRequestModel();
+        testCreateOrderRequestModel.Comment = "UserComment";
+        testCreateOrderRequestModel.Email = "user@gmail.com";
+        testCreateOrderRequestModel.FirstName = "UserFirstName";
+        testCreateOrderRequestModel.LastName = "UserLastName";
+        testCreateOrderRequestModel.Country = "UserCountry";
+        testCreateOrderRequestModel.City = "UserCity";
+        testCreateOrderRequestModel.PostalCode = "UserPostalCode";
+        testCreateOrderRequestModel.Address = "UserAddress";
+        testCreateOrderRequestModel.PhoneNumber = "UserPhoneNumber";
+        testCreateOrderRequestModel.IsShippingAddressDifferent = true;
+        testCreateOrderRequestModel.AltFirstName = "AltUserFirstName";
+        testCreateOrderRequestModel.AltLastName = "AltUserLastName";
+        testCreateOrderRequestModel.AltCountry = "AltUserCountry";
+        testCreateOrderRequestModel.AltCity = "AltUserCity";
+        testCreateOrderRequestModel.AltPostalCode = "AltUserPostalCode";
+        testCreateOrderRequestModel.AltAddress = "AltUserAddress";
+        testCreateOrderRequestModel.AltPhoneNumber = "AltUserPhoneNumber";
+        testCreateOrderRequestModel.UserId = _chosenUserId;
+        testCreateOrderRequestModel.PaymentProcessorSessionId = "paymentProcessorSessionId";
+        testCreateOrderRequestModel.OrderItemRequestModels.Add(new TestOrderItemRequestModel()
+        {
+            Quantity = 3,
+            VariantId = _chosenVariantId
+        });
+        testCreateOrderRequestModel.PaymentOptionId = _chosenPaymentOptionId;
+        testCreateOrderRequestModel.ShippingOptionId = _chosenShippingOptionId;
+        testCreateOrderRequestModel.UserCouponId = "bogusUserCouponId";
+
+        //Act
+        HttpResponseMessage response = await httpClient.PostAsJsonAsync("api/order", testCreateOrderRequestModel);
+        string? errorMessage = await TestUtilitiesLibrary.JsonUtilities.GetSingleStringValueFromBody(response, "errorMessage");
+
+        //Assert
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+        errorMessage.Should().NotBeNull().And.Be("InvalidCouponIdWasGiven");
+    }
+
+    [Test, Order(90)]
+    public async Task CreateOrder_ShouldFailAndReturnBadRequest_IfUserDoesNotOwnCoupon()
+    {
+        //Arrange
+        httpClient.DefaultRequestHeaders.Remove("X-API-KEY");
+        httpClient.DefaultRequestHeaders.Add("X-API-KEY", _chosenApiKey);
+        TestCreateOrderRequestModel testCreateOrderRequestModel = new TestCreateOrderRequestModel();
+        testCreateOrderRequestModel.Comment = "UserComment";
+        testCreateOrderRequestModel.Email = "user@gmail.com";
+        testCreateOrderRequestModel.FirstName = "UserFirstName";
+        testCreateOrderRequestModel.LastName = "UserLastName";
+        testCreateOrderRequestModel.Country = "UserCountry";
+        testCreateOrderRequestModel.City = "UserCity";
+        testCreateOrderRequestModel.PostalCode = "UserPostalCode";
+        testCreateOrderRequestModel.Address = "UserAddress";
+        testCreateOrderRequestModel.PhoneNumber = "UserPhoneNumber";
+        testCreateOrderRequestModel.IsShippingAddressDifferent = true;
+        testCreateOrderRequestModel.AltFirstName = "AltUserFirstName";
+        testCreateOrderRequestModel.AltLastName = "AltUserLastName";
+        testCreateOrderRequestModel.AltCountry = "AltUserCountry";
+        testCreateOrderRequestModel.AltCity = "AltUserCity";
+        testCreateOrderRequestModel.AltPostalCode = "AltUserPostalCode";
+        testCreateOrderRequestModel.AltAddress = "AltUserAddress";
+        testCreateOrderRequestModel.AltPhoneNumber = "AltUserPhoneNumber";
+        testCreateOrderRequestModel.UserId = _chosenUserId;
+        testCreateOrderRequestModel.PaymentProcessorSessionId = "paymentProcessorSessionId";
+        testCreateOrderRequestModel.OrderItemRequestModels.Add(new TestOrderItemRequestModel()
+        {
+            Quantity = 3,
+            VariantId = _chosenVariantId
+        });
+        testCreateOrderRequestModel.PaymentOptionId = _chosenPaymentOptionId;
+        testCreateOrderRequestModel.ShippingOptionId = _chosenShippingOptionId;
+        testCreateOrderRequestModel.UserCouponId = _otherUserCouponId;
+
+        //Act
+        HttpResponseMessage response = await httpClient.PostAsJsonAsync("api/order", testCreateOrderRequestModel);
+        string? errorMessage = await TestUtilitiesLibrary.JsonUtilities.GetSingleStringValueFromBody(response, "errorMessage");
+
+        //Assert
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+        errorMessage.Should().NotBeNull().And.Be("InvalidCouponIdWasGiven");
+    }
+
+    [Test, Order(100)]
+    public async Task CreateOrder_ShouldFailAndReturnBadRequest_IfThereIsAtLeastOneInvalidVariant()
+    {
+        //Arrange
+        httpClient.DefaultRequestHeaders.Remove("X-API-KEY");
+        httpClient.DefaultRequestHeaders.Add("X-API-KEY", _chosenApiKey);
+        TestCreateOrderRequestModel testCreateOrderRequestModel = new TestCreateOrderRequestModel();
+        testCreateOrderRequestModel.Comment = "UserComment";
+        testCreateOrderRequestModel.Email = "user@gmail.com";
+        testCreateOrderRequestModel.FirstName = "UserFirstName";
+        testCreateOrderRequestModel.LastName = "UserLastName";
+        testCreateOrderRequestModel.Country = "UserCountry";
+        testCreateOrderRequestModel.City = "UserCity";
+        testCreateOrderRequestModel.PostalCode = "UserPostalCode";
+        testCreateOrderRequestModel.Address = "UserAddress";
+        testCreateOrderRequestModel.PhoneNumber = "UserPhoneNumber";
+        testCreateOrderRequestModel.IsShippingAddressDifferent = true;
+        testCreateOrderRequestModel.AltFirstName = "AltUserFirstName";
+        testCreateOrderRequestModel.AltLastName = "AltUserLastName";
+        testCreateOrderRequestModel.AltCountry = "AltUserCountry";
+        testCreateOrderRequestModel.AltCity = "AltUserCity";
+        testCreateOrderRequestModel.AltPostalCode = "AltUserPostalCode";
+        testCreateOrderRequestModel.AltAddress = "AltUserAddress";
+        testCreateOrderRequestModel.AltPhoneNumber = "AltUserPhoneNumber";
+        testCreateOrderRequestModel.UserId = _chosenUserId;
+        testCreateOrderRequestModel.PaymentProcessorSessionId = "paymentProcessorSessionId";
+        testCreateOrderRequestModel.OrderItemRequestModels.Add(new TestOrderItemRequestModel()
+        {
+            Quantity = 3,
+            VariantId = _chosenVariantId
+        });
+        testCreateOrderRequestModel.OrderItemRequestModels.Add(new TestOrderItemRequestModel()
+        {
+            Quantity = 2,
+            VariantId = "bogusVariantId"
+        });
+        testCreateOrderRequestModel.PaymentOptionId = _chosenPaymentOptionId;
+        testCreateOrderRequestModel.ShippingOptionId = _chosenShippingOptionId;
+        testCreateOrderRequestModel.UserCouponId = _chosenUserCouponId;
+
+        //Act
+        HttpResponseMessage response = await httpClient.PostAsJsonAsync("api/order", testCreateOrderRequestModel);
+        string? errorMessage = await TestUtilitiesLibrary.JsonUtilities.GetSingleStringValueFromBody(response, "errorMessage");
+
+        //Assert
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+        errorMessage.Should().NotBeNull().And.Be("InvalidVariantIdWasGiven");
+    }
+
+    [Test, Order(110)]
+    public async Task CreateOrder_ShouldFailAndReturnBadRequest_IfThereIsAtLeastOneVariantWithInsufficientStock()
+    {
+        //Arrange
+        httpClient.DefaultRequestHeaders.Remove("X-API-KEY");
+        httpClient.DefaultRequestHeaders.Add("X-API-KEY", _chosenApiKey);
+        TestCreateOrderRequestModel testCreateOrderRequestModel = new TestCreateOrderRequestModel();
+        testCreateOrderRequestModel.Comment = "UserComment";
+        testCreateOrderRequestModel.Email = "user@gmail.com";
+        testCreateOrderRequestModel.FirstName = "UserFirstName";
+        testCreateOrderRequestModel.LastName = "UserLastName";
+        testCreateOrderRequestModel.Country = "UserCountry";
+        testCreateOrderRequestModel.City = "UserCity";
+        testCreateOrderRequestModel.PostalCode = "UserPostalCode";
+        testCreateOrderRequestModel.Address = "UserAddress";
+        testCreateOrderRequestModel.PhoneNumber = "UserPhoneNumber";
+        testCreateOrderRequestModel.IsShippingAddressDifferent = true;
+        testCreateOrderRequestModel.AltFirstName = "AltUserFirstName";
+        testCreateOrderRequestModel.AltLastName = "AltUserLastName";
+        testCreateOrderRequestModel.AltCountry = "AltUserCountry";
+        testCreateOrderRequestModel.AltCity = "AltUserCity";
+        testCreateOrderRequestModel.AltPostalCode = "AltUserPostalCode";
+        testCreateOrderRequestModel.AltAddress = "AltUserAddress";
+        testCreateOrderRequestModel.AltPhoneNumber = "AltUserPhoneNumber";
+        testCreateOrderRequestModel.UserId = _chosenUserId;
+        testCreateOrderRequestModel.PaymentProcessorSessionId = "paymentProcessorSessionId";
+        testCreateOrderRequestModel.OrderItemRequestModels.Add(new TestOrderItemRequestModel()
+        {
+            Quantity = 1000000,
+            VariantId = _chosenVariantId
+        });
+        testCreateOrderRequestModel.PaymentOptionId = _chosenPaymentOptionId;
+        testCreateOrderRequestModel.ShippingOptionId = _chosenShippingOptionId;
+        testCreateOrderRequestModel.UserCouponId = _chosenUserCouponId;
+
+        //Act
+        HttpResponseMessage response = await httpClient.PostAsJsonAsync("api/order", testCreateOrderRequestModel);
+        string? errorMessage = await TestUtilitiesLibrary.JsonUtilities.GetSingleStringValueFromBody(response, "errorMessage");
+
+        //Assert
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        errorMessage.Should().NotBeNull().And.Be("InsufficientStockForVariant");
+    }
+
+    [Test, Order(120)]
+    public async Task CreateOrder_ShouldSucceedAndCreateOrder()
+    {
+        //Arrange
+        httpClient.DefaultRequestHeaders.Remove("X-API-KEY");
+        httpClient.DefaultRequestHeaders.Add("X-API-KEY", _chosenApiKey);
+        TestCreateOrderRequestModel testCreateOrderRequestModel = new TestCreateOrderRequestModel();
+        testCreateOrderRequestModel.Comment = "UserComment";
+        testCreateOrderRequestModel.Email = "user@gmail.com";
+        testCreateOrderRequestModel.FirstName = "UserFirstName";
+        testCreateOrderRequestModel.LastName = "UserLastName";
+        testCreateOrderRequestModel.Country = "UserCountry";
+        testCreateOrderRequestModel.City = "UserCity";
+        testCreateOrderRequestModel.PostalCode = "UserPostalCode";
+        testCreateOrderRequestModel.Address = "UserAddress";
+        testCreateOrderRequestModel.PhoneNumber = "UserPhoneNumber";
+        testCreateOrderRequestModel.IsShippingAddressDifferent = true;
+        testCreateOrderRequestModel.AltFirstName = "AltUserFirstName";
+        testCreateOrderRequestModel.AltLastName = "AltUserLastName";
+        testCreateOrderRequestModel.AltCountry = "AltUserCountry";
+        testCreateOrderRequestModel.AltCity = "AltUserCity";
+        testCreateOrderRequestModel.AltPostalCode = "AltUserPostalCode";
+        testCreateOrderRequestModel.AltAddress = "AltUserAddress";
+        testCreateOrderRequestModel.AltPhoneNumber = "AltUserPhoneNumber";
+        testCreateOrderRequestModel.UserId = _chosenUserId;
+        testCreateOrderRequestModel.PaymentProcessorSessionId = "paymentProcessorSessionId";
+        testCreateOrderRequestModel.OrderItemRequestModels.Add(new TestOrderItemRequestModel()
+        {
+            Quantity = 3,
+            VariantId = _chosenVariantId
+        });
+        testCreateOrderRequestModel.PaymentOptionId = _chosenPaymentOptionId;
+        testCreateOrderRequestModel.ShippingOptionId = _chosenShippingOptionId;
+        testCreateOrderRequestModel.UserCouponId = _chosenUserCouponId;
+
+        //Act
+        HttpResponseMessage response = await httpClient.PostAsJsonAsync("api/order", testCreateOrderRequestModel);
+        string? responseBody = await response.Content.ReadAsStringAsync();
+        TestOrder? testOrder = JsonSerializer.Deserialize<TestOrder>(responseBody, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+
+        HttpResponseMessage variantResponse = await httpClient.GetAsync($"api/variant/id/{_chosenVariantId}/includeDeactivated/true");
+        string? variantResponseBody = await variantResponse.Content.ReadAsStringAsync();
+        TestVariant? testVariant = JsonSerializer.Deserialize<TestVariant>(variantResponseBody, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+
+        HttpResponseMessage couponResponse = await httpClient.GetAsync($"api/coupon/{_chosenCouponId}/includeDeactivated/true");
+        string? couponResponseBody = await couponResponse.Content.ReadAsStringAsync();
+        TestCoupon? testCoupon = JsonSerializer.Deserialize<TestCoupon>(couponResponseBody, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+
+        //Assert
+        response.StatusCode.Should().Be(HttpStatusCode.Created);
+        testOrder.Should().NotBeNull();
+        testOrder!.Comment.Should().Be(testCreateOrderRequestModel.Comment);
+        testOrder.OrderStatus.Should().Be("Pending");
+        testOrder!.OrderAddress.Should().NotBeNull();
+        testOrder!.OrderAddress!.Email.Should().Be(testCreateOrderRequestModel.Email);
+        testOrder!.OrderAddress.FirstName.Should().Be(testCreateOrderRequestModel.FirstName);
+        testOrder!.OrderAddress.LastName.Should().Be(testCreateOrderRequestModel.LastName);
+        testOrder!.OrderAddress.Country.Should().Be(testCreateOrderRequestModel.Country);
+        testOrder!.OrderAddress.City.Should().Be(testCreateOrderRequestModel.City);
+        testOrder!.OrderAddress.PostalCode.Should().Be(testCreateOrderRequestModel.PostalCode);
+        testOrder!.OrderAddress.Address.Should().Be(testCreateOrderRequestModel.Address);
+        testOrder!.OrderAddress.PhoneNumber.Should().Be(testCreateOrderRequestModel.PhoneNumber);
+        testOrder!.OrderAddress.IsShippingAddressDifferent.Should().Be(testCreateOrderRequestModel.IsShippingAddressDifferent);
+        testOrder!.OrderAddress.AltFirstName.Should().Be(testCreateOrderRequestModel.AltFirstName);
+        testOrder!.OrderAddress.AltLastName.Should().Be(testCreateOrderRequestModel.AltLastName);
+        testOrder!.OrderAddress.AltCountry.Should().Be(testCreateOrderRequestModel.AltCountry);
+        testOrder!.OrderAddress.AltCity.Should().Be(testCreateOrderRequestModel.AltCity);
+        testOrder!.OrderAddress.AltPostalCode.Should().Be(testCreateOrderRequestModel.AltPostalCode);
+        testOrder!.OrderAddress.AltAddress.Should().Be(testCreateOrderRequestModel.AltAddress);
+        testOrder!.OrderAddress.AltPhoneNumber.Should().Be(testCreateOrderRequestModel.AltPhoneNumber);
+        testOrder.UserId.Should().Be(testCreateOrderRequestModel.UserId);
+        testOrder.PaymentDetails.Should().NotBeNull();
+        testOrder.PaymentDetails!.PaymentCurrency.Should().Be("N/A");
+        testOrder.PaymentDetails!.AmountPaidInCustomerCurrency.Should().Be(0);
+        testOrder.PaymentDetails!.AmountPaidInEuro.Should().Be(0);
+        testOrder.PaymentDetails!.NetAmountPaidInEuro.Should().Be(0);
+        testOrder.PaymentDetails!.PaymentProcessorSessionId.Should().Be(testCreateOrderRequestModel.PaymentProcessorSessionId);
+        testOrder.PaymentDetails!.PaymentOptionId.Should().Be(testCreateOrderRequestModel.PaymentOptionId);
+        testOrder.PaymentDetails!.PaymentStatus.Should().Be("Pending");
+        testOrder.OrderItems.Should().HaveCount(1);
+        testOrder.OrderItems[0].Quantity.Should().Be(testCreateOrderRequestModel.OrderItemRequestModels[0].Quantity);
+        testOrder.OrderItems[0].UnitPriceAtOrder.Should().Be(testVariant!.Price - (testVariant.Price * testVariant.Discount!.Percentage / 100));
+        testOrder.ShippingOptionId.Should().Be(testCreateOrderRequestModel.ShippingOptionId);
+        testOrder.UserCouponId.Should().Be(testCreateOrderRequestModel.UserCouponId);
+
+        testVariant!.UnitsInStock.Should().NotBeNull().And.BeLessThan(10);
+        testVariant.ExistsInOrder.Should().BeTrue();
+        testVariant.VariantImages[0].Image!.ExistsInOrder.Should().BeTrue();
+
+        TestUserCoupon chosenUserCoupon = testCoupon!.UserCoupons.FirstOrDefault(userCoupon => userCoupon.Id == _chosenUserCouponId)!;
+        chosenUserCoupon.ExistsInOrder.Should().BeTrue();
+        chosenUserCoupon.TimesUsed.Should().Be(1);
+
+        _chosenOrderId = testOrder.Id;
+    }
+
+    [Test, Order(130)]
+    public async Task CreateOrder_ShouldFailAndReturnBadRequest_IfCouponHasUsageHasExceededMaxLimit()
+    {
+        //this is the same order essentially(still valid since there are enought units in stock), but this time the user has exceeded the max usage for the coupon
+
+        //Arrange
+        httpClient.DefaultRequestHeaders.Remove("X-API-KEY");
+        httpClient.DefaultRequestHeaders.Add("X-API-KEY", _chosenApiKey);
+        TestCreateOrderRequestModel testCreateOrderRequestModel = new TestCreateOrderRequestModel();
+        testCreateOrderRequestModel.Comment = "UserComment";
+        testCreateOrderRequestModel.Email = "user@gmail.com";
+        testCreateOrderRequestModel.FirstName = "UserFirstName";
+        testCreateOrderRequestModel.LastName = "UserLastName";
+        testCreateOrderRequestModel.Country = "UserCountry";
+        testCreateOrderRequestModel.City = "UserCity";
+        testCreateOrderRequestModel.PostalCode = "UserPostalCode";
+        testCreateOrderRequestModel.Address = "UserAddress";
+        testCreateOrderRequestModel.PhoneNumber = "UserPhoneNumber";
+        testCreateOrderRequestModel.IsShippingAddressDifferent = true;
+        testCreateOrderRequestModel.AltFirstName = "AltUserFirstName";
+        testCreateOrderRequestModel.AltLastName = "AltUserLastName";
+        testCreateOrderRequestModel.AltCountry = "AltUserCountry";
+        testCreateOrderRequestModel.AltCity = "AltUserCity";
+        testCreateOrderRequestModel.AltPostalCode = "AltUserPostalCode";
+        testCreateOrderRequestModel.AltAddress = "AltUserAddress";
+        testCreateOrderRequestModel.AltPhoneNumber = "AltUserPhoneNumber";
+        testCreateOrderRequestModel.UserId = _chosenUserId;
+        testCreateOrderRequestModel.PaymentProcessorSessionId = "paymentProcessorSessionId";
+        testCreateOrderRequestModel.OrderItemRequestModels.Add(new TestOrderItemRequestModel()
+        {
+            Quantity = 3,
+            VariantId = _chosenVariantId
+        });
+        testCreateOrderRequestModel.PaymentOptionId = _chosenPaymentOptionId;
+        testCreateOrderRequestModel.ShippingOptionId = _chosenShippingOptionId;
+        testCreateOrderRequestModel.UserCouponId = _chosenUserCouponId;
+
+        //Act
+        HttpResponseMessage response = await httpClient.PostAsJsonAsync("api/order", testCreateOrderRequestModel);
+        string? errorMessage = await TestUtilitiesLibrary.JsonUtilities.GetSingleStringValueFromBody(response, "errorMessage");
+
+        //Assert
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        errorMessage.Should().NotBeNull().And.Be("CouponUsageLimitExceeded");
+    }
+
+    [Test, Order(140)]
+    public async Task GetOrders_ShouldFailAndReturnUnauthorized_IfAPIKeyIsInvalid()
+    {
+        //Arrange
+        httpClient.DefaultRequestHeaders.Remove("X-API-KEY");
+        httpClient.DefaultRequestHeaders.Add("X-API-KEY", "bogusKey");
+
+        //Act
+        HttpResponseMessage response = await httpClient.GetAsync("api/order/amount/10"); //here 10 is just an arbitraty value for the amount
+        string? errorMessage = await TestUtilitiesLibrary.JsonUtilities.GetSingleStringValueFromBody(response, "errorMessage");
+
+        //Assert
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+        errorMessage.Should().NotBeNull().And.Contain("Invalid");
+    }
+
+    [Test, Order(150)]
+    public async Task GetOrders_ShouldSucceedAndReturnOrders()
+    {
+        //Arrange
+        httpClient.DefaultRequestHeaders.Remove("X-API-KEY");
+        httpClient.DefaultRequestHeaders.Add("X-API-KEY", _chosenApiKey);
+
+        //Act
+        HttpResponseMessage response = await httpClient.GetAsync("api/order/amount/10");
+        string? responseBody = await response.Content.ReadAsStringAsync();
+        List<TestOrder>? testOrders = JsonSerializer.Deserialize<List<TestOrder>>(responseBody, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+
+        //Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        testOrders.Should().NotBeNull().And.HaveCount(1);
+    }
+
+    [Test, Order(160)]
+    public async Task GetOrder_ShouldFailAndReturnUnauthorized_IfAPIKeyIsInvalid()
+    {
+        //Arrange
+        httpClient.DefaultRequestHeaders.Remove("X-API-KEY");
+        httpClient.DefaultRequestHeaders.Add("X-API-KEY", "bogusKey");
+        string orderId = _chosenOrderId!;
+
+        //Act
+        HttpResponseMessage response = await httpClient.GetAsync($"api/order/{orderId}");
+        string? errorMessage = await TestUtilitiesLibrary.JsonUtilities.GetSingleStringValueFromBody(response, "errorMessage");
+
+        //Assert
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+        errorMessage.Should().NotBeNull().And.Contain("Invalid");
+    }
+
+    [Test, Order(170)]
+    public async Task GetOrder_ShouldFailAndReturnNotFound_IfOrderNotInSystem()
+    {
+        //Arrange
+        httpClient.DefaultRequestHeaders.Remove("X-API-KEY");
+        httpClient.DefaultRequestHeaders.Add("X-API-KEY", _chosenApiKey);
+        string bogusOrderId = "bogusOrderId";
+
+        //Act
+        HttpResponseMessage response = await httpClient.GetAsync($"api/order/{bogusOrderId}");
+
+        //Assert
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Test, Order(180)]
+    public async Task GetOrder_ShouldSucceedAndReturnOrder()
+    {
+        //Arrange
+        httpClient.DefaultRequestHeaders.Remove("X-API-KEY");
+        httpClient.DefaultRequestHeaders.Add("X-API-KEY", _chosenApiKey);
+        string orderId = _chosenOrderId!;
+
+        //Act
+        HttpResponseMessage response = await httpClient.GetAsync($"api/order/{orderId}");
+        string? responseBody = await response.Content.ReadAsStringAsync();
+        TestOrder? testOrder = JsonSerializer.Deserialize<TestOrder>(responseBody, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+
+        //Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        testOrder.Should().NotBeNull();
+        testOrder!.Comment.Should().NotBeNull();
+        testOrder.OrderStatus.Should().Be("Pending");
+        testOrder!.OrderAddress.Should().NotBeNull();
+        testOrder!.OrderAddress!.Email.Should().NotBeNull();
+        testOrder!.OrderAddress.FirstName.Should().NotBeNull();
+        testOrder!.OrderAddress.LastName.Should().NotBeNull();
+        testOrder!.OrderAddress.Country.Should().NotBeNull();
+        testOrder!.OrderAddress.City.Should().NotBeNull();
+        testOrder!.OrderAddress.PostalCode.Should().NotBeNull();
+        testOrder!.OrderAddress.Address.Should().NotBeNull();
+        testOrder!.OrderAddress.PhoneNumber.Should().NotBeNull();
+        testOrder!.OrderAddress.IsShippingAddressDifferent.Should().NotBeNull().And.BeTrue();
+        testOrder!.OrderAddress.AltFirstName.Should().NotBeNull();
+        testOrder!.OrderAddress.AltLastName.Should().NotBeNull();
+        testOrder!.OrderAddress.AltCountry.Should().NotBeNull();
+        testOrder!.OrderAddress.AltCity.Should().NotBeNull();
+        testOrder!.OrderAddress.AltPostalCode.Should().NotBeNull();
+        testOrder!.OrderAddress.AltAddress.Should().NotBeNull();
+        testOrder!.OrderAddress.AltPhoneNumber.Should().NotBeNull();
+        testOrder.UserId.Should().NotBeNull();
+        testOrder.PaymentDetails.Should().NotBeNull();
+        testOrder.PaymentDetails!.PaymentCurrency.Should().Be("N/A");
+        testOrder.PaymentDetails!.AmountPaidInCustomerCurrency.Should().Be(0);
+        testOrder.PaymentDetails!.AmountPaidInEuro.Should().Be(0);
+        testOrder.PaymentDetails!.NetAmountPaidInEuro.Should().Be(0);
+        testOrder.PaymentDetails!.PaymentProcessorSessionId.Should().NotBeNull();
+        testOrder.PaymentDetails!.PaymentOptionId.Should().NotBeNull();
+        testOrder.PaymentDetails!.PaymentStatus.Should().Be("Pending");
+        testOrder.OrderItems.Should().HaveCount(1);
+        testOrder.OrderItems[0].Quantity.Should().NotBeNull();
+        testOrder.OrderItems[0].UnitPriceAtOrder.Should().NotBeNull();
+        testOrder.ShippingOptionId.Should().NotBeNull();
+        testOrder.UserCouponId.Should().NotBeNull();
+    }
+
+    [Test, Order(190)]
+    public async Task UpdateOrderStatus_ShouldFailAndReturnUnauthorized_IfAPIKeyIsInvalid()
+    {
+        //Arrange
+        httpClient.DefaultRequestHeaders.Remove("X-API-KEY");
+        httpClient.DefaultRequestHeaders.Add("X-API-KEY", "bogusKey");
+        TestUpdateOrderStatusRequestModel testUpdateOrderStatusRequestModel = new TestUpdateOrderStatusRequestModel();
+        testUpdateOrderStatusRequestModel.OrderId = _chosenOrderId;
+        testUpdateOrderStatusRequestModel.NewOrderStatus = "Confirmed";
+
+        //Act
+        HttpResponseMessage response = await httpClient.PutAsJsonAsync("api/order/updateOrderStatus", testUpdateOrderStatusRequestModel);
+        string? errorMessage = await TestUtilitiesLibrary.JsonUtilities.GetSingleStringValueFromBody(response, "errorMessage");
+
+        //Assert
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+        errorMessage.Should().NotBeNull().And.Contain("Invalid");
+    }
+
+    [Test, Order(200)]
+    public async Task UpdateOrderStatus_ShouldFailAndReturnNotFound_IfInvalidRequestModelFormat()
+    {
+        //Arrange
+        httpClient.DefaultRequestHeaders.Remove("X-API-KEY");
+        httpClient.DefaultRequestHeaders.Add("X-API-KEY", _chosenApiKey);
+        TestUpdateOrderStatusRequestModel testUpdateOrderStatusRequestModel = new TestUpdateOrderStatusRequestModel();
+        testUpdateOrderStatusRequestModel.OrderId = _chosenOrderId;
+
+        //Act
+        HttpResponseMessage response = await httpClient.PutAsJsonAsync("api/order/updateOrderStatus", testUpdateOrderStatusRequestModel); //NewOrderStatus property is missing
+
+        //Assert
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Test, Order(210)]
+    public async Task UpdateOrderStatus_ShouldFailAndReturnNotFound_IfOrderNotInSystem()
+    {
+        //Arrange
+        httpClient.DefaultRequestHeaders.Remove("X-API-KEY");
+        httpClient.DefaultRequestHeaders.Add("X-API-KEY", _chosenApiKey);
+        TestUpdateOrderStatusRequestModel testUpdateOrderStatusRequestModel = new TestUpdateOrderStatusRequestModel();
+        testUpdateOrderStatusRequestModel.OrderId = "bogusOrderId";
+        testUpdateOrderStatusRequestModel.NewOrderStatus = "Confirmed";
+
+        //Act
+        HttpResponseMessage response = await httpClient.PutAsJsonAsync("api/order/updateOrderStatus", testUpdateOrderStatusRequestModel);
+        string? errorMessage = await TestUtilitiesLibrary.JsonUtilities.GetSingleStringValueFromBody(response, "errorMessage");
+
+        //Assert
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+        errorMessage.Should().NotBeNull().And.Be("EntityNotFoundWithGivenId");
+    }
+
+    [Test, Order(220)]
+    public async Task UpdateOrderStatus_ShouldFailAndReturnBadRequest_IfInvalidNewOrderStatus()
+    {
+        //Arrange
+        httpClient.DefaultRequestHeaders.Remove("X-API-KEY");
+        httpClient.DefaultRequestHeaders.Add("X-API-KEY", _chosenApiKey);
+        TestUpdateOrderStatusRequestModel testUpdateOrderStatusRequestModel = new TestUpdateOrderStatusRequestModel();
+        testUpdateOrderStatusRequestModel.OrderId = _chosenOrderId;
+        testUpdateOrderStatusRequestModel.NewOrderStatus = "Shipped"; //the order status can not become from Pending to Shipped
+
+        //Act
+        HttpResponseMessage response = await httpClient.PutAsJsonAsync("api/order/updateOrderStatus", testUpdateOrderStatusRequestModel);
+        string? errorMessage = await TestUtilitiesLibrary.JsonUtilities.GetSingleStringValueFromBody(response, "errorMessage");
+
+        //Assert
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        errorMessage.Should().NotBeNull().And.Be("InvalidNewOrderState");
+    }
+
+    [Test, Order(230)]
+    public async Task UpdateOrderStatus_ShouldSucceedAndUpdateOrderStatus()
+    {
+        //Arrange
+        httpClient.DefaultRequestHeaders.Remove("X-API-KEY");
+        httpClient.DefaultRequestHeaders.Add("X-API-KEY", _chosenApiKey);
+        TestUpdateOrderStatusRequestModel testUpdateOrderStatusRequestModel = new TestUpdateOrderStatusRequestModel();
+        testUpdateOrderStatusRequestModel.OrderId = _chosenOrderId;
+        testUpdateOrderStatusRequestModel.NewOrderStatus = "Confirmed";
+
+        //Act
+        HttpResponseMessage response = await httpClient.PutAsJsonAsync("api/order/updateOrderStatus", testUpdateOrderStatusRequestModel);
+        HttpResponseMessage getResponse = await httpClient.GetAsync($"api/order/{_chosenOrderId}");
+        string? getResponseBody = await getResponse.Content.ReadAsStringAsync();
+        TestOrder? testOrder = JsonSerializer.Deserialize<TestOrder>(getResponseBody, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+
+        //Assert
+        response.StatusCode.Should().Be(HttpStatusCode.NoContent);
+        testOrder!.Should().NotBeNull();
+        testOrder!.OrderStatus.Should().NotBeNull().And.Be(testUpdateOrderStatusRequestModel.NewOrderStatus);
+    }
+
+    [Test, Order(240)]
+    public async Task UpdateOrder_ShouldFailAndReturnUnauthorized_IfAPIKeyIsInvalid()
+    {
+        //Arrange
+        httpClient.DefaultRequestHeaders.Remove("X-API-KEY");
+        httpClient.DefaultRequestHeaders.Add("X-API-KEY", "bogusKey");
+        TestUpdateOrderRequestModel testUpdateOrderRequestModel = new TestUpdateOrderRequestModel();
+        testUpdateOrderRequestModel.Email = "updatedUser@gmail.com";
+        testUpdateOrderRequestModel.FirstName = "UpdatedUserFirstName";
+        testUpdateOrderRequestModel.LastName = "UpdatedUserLastName";
+        testUpdateOrderRequestModel.Country = "UpdatedUserCountry";
+        testUpdateOrderRequestModel.City = "UpdatedUserCity";
+        testUpdateOrderRequestModel.PostalCode = "UpdatedUserPostalCode";
+        testUpdateOrderRequestModel.Address = "UpdatedUserAddress";
+        testUpdateOrderRequestModel.PhoneNumber = "UpdatedUserPhoneNumber";
+        testUpdateOrderRequestModel.IsShippingAddressDifferent = true;
+        testUpdateOrderRequestModel.AltFirstName = "UpdatedAltUserFirstName";
+        testUpdateOrderRequestModel.AltLastName = "UpdatedAltUserLastName";
+        testUpdateOrderRequestModel.AltCountry = "UpdatedAltUserCountry";
+        testUpdateOrderRequestModel.AltCity = "UpdatedAltUserCity";
+        testUpdateOrderRequestModel.AltPostalCode = "UpdatedAltUserPostalCode";
+        testUpdateOrderRequestModel.AltAddress = "UpdatedAltUserAddress";
+        testUpdateOrderRequestModel.AltPhoneNumber = "UpdatedAltUserPhoneNumber";
+        testUpdateOrderRequestModel.PaymentProcessorSessionId = "paymentProcessorSessionId"; //find the order based on the paymentProcessorSessionId
+        testUpdateOrderRequestModel.PaymentStatus = "Paid";
+        testUpdateOrderRequestModel.PaymentCurrency = "eur";
+        testUpdateOrderRequestModel.AmountPaidInCustomerCurrency = 193.5m;
+        testUpdateOrderRequestModel.AmountPaidInEuro = 193.5m;
+        testUpdateOrderRequestModel.NetAmountPaidInEuro = 170m; //theoretically this is calculated after stripe fee
+        testUpdateOrderRequestModel.OrderItemRequestModels = new List<TestOrderItemRequestModel>() { new TestOrderItemRequestModel() { Quantity = 5, VariantId = _otherChosenVariantId } };
+        testUpdateOrderRequestModel.UserCouponId = _otherChosenUserCouponId;
+
+        //Act
+        HttpResponseMessage response = await httpClient.PutAsJsonAsync("api/order", testUpdateOrderRequestModel);
+        string? errorMessage = await TestUtilitiesLibrary.JsonUtilities.GetSingleStringValueFromBody(response, "errorMessage");
+
+        //Assert
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+        errorMessage.Should().NotBeNull().And.Contain("Invalid");
+    }
+
+    [Test, Order(250)]
+    public async Task UpdateOrder_ShouldFailAndReturnNotFound_IfInvalidRequestModelFormat()
+    {
+        //Arrange
+        httpClient.DefaultRequestHeaders.Remove("X-API-KEY");
+        httpClient.DefaultRequestHeaders.Add("X-API-KEY", _chosenApiKey);
+        TestUpdateOrderRequestModel testUpdateOrderRequestModel = new TestUpdateOrderRequestModel();
+        testUpdateOrderRequestModel.Email = "updatedUser@gmail.com";
+        testUpdateOrderRequestModel.FirstName = "UpdatedUserFirstName";
+        testUpdateOrderRequestModel.LastName = "UpdatedUserLastName";
+        testUpdateOrderRequestModel.Country = "UpdatedUserCountry";
+        testUpdateOrderRequestModel.City = "UpdatedUserCity";
+        testUpdateOrderRequestModel.PostalCode = "UpdatedUserPostalCode";
+        testUpdateOrderRequestModel.Address = "UpdatedUserAddress";
+        testUpdateOrderRequestModel.PhoneNumber = "UpdatedUserPhoneNumber";
+        testUpdateOrderRequestModel.IsShippingAddressDifferent = true;
+        testUpdateOrderRequestModel.AltFirstName = "UpdatedAltUserFirstName";
+        testUpdateOrderRequestModel.AltLastName = "UpdatedAltUserLastName";
+        testUpdateOrderRequestModel.AltCountry = "UpdatedAltUserCountry";
+        testUpdateOrderRequestModel.AltCity = "UpdatedAltUserCity";
+        testUpdateOrderRequestModel.AltPostalCode = "UpdatedAltUserPostalCode";
+        testUpdateOrderRequestModel.AltAddress = "UpdatedAltUserAddress";
+        testUpdateOrderRequestModel.AltPhoneNumber = "UpdatedAltUserPhoneNumber";
+        testUpdateOrderRequestModel.PaymentProcessorSessionId = "paymentProcessorSessionId"; //find the order based on the paymentProcessorSessionId
+        testUpdateOrderRequestModel.PaymentStatus = "Paid";
+        testUpdateOrderRequestModel.PaymentCurrency = "eur";
+        testUpdateOrderRequestModel.AmountPaidInCustomerCurrency = -150;
+        testUpdateOrderRequestModel.AmountPaidInEuro = 193.5m;
+        testUpdateOrderRequestModel.NetAmountPaidInEuro = 170m; //theoretically this is calculated after stripe fee
+        testUpdateOrderRequestModel.OrderItemRequestModels = new List<TestOrderItemRequestModel>() { new TestOrderItemRequestModel() { Quantity = 5, VariantId = _otherChosenVariantId } };
+        testUpdateOrderRequestModel.UserCouponId = _otherChosenUserCouponId;
+
+        //Act
+        HttpResponseMessage response = await httpClient.PutAsJsonAsync("api/order", testUpdateOrderRequestModel); //the amounts can not be negative and thus the request model is invalid
+
+        //Assert
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Test, Order(260)]
+    public async Task UpdateOrder_ShouldFailAndReturnNotFound_IfOrderNotInSystemBasedOnOrderId()
+    {
+        //Arrange
+        TestUpdateOrderRequestModel testUpdateOrderRequestModel = new TestUpdateOrderRequestModel();
+        testUpdateOrderRequestModel.Email = "updatedUser@gmail.com";
+        testUpdateOrderRequestModel.FirstName = "UpdatedUserFirstName";
+        testUpdateOrderRequestModel.LastName = "UpdatedUserLastName";
+        testUpdateOrderRequestModel.Country = "UpdatedUserCountry";
+        testUpdateOrderRequestModel.City = "UpdatedUserCity";
+        testUpdateOrderRequestModel.PostalCode = "UpdatedUserPostalCode";
+        testUpdateOrderRequestModel.Address = "UpdatedUserAddress";
+        testUpdateOrderRequestModel.PhoneNumber = "UpdatedUserPhoneNumber";
+        testUpdateOrderRequestModel.IsShippingAddressDifferent = true;
+        testUpdateOrderRequestModel.AltFirstName = "UpdatedAltUserFirstName";
+        testUpdateOrderRequestModel.AltLastName = "UpdatedAltUserLastName";
+        testUpdateOrderRequestModel.AltCountry = "UpdatedAltUserCountry";
+        testUpdateOrderRequestModel.AltCity = "UpdatedAltUserCity";
+        testUpdateOrderRequestModel.AltPostalCode = "UpdatedAltUserPostalCode";
+        testUpdateOrderRequestModel.AltAddress = "UpdatedAltUserAddress";
+        testUpdateOrderRequestModel.AltPhoneNumber = "UpdatedAltUserPhoneNumber";
+        testUpdateOrderRequestModel.Id = "bogusOrderId";
+        testUpdateOrderRequestModel.PaymentStatus = "Paid";
+        testUpdateOrderRequestModel.PaymentCurrency = "eur";
+        testUpdateOrderRequestModel.AmountPaidInCustomerCurrency = 193.5m; //this was the amount?
+        testUpdateOrderRequestModel.AmountPaidInEuro = 193.5m;
+        testUpdateOrderRequestModel.NetAmountPaidInEuro = 170m; //theoretically this is calculated after stripe fee
+        testUpdateOrderRequestModel.OrderItemRequestModels = new List<TestOrderItemRequestModel>() { new TestOrderItemRequestModel() { Quantity = 5, VariantId = _otherChosenVariantId } };
+        testUpdateOrderRequestModel.UserCouponId = _otherChosenUserCouponId;
+
+        //Act
+        HttpResponseMessage response = await httpClient.PutAsJsonAsync("api/order", testUpdateOrderRequestModel);
+        string? errorMessage = await TestUtilitiesLibrary.JsonUtilities.GetSingleStringValueFromBody(response, "errorMessage");
+
+        //Assert
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+        errorMessage.Should().NotBeNull().And.Be("EntityNotFoundWithGivenId");
+    }
+
+    [Test, Order(270)]
+    public async Task UpdateOrder_ShouldFailAndReturnNotFound_IfOrderNotInSystemBasedOnPaymentProcessorSessionId()
+    {
+        //Arrange
+        TestUpdateOrderRequestModel testUpdateOrderRequestModel = new TestUpdateOrderRequestModel();
+        testUpdateOrderRequestModel.Email = "updatedUser@gmail.com";
+        testUpdateOrderRequestModel.FirstName = "UpdatedUserFirstName";
+        testUpdateOrderRequestModel.LastName = "UpdatedUserLastName";
+        testUpdateOrderRequestModel.Country = "UpdatedUserCountry";
+        testUpdateOrderRequestModel.City = "UpdatedUserCity";
+        testUpdateOrderRequestModel.PostalCode = "UpdatedUserPostalCode";
+        testUpdateOrderRequestModel.Address = "UpdatedUserAddress";
+        testUpdateOrderRequestModel.PhoneNumber = "UpdatedUserPhoneNumber";
+        testUpdateOrderRequestModel.IsShippingAddressDifferent = true;
+        testUpdateOrderRequestModel.AltFirstName = "UpdatedAltUserFirstName";
+        testUpdateOrderRequestModel.AltLastName = "UpdatedAltUserLastName";
+        testUpdateOrderRequestModel.AltCountry = "UpdatedAltUserCountry";
+        testUpdateOrderRequestModel.AltCity = "UpdatedAltUserCity";
+        testUpdateOrderRequestModel.AltPostalCode = "UpdatedAltUserPostalCode";
+        testUpdateOrderRequestModel.AltAddress = "UpdatedAltUserAddress";
+        testUpdateOrderRequestModel.AltPhoneNumber = "UpdatedAltUserPhoneNumber";
+        testUpdateOrderRequestModel.PaymentProcessorSessionId = "bogusPaymentProcessorSessionId";
+        testUpdateOrderRequestModel.PaymentStatus = "Paid";
+        testUpdateOrderRequestModel.PaymentCurrency = "eur";
+        testUpdateOrderRequestModel.AmountPaidInCustomerCurrency = 193.5m; //this was the amount?
+        testUpdateOrderRequestModel.AmountPaidInEuro = 193.5m;
+        testUpdateOrderRequestModel.NetAmountPaidInEuro = 170m; //theoretically this is calculated after stripe fee
+        testUpdateOrderRequestModel.OrderItemRequestModels = new List<TestOrderItemRequestModel>() { new TestOrderItemRequestModel() { Quantity = 5, VariantId = _otherChosenVariantId } };
+        testUpdateOrderRequestModel.UserCouponId = _otherChosenUserCouponId;
+
+        //Act
+        HttpResponseMessage response = await httpClient.PutAsJsonAsync("api/order", testUpdateOrderRequestModel);
+        string? errorMessage = await TestUtilitiesLibrary.JsonUtilities.GetSingleStringValueFromBody(response, "errorMessage");
+
+        //Assert
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+        errorMessage.Should().NotBeNull().And.Be("OrderNotFoundWithGivenPaymentProcessorSessionId");
+    }
+
+    [Test, Order(280)]
+    public async Task UpdateOrder_ShouldFailAndReturnBadRequest_IfBothOrderIdAndPaymentProcessorSessionIdAreNull()
+    {
+        //Arrange
+        TestUpdateOrderRequestModel testUpdateOrderRequestModel = new TestUpdateOrderRequestModel();
+        testUpdateOrderRequestModel.Email = "updatedUser@gmail.com";
+        testUpdateOrderRequestModel.FirstName = "UpdatedUserFirstName";
+        testUpdateOrderRequestModel.LastName = "UpdatedUserLastName";
+        testUpdateOrderRequestModel.Country = "UpdatedUserCountry";
+        testUpdateOrderRequestModel.City = "UpdatedUserCity";
+        testUpdateOrderRequestModel.PostalCode = "UpdatedUserPostalCode";
+        testUpdateOrderRequestModel.Address = "UpdatedUserAddress";
+        testUpdateOrderRequestModel.PhoneNumber = "UpdatedUserPhoneNumber";
+        testUpdateOrderRequestModel.IsShippingAddressDifferent = true;
+        testUpdateOrderRequestModel.AltFirstName = "UpdatedAltUserFirstName";
+        testUpdateOrderRequestModel.AltLastName = "UpdatedAltUserLastName";
+        testUpdateOrderRequestModel.AltCountry = "UpdatedAltUserCountry";
+        testUpdateOrderRequestModel.AltCity = "UpdatedAltUserCity";
+        testUpdateOrderRequestModel.AltPostalCode = "UpdatedAltUserPostalCode";
+        testUpdateOrderRequestModel.AltAddress = "UpdatedAltUserAddress";
+        testUpdateOrderRequestModel.AltPhoneNumber = "UpdatedAltUserPhoneNumber";
+        testUpdateOrderRequestModel.PaymentStatus = "Paid";
+        testUpdateOrderRequestModel.PaymentCurrency = "eur";
+        testUpdateOrderRequestModel.AmountPaidInCustomerCurrency = 193.5m;
+        testUpdateOrderRequestModel.AmountPaidInEuro = 193.5m;
+        testUpdateOrderRequestModel.NetAmountPaidInEuro = 170m; //theoretically this is calculated after stripe fee
+        testUpdateOrderRequestModel.OrderItemRequestModels = new List<TestOrderItemRequestModel>() { new TestOrderItemRequestModel() { Quantity = 5, VariantId = _otherChosenVariantId } };
+        testUpdateOrderRequestModel.UserCouponId = _otherChosenUserCouponId;
+
+        //Act
+        HttpResponseMessage response = await httpClient.PutAsJsonAsync("api/order", testUpdateOrderRequestModel);
+        string? errorMessage = await TestUtilitiesLibrary.JsonUtilities.GetSingleStringValueFromBody(response, "errorMessage");
+
+        //Assert
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        errorMessage.Should().NotBeNull().And.Be("TheOrderIdAndThePaymentProcessorSessionIdCanNotBeBothNull");
+    }
+
+    [Test, Order(290)]
+    public async Task UpdateOrder_ShouldFailAndReturnNotFound_IfInvalidUserCouponId()
+    {
+        //Arrange
+        httpClient.DefaultRequestHeaders.Remove("X-API-KEY");
+        httpClient.DefaultRequestHeaders.Add("X-API-KEY", _chosenApiKey);
+        TestUpdateOrderRequestModel testUpdateOrderRequestModel = new TestUpdateOrderRequestModel();
+        testUpdateOrderRequestModel.Email = "updatedUser@gmail.com";
+        testUpdateOrderRequestModel.FirstName = "UpdatedUserFirstName";
+        testUpdateOrderRequestModel.LastName = "UpdatedUserLastName";
+        testUpdateOrderRequestModel.Country = "UpdatedUserCountry";
+        testUpdateOrderRequestModel.City = "UpdatedUserCity";
+        testUpdateOrderRequestModel.PostalCode = "UpdatedUserPostalCode";
+        testUpdateOrderRequestModel.Address = "UpdatedUserAddress";
+        testUpdateOrderRequestModel.PhoneNumber = "UpdatedUserPhoneNumber";
+        testUpdateOrderRequestModel.IsShippingAddressDifferent = true;
+        testUpdateOrderRequestModel.AltFirstName = "UpdatedAltUserFirstName";
+        testUpdateOrderRequestModel.AltLastName = "UpdatedAltUserLastName";
+        testUpdateOrderRequestModel.AltCountry = "UpdatedAltUserCountry";
+        testUpdateOrderRequestModel.AltCity = "UpdatedAltUserCity";
+        testUpdateOrderRequestModel.AltPostalCode = "UpdatedAltUserPostalCode";
+        testUpdateOrderRequestModel.AltAddress = "UpdatedAltUserAddress";
+        testUpdateOrderRequestModel.AltPhoneNumber = "UpdatedAltUserPhoneNumber";
+        testUpdateOrderRequestModel.PaymentProcessorSessionId = "paymentProcessorSessionId"; //find the order based on the paymentProcessorSessionId
+        testUpdateOrderRequestModel.PaymentStatus = "Paid";
+        testUpdateOrderRequestModel.PaymentCurrency = "eur";
+        testUpdateOrderRequestModel.AmountPaidInCustomerCurrency = 193.5m;
+        testUpdateOrderRequestModel.AmountPaidInEuro = 193.5m;
+        testUpdateOrderRequestModel.NetAmountPaidInEuro = 170m; //theoretically this is calculated after stripe fee
+        testUpdateOrderRequestModel.OrderItemRequestModels = new List<TestOrderItemRequestModel>() { new TestOrderItemRequestModel() { Quantity = 5, VariantId = _otherChosenVariantId } };
+        testUpdateOrderRequestModel.UserCouponId = "bogusUserCouponId";
+
+        //Act
+        HttpResponseMessage response = await httpClient.PutAsJsonAsync("api/order", testUpdateOrderRequestModel);
+        string? errorMessage = await TestUtilitiesLibrary.JsonUtilities.GetSingleStringValueFromBody(response, "errorMessage");
+
+        //Assert
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+        errorMessage.Should().NotBeNull().And.Be("InvalidCouponIdWasGiven");
+    }
+
+    [Test, Order(300)]
+    public async Task UpdateOrder_ShouldFailAndReturnNotFound_IfThereIsAtLeastOneInvalidVariant()
+    {
+        //Arrange
+        httpClient.DefaultRequestHeaders.Remove("X-API-KEY");
+        httpClient.DefaultRequestHeaders.Add("X-API-KEY", _chosenApiKey);
+        TestUpdateOrderRequestModel testUpdateOrderRequestModel = new TestUpdateOrderRequestModel();
+        testUpdateOrderRequestModel.Email = "updatedUser@gmail.com";
+        testUpdateOrderRequestModel.FirstName = "UpdatedUserFirstName";
+        testUpdateOrderRequestModel.LastName = "UpdatedUserLastName";
+        testUpdateOrderRequestModel.Country = "UpdatedUserCountry";
+        testUpdateOrderRequestModel.City = "UpdatedUserCity";
+        testUpdateOrderRequestModel.PostalCode = "UpdatedUserPostalCode";
+        testUpdateOrderRequestModel.Address = "UpdatedUserAddress";
+        testUpdateOrderRequestModel.PhoneNumber = "UpdatedUserPhoneNumber";
+        testUpdateOrderRequestModel.IsShippingAddressDifferent = true;
+        testUpdateOrderRequestModel.AltFirstName = "UpdatedAltUserFirstName";
+        testUpdateOrderRequestModel.AltLastName = "UpdatedAltUserLastName";
+        testUpdateOrderRequestModel.AltCountry = "UpdatedAltUserCountry";
+        testUpdateOrderRequestModel.AltCity = "UpdatedAltUserCity";
+        testUpdateOrderRequestModel.AltPostalCode = "UpdatedAltUserPostalCode";
+        testUpdateOrderRequestModel.AltAddress = "UpdatedAltUserAddress";
+        testUpdateOrderRequestModel.AltPhoneNumber = "UpdatedAltUserPhoneNumber";
+        testUpdateOrderRequestModel.PaymentProcessorSessionId = "paymentProcessorSessionId"; //find the order based on the paymentProcessorSessionId
+        testUpdateOrderRequestModel.PaymentStatus = "Paid";
+        testUpdateOrderRequestModel.PaymentCurrency = "eur";
+        testUpdateOrderRequestModel.AmountPaidInCustomerCurrency = 193.5m;
+        testUpdateOrderRequestModel.AmountPaidInEuro = 193.5m;
+        testUpdateOrderRequestModel.NetAmountPaidInEuro = 170m; //theoretically this is calculated after stripe fee
+        testUpdateOrderRequestModel.OrderItemRequestModels = new List<TestOrderItemRequestModel>() { new TestOrderItemRequestModel() { Quantity = 5, VariantId = "bogusVariantId" } };
+        testUpdateOrderRequestModel.UserCouponId = _otherChosenUserCouponId;
+
+        //Act
+        HttpResponseMessage response = await httpClient.PutAsJsonAsync("api/order", testUpdateOrderRequestModel);
+        string? errorMessage = await TestUtilitiesLibrary.JsonUtilities.GetSingleStringValueFromBody(response, "errorMessage");
+
+        //Assert
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+        errorMessage.Should().NotBeNull().And.Be("InvalidVariantIdWasGiven");
+    }
+
+    [Test, Order(310)]
+    public async Task UpdateOrder_ShouldFailAndReturnBadRequest_IfThereIsAtLeastOneVariantWithInsufficientStock()
+    {
+        //Arrange
+        httpClient.DefaultRequestHeaders.Remove("X-API-KEY");
+        httpClient.DefaultRequestHeaders.Add("X-API-KEY", _chosenApiKey);
+        TestUpdateOrderRequestModel testUpdateOrderRequestModel = new TestUpdateOrderRequestModel();
+        testUpdateOrderRequestModel.Email = "updatedUser@gmail.com";
+        testUpdateOrderRequestModel.FirstName = "UpdatedUserFirstName";
+        testUpdateOrderRequestModel.LastName = "UpdatedUserLastName";
+        testUpdateOrderRequestModel.Country = "UpdatedUserCountry";
+        testUpdateOrderRequestModel.City = "UpdatedUserCity";
+        testUpdateOrderRequestModel.PostalCode = "UpdatedUserPostalCode";
+        testUpdateOrderRequestModel.Address = "UpdatedUserAddress";
+        testUpdateOrderRequestModel.PhoneNumber = "UpdatedUserPhoneNumber";
+        testUpdateOrderRequestModel.IsShippingAddressDifferent = true;
+        testUpdateOrderRequestModel.AltFirstName = "UpdatedAltUserFirstName";
+        testUpdateOrderRequestModel.AltLastName = "UpdatedAltUserLastName";
+        testUpdateOrderRequestModel.AltCountry = "UpdatedAltUserCountry";
+        testUpdateOrderRequestModel.AltCity = "UpdatedAltUserCity";
+        testUpdateOrderRequestModel.AltPostalCode = "UpdatedAltUserPostalCode";
+        testUpdateOrderRequestModel.AltAddress = "UpdatedAltUserAddress";
+        testUpdateOrderRequestModel.AltPhoneNumber = "UpdatedAltUserPhoneNumber";
+        testUpdateOrderRequestModel.PaymentProcessorSessionId = "paymentProcessorSessionId"; //find the order based on the paymentProcessorSessionId
+        testUpdateOrderRequestModel.PaymentStatus = "Paid";
+        testUpdateOrderRequestModel.PaymentCurrency = "eur";
+        testUpdateOrderRequestModel.AmountPaidInCustomerCurrency = 193.5m;
+        testUpdateOrderRequestModel.AmountPaidInEuro = 193.5m;
+        testUpdateOrderRequestModel.NetAmountPaidInEuro = 170m; //theoretically this is calculated after stripe fee
+        testUpdateOrderRequestModel.OrderItemRequestModels = new List<TestOrderItemRequestModel>() { new TestOrderItemRequestModel() { Quantity = 1000000, VariantId = _otherChosenVariantId } };
+        testUpdateOrderRequestModel.UserCouponId = _otherChosenUserCouponId;
+
+        //Act
+        HttpResponseMessage response = await httpClient.PutAsJsonAsync("api/order", testUpdateOrderRequestModel);
+        string? errorMessage = await TestUtilitiesLibrary.JsonUtilities.GetSingleStringValueFromBody(response, "errorMessage");
+
+        //Assert
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        errorMessage.Should().NotBeNull().And.Be("InsufficientStockForVariant");
+    }
+
+    [Test, Order(320)]
+    public async Task UpdateOrder_ShouldSucceedAndUpdateOrder()
+    {
+        //Arrange
+        httpClient.DefaultRequestHeaders.Remove("X-API-KEY");
+        httpClient.DefaultRequestHeaders.Add("X-API-KEY", _chosenApiKey);
+        TestUpdateOrderRequestModel testUpdateOrderRequestModel = new TestUpdateOrderRequestModel();
+        testUpdateOrderRequestModel.Email = "updatedUser@gmail.com";
+        testUpdateOrderRequestModel.FirstName = "UpdatedUserFirstName";
+        testUpdateOrderRequestModel.LastName = "UpdatedUserLastName";
+        testUpdateOrderRequestModel.Country = "UpdatedUserCountry";
+        testUpdateOrderRequestModel.City = "UpdatedUserCity";
+        testUpdateOrderRequestModel.PostalCode = "UpdatedUserPostalCode";
+        testUpdateOrderRequestModel.Address = "UpdatedUserAddress";
+        testUpdateOrderRequestModel.PhoneNumber = "UpdatedUserPhoneNumber";
+        testUpdateOrderRequestModel.IsShippingAddressDifferent = true;
+        testUpdateOrderRequestModel.AltFirstName = "UpdatedAltUserFirstName";
+        testUpdateOrderRequestModel.AltLastName = "UpdatedAltUserLastName";
+        testUpdateOrderRequestModel.AltCountry = "UpdatedAltUserCountry";
+        testUpdateOrderRequestModel.AltCity = "UpdatedAltUserCity";
+        testUpdateOrderRequestModel.AltPostalCode = "UpdatedAltUserPostalCode";
+        testUpdateOrderRequestModel.AltAddress = "UpdatedAltUserAddress";
+        testUpdateOrderRequestModel.AltPhoneNumber = "UpdatedAltUserPhoneNumber";
+        testUpdateOrderRequestModel.PaymentProcessorSessionId = "paymentProcessorSessionId"; //find the order based on the paymentProcessorSessionId
+        testUpdateOrderRequestModel.PaymentStatus = "Paid";
+        testUpdateOrderRequestModel.PaymentCurrency = "eur";
+        testUpdateOrderRequestModel.AmountPaidInCustomerCurrency = 193.5m;
+        testUpdateOrderRequestModel.AmountPaidInEuro = 193.5m;
+        testUpdateOrderRequestModel.NetAmountPaidInEuro = 170m; //theoretically this is calculated after stripe fee
+        testUpdateOrderRequestModel.OrderItemRequestModels = new List<TestOrderItemRequestModel>() { new TestOrderItemRequestModel() { Quantity = 5, VariantId = _otherChosenVariantId } };
+        testUpdateOrderRequestModel.UserCouponId = _otherChosenUserCouponId;
+
+        //Act
+        HttpResponseMessage response = await httpClient.PutAsJsonAsync("api/order", testUpdateOrderRequestModel);
+        HttpResponseMessage getResponse = await httpClient.GetAsync($"api/order/{_chosenOrderId}");
+        string? getResponseBody = await getResponse.Content.ReadAsStringAsync();
+        TestOrder? testOrder = JsonSerializer.Deserialize<TestOrder>(getResponseBody, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+
+        HttpResponseMessage variantResponse = await httpClient.GetAsync($"api/variant/id/{_chosenVariantId}/includeDeactivated/true");
+        string? variantResponseBody = await variantResponse.Content.ReadAsStringAsync();
+        TestVariant? testVariant = JsonSerializer.Deserialize<TestVariant>(variantResponseBody, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+
+        HttpResponseMessage couponResponse = await httpClient.GetAsync($"api/coupon/{_chosenCouponId}/includeDeactivated/true");
+        string? couponResponseBody = await couponResponse.Content.ReadAsStringAsync();
+        TestCoupon? testCoupon = JsonSerializer.Deserialize<TestCoupon>(couponResponseBody, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+
+        //Assert
+        response.StatusCode.Should().Be(HttpStatusCode.NoContent);
+        testOrder.Should().NotBeNull();
+        testOrder!.OrderAddress.Should().NotBeNull();
+        testOrder!.OrderAddress!.Email.Should().Be(testUpdateOrderRequestModel.Email);
+        testOrder!.OrderAddress.FirstName.Should().Be(testUpdateOrderRequestModel.FirstName);
+        testOrder!.OrderAddress.LastName.Should().Be(testUpdateOrderRequestModel.LastName);
+        testOrder!.OrderAddress.Country.Should().Be(testUpdateOrderRequestModel.Country);
+        testOrder!.OrderAddress.City.Should().Be(testUpdateOrderRequestModel.City);
+        testOrder!.OrderAddress.PostalCode.Should().Be(testUpdateOrderRequestModel.PostalCode);
+        testOrder!.OrderAddress.Address.Should().Be(testUpdateOrderRequestModel.Address);
+        testOrder!.OrderAddress.PhoneNumber.Should().Be(testUpdateOrderRequestModel.PhoneNumber);
+        testOrder!.OrderAddress.IsShippingAddressDifferent.Should().Be(testUpdateOrderRequestModel.IsShippingAddressDifferent);
+        testOrder!.OrderAddress.AltFirstName.Should().Be(testUpdateOrderRequestModel.AltFirstName);
+        testOrder!.OrderAddress.AltLastName.Should().Be(testUpdateOrderRequestModel.AltLastName);
+        testOrder!.OrderAddress.AltCountry.Should().Be(testUpdateOrderRequestModel.AltCountry);
+        testOrder!.OrderAddress.AltCity.Should().Be(testUpdateOrderRequestModel.AltCity);
+        testOrder!.OrderAddress.AltPostalCode.Should().Be(testUpdateOrderRequestModel.AltPostalCode);
+        testOrder!.OrderAddress.AltAddress.Should().Be(testUpdateOrderRequestModel.AltAddress);
+        testOrder!.OrderAddress.AltPhoneNumber.Should().Be(testUpdateOrderRequestModel.AltPhoneNumber);
+        testOrder.PaymentDetails.Should().NotBeNull();
+        testOrder.PaymentDetails!.PaymentCurrency.Should().Be(testUpdateOrderRequestModel.PaymentCurrency);
+        testOrder.PaymentDetails!.AmountPaidInCustomerCurrency.Should().Be(testUpdateOrderRequestModel.AmountPaidInCustomerCurrency);
+        testOrder.PaymentDetails!.AmountPaidInEuro.Should().Be(testUpdateOrderRequestModel.AmountPaidInEuro);
+        testOrder.PaymentDetails!.NetAmountPaidInEuro.Should().Be(testUpdateOrderRequestModel.NetAmountPaidInEuro);
+        testOrder.PaymentDetails!.PaymentProcessorSessionId.Should().Be(testUpdateOrderRequestModel.PaymentProcessorSessionId);
+        testOrder.PaymentDetails!.PaymentStatus.Should().Be(testUpdateOrderRequestModel.PaymentStatus);
+        testOrder.OrderItems.Should().HaveCount(1);
+        testOrder.OrderItems[0].Discount.Should().BeNull();
+        testOrder.OrderItems[0].DiscountId.Should().BeNull();
+        testOrder.OrderItems[0].UnitPriceAtOrder.Should().Be(100);
+        testOrder.OrderItems[0].Quantity.Should().Be(testUpdateOrderRequestModel.OrderItemRequestModels[0].Quantity);
+
+        testVariant!.UnitsInStock.Should().NotBeNull().And.Be(10);
+        testVariant.ExistsInOrder.Should().BeFalse();
+        testVariant.VariantImages[0].Image!.ExistsInOrder.Should().BeFalse();
+
+        TestUserCoupon previousOrderUserCoupon = testCoupon!.UserCoupons.FirstOrDefault(userCoupon => userCoupon.Id == _chosenUserCouponId)!;
+        previousOrderUserCoupon.ExistsInOrder.Should().BeFalse();
+        previousOrderUserCoupon.TimesUsed.Should().Be(0);
+    }
+
+    [Test, Order(330)]
+    public async Task UpdateOrder_ShouldFailAndReturnBadRequest_IfTheOrderStatusHasBeenFinalized()
+    {
+        //Arrange
+        httpClient.DefaultRequestHeaders.Remove("X-API-KEY");
+        httpClient.DefaultRequestHeaders.Add("X-API-KEY", _chosenApiKey);
+        TestUpdateOrderRequestModel testUpdateOrderRequestModel = new TestUpdateOrderRequestModel();
+        testUpdateOrderRequestModel.Email = "updatedUser@gmail.com";
+        testUpdateOrderRequestModel.FirstName = "UpdatedUserFirstName";
+        testUpdateOrderRequestModel.LastName = "UpdatedUserLastName";
+        testUpdateOrderRequestModel.Country = "UpdatedUserCountry";
+        testUpdateOrderRequestModel.City = "UpdatedUserCity";
+        testUpdateOrderRequestModel.PostalCode = "UpdatedUserPostalCode";
+        testUpdateOrderRequestModel.Address = "UpdatedUserAddress";
+        testUpdateOrderRequestModel.PhoneNumber = "UpdatedUserPhoneNumber";
+        testUpdateOrderRequestModel.IsShippingAddressDifferent = true;
+        testUpdateOrderRequestModel.AltFirstName = "UpdatedAltUserFirstName";
+        testUpdateOrderRequestModel.AltLastName = "UpdatedAltUserLastName";
+        testUpdateOrderRequestModel.AltCountry = "UpdatedAltUserCountry";
+        testUpdateOrderRequestModel.AltCity = "UpdatedAltUserCity";
+        testUpdateOrderRequestModel.AltPostalCode = "UpdatedAltUserPostalCode";
+        testUpdateOrderRequestModel.AltAddress = "UpdatedAltUserAddress";
+        testUpdateOrderRequestModel.AltPhoneNumber = "UpdatedAltUserPhoneNumber";
+        testUpdateOrderRequestModel.PaymentProcessorSessionId = "paymentProcessorSessionId"; //find the order based on the paymentProcessorSessionId
+        testUpdateOrderRequestModel.PaymentStatus = "Paid";
+        testUpdateOrderRequestModel.PaymentCurrency = "eur";
+        testUpdateOrderRequestModel.AmountPaidInCustomerCurrency = 193.5m;
+        testUpdateOrderRequestModel.AmountPaidInEuro = 193.5m;
+        testUpdateOrderRequestModel.NetAmountPaidInEuro = 170m; //theoretically this is calculated after stripe fee
+        testUpdateOrderRequestModel.OrderItemRequestModels = new List<TestOrderItemRequestModel>() { new TestOrderItemRequestModel() { Quantity = 5, VariantId = _otherChosenVariantId } };
+        testUpdateOrderRequestModel.UserCouponId = _otherChosenUserCouponId;
+
+        TestUpdateOrderStatusRequestModel testUpdateOrderStatusRequestModel = new TestUpdateOrderStatusRequestModel();
+        testUpdateOrderStatusRequestModel.OrderId = _chosenOrderId;
+        testUpdateOrderStatusRequestModel.NewOrderStatus = "Canceled";
+        await httpClient.PutAsJsonAsync("api/order/updateOrderStatus", testUpdateOrderStatusRequestModel);
+
+        //Act
+        HttpResponseMessage response = await httpClient.PutAsJsonAsync("api/order", testUpdateOrderRequestModel);
+        string? errorMessage = await TestUtilitiesLibrary.JsonUtilities.GetSingleStringValueFromBody(response, "errorMessage");
+
+        //Assert
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        errorMessage.Should().NotBeNull().And.Be("OrderStatusHasBeenFinalizedAndThusTheOrderCanNotBeAltered");
+    }
+
+    [Test, Order(340)]
+    public async Task UpdateOrderStatus_ShouldFailAndReturnBadRequest_IfTheOrderStatusHasBeenFinalized()
+    {
+        //Arrange
+        httpClient.DefaultRequestHeaders.Remove("X-API-KEY");
+        httpClient.DefaultRequestHeaders.Add("X-API-KEY", _chosenApiKey);
+
+        TestUpdateOrderStatusRequestModel testUpdateOrderStatusRequestModel = new TestUpdateOrderStatusRequestModel();
+        testUpdateOrderStatusRequestModel.OrderId = _chosenOrderId;
+        testUpdateOrderStatusRequestModel.NewOrderStatus = "Refunded";
+        await httpClient.PutAsJsonAsync("api/order/updateOrderStatus", testUpdateOrderStatusRequestModel);
+
+        //Act
+        HttpResponseMessage response = await httpClient.PutAsJsonAsync("api/order/updateOrderStatus", testUpdateOrderStatusRequestModel);
+        string? errorMessage = await TestUtilitiesLibrary.JsonUtilities.GetSingleStringValueFromBody(response, "errorMessage");
+
+        //Assert
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        errorMessage.Should().NotBeNull().And.Be("OrderStatusHasBeenFinalizedAndThusOrderStatusCanNotBeAltered");
+    }
+
+    [Test, Order(350)]
+    public async Task DeleteOrder_ShouldFailAndReturnUnauthorized_IfAPIKeyIsInvalid()
+    {
+        //Arrange
+        httpClient.DefaultRequestHeaders.Remove("X-API-KEY");
+        httpClient.DefaultRequestHeaders.Add("X-API-KEY", "bogusKey");
+        string orderId = _chosenOrderId!;
+
+        //Act
+        HttpResponseMessage response = await httpClient.DeleteAsync($"api/order/{orderId}");
+        string? errorMessage = await TestUtilitiesLibrary.JsonUtilities.GetSingleStringValueFromBody(response, "errorMessage");
+
+        //Assert
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+        errorMessage.Should().NotBeNull().And.Contain("Invalid");
+    }
+
+    [Test, Order(360)]
+    public async Task DeleteOrder_ShouldFailAndReturnNotFound_IfOrderNotInSystem()
+    {
+        //Arrange
+        httpClient.DefaultRequestHeaders.Remove("X-API-KEY");
+        httpClient.DefaultRequestHeaders.Add("X-API-KEY", _chosenApiKey);
+        string bogusOrderId = "bogusOrderId";
+
+        //Act
+        HttpResponseMessage response = await httpClient.DeleteAsync($"api/order/{bogusOrderId}");
+
+        //Assert
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    //TODO Other than that rerun all the tests and maybe check the other entity controller tests now that the order tests have been added
+    [Test, Order(370)]
+    public async Task DeleteOrder_ShouldSucceedAndDeleteOrder()
+    {
+        //Arrange
+        httpClient.DefaultRequestHeaders.Remove("X-API-KEY");
+        httpClient.DefaultRequestHeaders.Add("X-API-KEY", _chosenApiKey);
+        string orderId = _chosenOrderId!;
+
+        //Act
+        HttpResponseMessage response = await httpClient.DeleteAsync($"api/order/{orderId}");
+        HttpResponseMessage secondResponse = await httpClient.DeleteAsync($"api/order/{orderId}");
+
+        HttpResponseMessage variantResponse = await httpClient.GetAsync($"api/variant/id/{_otherChosenVariantId}/includeDeactivated/true");
+        string? variantResponseBody = await variantResponse.Content.ReadAsStringAsync();
+        TestVariant? testVariant = JsonSerializer.Deserialize<TestVariant>(variantResponseBody, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+
+        HttpResponseMessage couponResponse = await httpClient.GetAsync($"api/coupon/{_chosenCouponId}/includeDeactivated/true");
+        string? couponResponseBody = await couponResponse.Content.ReadAsStringAsync();
+        TestCoupon? testCoupon = JsonSerializer.Deserialize<TestCoupon>(couponResponseBody, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+
+        //Assert
+        response.StatusCode.Should().Be(HttpStatusCode.NoContent);
+        secondResponse.StatusCode.Should().Be(HttpStatusCode.NotFound);
+
+        testVariant!.UnitsInStock.Should().NotBeNull().And.Be(20);
+        testVariant!.ExistsInOrder.Should().BeFalse();
+
+        TestUserCoupon orderUserCoupon = testCoupon!.UserCoupons.FirstOrDefault(userCoupon => userCoupon.Id == _otherChosenUserCouponId)!;
+        orderUserCoupon.ExistsInOrder.Should().BeFalse();
+        orderUserCoupon.TimesUsed.Should().Be(0);
+    }
+
+    //Rate Limit Test
+    [Test, Order(500)]
+    public async Task GetOrders_ShouldFail_IfRateLimitIsExceededAndBypassHeaderNotFilledCorrectly()
+    {
+        //Arrange
+        httpClient.DefaultRequestHeaders.Remove("X-Bypass-Rate-Limiting");
+        httpClient.DefaultRequestHeaders.Remove("X-API-KEY");
+        httpClient.DefaultRequestHeaders.Add("X-API-KEY", _chosenApiKey);
+
+        //Act
+        HttpResponseMessage response = new();
+        for (int i = 0; i < 101; i++)
+            response = await httpClient.GetAsync("api/order/amount/10");
+
+        //Assert
+        response.StatusCode.Should().Be(HttpStatusCode.TooManyRequests);
+    }
+
+    [OneTimeTearDown]
+    public void OnTimeTearDown()
+    {
+        httpClient.Dispose();
+        TestUtilitiesLibrary.DatabaseUtilities.ResetSqlAuthDatabase(
+            "Data Source=(localdb)\\MSSQLLocalDB;Initial Catalog=EshopAppDataDb;Integrated Security=True;Connect Timeout=30;Encrypt=False;TrustServerCertificate=False;ApplicationIntent=ReadWrite;MultiSubnetFailover=False",
+            new string[] { "dbo.Attributes", "dbo.Categories", "dbo.Products", "dbo.Variants", "dbo.Discounts", "dbo.Images", "dbo.VariantImages", "dbo.Orders", "dbo.Coupons", "dbo.UserCoupons", "dbo.ShippingOptions", "dbo.PaymentOptions" },
+            "Data Database Successfully Cleared!"
+        );
+    }
+}

--- a/EshopApp.DataLibraryAPI.Tests/IntegrationTests/ControllerTests/PaymentOptionControllerTests.cs
+++ b/EshopApp.DataLibraryAPI.Tests/IntegrationTests/ControllerTests/PaymentOptionControllerTests.cs
@@ -1,0 +1,499 @@
+﻿using EshopApp.DataLibraryAPI.Tests.IntegrationTests.Models;
+using EshopApp.DataLibraryAPI.Tests.IntegrationTests.Models.PaymentOptionModels;
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc.Testing;
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+
+namespace EshopApp.DataLibraryAPI.Tests.IntegrationTests.ControllerTests;
+
+[TestFixture]
+[Category("Integration")]
+[Author("konstantinos kinnas", "kinnaskonstantinos0@gmail.com")]
+internal class PaymentOptionControllerTests
+{
+    private HttpClient httpClient;
+    private string? _chosenApiKey;
+    private string? _chosenPaymentOptionId;
+    private string? _otherPaymentOptionId;
+    private string? _otherPaymentOptionName;
+    private string? _otherPaymentOptionNameAlias;
+
+    [OneTimeSetUp]
+    public async Task OnTimeSetup()
+    {
+        var webApplicationFactory = new WebApplicationFactory<Program>();
+        httpClient = webApplicationFactory.CreateClient();
+        httpClient.DefaultRequestHeaders.Add("X-Bypass-Rate-Limiting", "a7f3f1c6-3d2b-4e3a-8d70-4b6e8d6d53d8");
+        _chosenApiKey = "user_e1f7b8c0-3c79-4a1b-9e7a-9d8b1d4a5c6e";
+        httpClient.DefaultRequestHeaders.Add("X-API-KEY", _chosenApiKey);
+
+        TestUtilitiesLibrary.DatabaseUtilities.ResetSqlAuthDatabase(
+            "Data Source=(localdb)\\MSSQLLocalDB;Initial Catalog=EshopAppDataDb;Integrated Security=True;Connect Timeout=30;Encrypt=False;TrustServerCertificate=False;ApplicationIntent=ReadWrite;MultiSubnetFailover=False",
+            new string[] { "dbo.Attributes", "dbo.Categories", "dbo.Products", "dbo.Variants", "dbo.Discounts", "dbo.Images", "dbo.VariantImages", "dbo.Orders", "dbo.Coupons", "dbo.UserCoupons", "dbo.ShippingOptions", "dbo.PaymentOptions" },
+            "Data Database Successfully Cleared!"
+        );
+
+        /*************** Other Payment Option ***************/
+        TestCreatePaymentOptionRequestModel testCreatePaymentOptionRequestModel = new TestCreatePaymentOptionRequestModel();
+        testCreatePaymentOptionRequestModel.Name = "OtherPaymentOption";
+        testCreatePaymentOptionRequestModel.NameAlias = "card";
+        testCreatePaymentOptionRequestModel.ExtraCost = 4;
+
+        HttpResponseMessage response = await httpClient.PostAsJsonAsync("api/paymentOption", testCreatePaymentOptionRequestModel);
+        string? responseBody = await response.Content.ReadAsStringAsync();
+        TestPaymentOption otherTestPaymentOption = JsonSerializer.Deserialize<TestPaymentOption>(responseBody, new JsonSerializerOptions { PropertyNameCaseInsensitive = true })!;
+        _otherPaymentOptionId = otherTestPaymentOption.Id;
+        _otherPaymentOptionName = otherTestPaymentOption.Name;
+        _otherPaymentOptionNameAlias = otherTestPaymentOption.NameAlias;
+    }
+
+    [Test, Order(10)]
+    public async Task CreatePaymentOption_ShouldFailAndReturnUnauthorized_IfXAPIKEYHeaderIsMissing()
+    {
+        //Arrange
+        httpClient.DefaultRequestHeaders.Remove("X-API-KEY");
+        TestCreatePaymentOptionRequestModel testCreatePaymentOptionRequestModel = new TestCreatePaymentOptionRequestModel();
+        testCreatePaymentOptionRequestModel.Name = "MyPaymentOption";
+        testCreatePaymentOptionRequestModel.NameAlias = "cash";
+        testCreatePaymentOptionRequestModel.Description = "My payment option description";
+        testCreatePaymentOptionRequestModel.ExtraCost = 0;
+        testCreatePaymentOptionRequestModel.IsDeactivated = false;
+        testCreatePaymentOptionRequestModel.ExistsInOrder = false;
+
+        //Act
+        HttpResponseMessage response = await httpClient.PostAsJsonAsync("api/paymentOption", testCreatePaymentOptionRequestModel);
+        string? errorMessage = await TestUtilitiesLibrary.JsonUtilities.GetSingleStringValueFromBody(response, "errorMessage");
+
+        //Assert
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+        errorMessage.Should().NotBeNull().And.Contain("X-API-KEY");
+    }
+
+    [Test, Order(20)]
+    public async Task CreatePaymentOption_ShouldFailAndReturnUnauthorized_IfAPIKeyIsInvalid()
+    {
+        //Arrange
+        httpClient.DefaultRequestHeaders.Remove("X-API-KEY");
+        httpClient.DefaultRequestHeaders.Add("X-API-KEY", "bogusKey");
+        TestCreatePaymentOptionRequestModel testCreatePaymentOptionRequestModel = new TestCreatePaymentOptionRequestModel();
+        testCreatePaymentOptionRequestModel.Name = "MyPaymentOption";
+        testCreatePaymentOptionRequestModel.NameAlias = "cash";
+        testCreatePaymentOptionRequestModel.Description = "My payment option description";
+        testCreatePaymentOptionRequestModel.ExtraCost = 0;
+        testCreatePaymentOptionRequestModel.IsDeactivated = false;
+        testCreatePaymentOptionRequestModel.ExistsInOrder = false;
+
+        //Act
+        HttpResponseMessage response = await httpClient.PostAsJsonAsync("api/paymentOption", testCreatePaymentOptionRequestModel);
+        string? errorMessage = await TestUtilitiesLibrary.JsonUtilities.GetSingleStringValueFromBody(response, "errorMessage");
+
+        //Assert
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+        errorMessage.Should().NotBeNull().And.Contain("Invalid");
+    }
+
+    [Test, Order(30)]
+    public async Task CreatePaymentOption_ShouldFailAndReturnBadRequest_IfInvalidRequestModelFormat()
+    {
+        //Arrange
+        httpClient.DefaultRequestHeaders.Remove("X-API-KEY");
+        httpClient.DefaultRequestHeaders.Add("X-API-KEY", _chosenApiKey);
+        TestCreatePaymentOptionRequestModel testCreatePaymentOptionRequestModel = new TestCreatePaymentOptionRequestModel();
+        testCreatePaymentOptionRequestModel.NameAlias = "cash";
+        testCreatePaymentOptionRequestModel.Description = "My payment option description";
+        testCreatePaymentOptionRequestModel.ExtraCost = 0;
+        testCreatePaymentOptionRequestModel.IsDeactivated = false;
+        testCreatePaymentOptionRequestModel.ExistsInOrder = false;
+
+        //Act
+        HttpResponseMessage response = await httpClient.PostAsJsonAsync("api/paymentOption", testCreatePaymentOptionRequestModel); //name property is missing and thus the request model is invalid
+
+        //Assert
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Test, Order(40)]
+    public async Task CreatePaymentOption_ShouldFailAndReturnBadRequest_IfDuplicatePaymentOptionName()
+    {
+        //Arrange
+        httpClient.DefaultRequestHeaders.Remove("X-API-KEY");
+        httpClient.DefaultRequestHeaders.Add("X-API-KEY", _chosenApiKey);
+        TestCreatePaymentOptionRequestModel testCreatePaymentOptionRequestModel = new TestCreatePaymentOptionRequestModel();
+        testCreatePaymentOptionRequestModel.Name = _otherPaymentOptionName;
+        testCreatePaymentOptionRequestModel.NameAlias = "cash";
+        testCreatePaymentOptionRequestModel.Description = "My payment option description";
+        testCreatePaymentOptionRequestModel.ExtraCost = 0;
+        testCreatePaymentOptionRequestModel.IsDeactivated = false;
+        testCreatePaymentOptionRequestModel.ExistsInOrder = false;
+
+        //Act
+        HttpResponseMessage response = await httpClient.PostAsJsonAsync("api/paymentOption", testCreatePaymentOptionRequestModel);
+        string? errorMessage = await TestUtilitiesLibrary.JsonUtilities.GetSingleStringValueFromBody(response, "errorMessage");
+
+        //Assert
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        errorMessage.Should().NotBeNull().And.Be("DuplicateEntityName");
+    }
+
+    [Test, Order(45)]
+    public async Task CreatePaymentOption_ShouldFailAndReturnBadRequest_IfDuplicatePaymentOptionNameAlias()
+    {
+        //Arrange
+        httpClient.DefaultRequestHeaders.Remove("X-API-KEY");
+        httpClient.DefaultRequestHeaders.Add("X-API-KEY", _chosenApiKey);
+        TestCreatePaymentOptionRequestModel testCreatePaymentOptionRequestModel = new TestCreatePaymentOptionRequestModel();
+        testCreatePaymentOptionRequestModel.Name = "MyPaymentOption";
+        testCreatePaymentOptionRequestModel.NameAlias = _otherPaymentOptionNameAlias;
+        testCreatePaymentOptionRequestModel.Description = "My payment option description";
+        testCreatePaymentOptionRequestModel.ExtraCost = 0;
+        testCreatePaymentOptionRequestModel.IsDeactivated = false;
+        testCreatePaymentOptionRequestModel.ExistsInOrder = false;
+
+        //Act
+        HttpResponseMessage response = await httpClient.PostAsJsonAsync("api/paymentOption", testCreatePaymentOptionRequestModel);
+        string? errorMessage = await TestUtilitiesLibrary.JsonUtilities.GetSingleStringValueFromBody(response, "errorMessage");
+
+        //Assert
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        errorMessage.Should().NotBeNull().And.Be("DuplicateEntityNameAlias");
+    }
+
+    [Test, Order(50)]
+    public async Task CreatePaymentOption_ShouldSucceedAndCreatePaymentOption()
+    {
+        //Arrange
+        httpClient.DefaultRequestHeaders.Remove("X-API-KEY");
+        httpClient.DefaultRequestHeaders.Add("X-API-KEY", _chosenApiKey);
+        TestCreatePaymentOptionRequestModel testCreatePaymentOptionRequestModel = new TestCreatePaymentOptionRequestModel();
+        testCreatePaymentOptionRequestModel.Name = "MyPaymentOption";
+        testCreatePaymentOptionRequestModel.NameAlias = "cash";
+        testCreatePaymentOptionRequestModel.Description = "My payment option description";
+        testCreatePaymentOptionRequestModel.ExtraCost = 0;
+        testCreatePaymentOptionRequestModel.IsDeactivated = false;
+        testCreatePaymentOptionRequestModel.ExistsInOrder = false;
+
+        //Act
+        HttpResponseMessage response = await httpClient.PostAsJsonAsync("api/paymentOption", testCreatePaymentOptionRequestModel);
+        string? responseBody = await response.Content.ReadAsStringAsync();
+        TestPaymentOption? testPaymentOption = JsonSerializer.Deserialize<TestPaymentOption>(responseBody, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+
+        //Assert
+        response.StatusCode.Should().Be(HttpStatusCode.Created);
+        testPaymentOption.Should().NotBeNull();
+        testPaymentOption!.Id.Should().NotBeNull();
+        testPaymentOption!.Name.Should().NotBeNull().And.Be(testCreatePaymentOptionRequestModel.Name);
+        testPaymentOption!.NameAlias.Should().NotBeNull().And.Be(testCreatePaymentOptionRequestModel.NameAlias);
+        testPaymentOption!.Description.Should().NotBeNull().And.Be(testCreatePaymentOptionRequestModel.Description);
+        testPaymentOption!.ExtraCost.Should().NotBeNull().And.Be(testCreatePaymentOptionRequestModel.ExtraCost);
+        testPaymentOption.IsDeactivated.Should().BeFalse();
+        testPaymentOption.ExistsInOrder.Should().BeFalse();
+        _chosenPaymentOptionId = testPaymentOption.Id;
+    }
+
+    [Test, Order(60)]
+    public async Task GetPaymentOptions_ShouldFailAndReturnUnauthorized_IfAPIKeyIsInvalid()
+    {
+        //Arrange
+        httpClient.DefaultRequestHeaders.Remove("X-API-KEY");
+        httpClient.DefaultRequestHeaders.Add("X-API-KEY", "bogusKey");
+
+        //Act
+        HttpResponseMessage response = await httpClient.GetAsync("api/paymentOption/amount/10/includeDeactivated/true"); //here 10 is just an arbitraty value for the amount
+        string? errorMessage = await TestUtilitiesLibrary.JsonUtilities.GetSingleStringValueFromBody(response, "errorMessage");
+
+        //Assert
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+        errorMessage.Should().NotBeNull().And.Contain("Invalid");
+    }
+
+    [Test, Order(70)]
+    public async Task GetPaymentOptions_ShouldSucceedAndReturnPaymentOptions()
+    {
+        //Arrange
+        httpClient.DefaultRequestHeaders.Remove("X-API-KEY");
+        httpClient.DefaultRequestHeaders.Add("X-API-KEY", _chosenApiKey);
+
+        //Act
+        HttpResponseMessage response = await httpClient.GetAsync("api/paymentOption/amount/10/includeDeactivated/true");
+        string? responseBody = await response.Content.ReadAsStringAsync();
+        List<TestPaymentOption>? testPaymentOptions = JsonSerializer.Deserialize<List<TestPaymentOption>>(responseBody, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+
+        //Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        testPaymentOptions.Should().NotBeNull().And.HaveCount(2);
+    }
+
+    [Test, Order(80)]
+    public async Task GetPaymentOption_ShouldFailAndReturnUnauthorized_IfAPIKeyIsInvalid()
+    {
+        //Arrange
+        httpClient.DefaultRequestHeaders.Remove("X-API-KEY");
+        httpClient.DefaultRequestHeaders.Add("X-API-KEY", "bogusKey");
+        string paymentOptionId = _chosenPaymentOptionId!;
+
+        //Act
+        HttpResponseMessage response = await httpClient.GetAsync($"api/paymentOption/{paymentOptionId}/includeDeactivated/true");
+        string? errorMessage = await TestUtilitiesLibrary.JsonUtilities.GetSingleStringValueFromBody(response, "errorMessage");
+
+        //Assert
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+        errorMessage.Should().NotBeNull().And.Contain("Invalid");
+    }
+
+    [Test, Order(90)]
+    public async Task GetPaymentOption_ShouldFailAndReturnNotFound_IfPaymentOptionNotInSystem()
+    {
+        //Arrange
+        httpClient.DefaultRequestHeaders.Remove("X-API-KEY");
+        httpClient.DefaultRequestHeaders.Add("X-API-KEY", _chosenApiKey);
+        string bogusPaymentOptionId = "bogusPaymentOptionId";
+
+        //Act
+        HttpResponseMessage response = await httpClient.GetAsync($"api/paymentOption/{bogusPaymentOptionId}/includeDeactivated/true");
+
+        //Assert
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Test, Order(100)]
+    public async Task GetPaymentOption_ShouldSucceedAndReturnPaymentOption()
+    {
+        //Arrange
+        httpClient.DefaultRequestHeaders.Remove("X-API-KEY");
+        httpClient.DefaultRequestHeaders.Add("X-API-KEY", _chosenApiKey);
+        string paymentOptionId = _chosenPaymentOptionId!;
+
+        //Act
+        HttpResponseMessage response = await httpClient.GetAsync($"api/paymentOption/{paymentOptionId}/includeDeactivated/true");
+        string? responseBody = await response.Content.ReadAsStringAsync();
+        TestPaymentOption? testPaymentOption = JsonSerializer.Deserialize<TestPaymentOption>(responseBody, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+
+        //Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        testPaymentOption.Should().NotBeNull();
+        testPaymentOption!.Id.Should().NotBeNull().And.Be(paymentOptionId);
+        testPaymentOption!.Name.Should().NotBeNull();
+        testPaymentOption!.NameAlias.Should().NotBeNull();
+        testPaymentOption!.Description.Should().NotBeNull();
+        testPaymentOption!.ExtraCost.Should().NotBeNull();
+        testPaymentOption!.IsDeactivated.Should().BeFalse();
+        testPaymentOption!.ExistsInOrder.Should().BeFalse();
+    }
+
+    [Test, Order(110)]
+    public async Task UpdatePaymentOption_ShouldFailAndReturnUnauthorized_IfAPIKeyIsInvalid()
+    {
+        //Arrange
+        httpClient.DefaultRequestHeaders.Remove("X-API-KEY");
+        httpClient.DefaultRequestHeaders.Add("X-API-KEY", "bogusKey");
+        TestUpdatePaymentOptionRequestModel testUpdatePaymentOptionRequestModel = new TestUpdatePaymentOptionRequestModel();
+        testUpdatePaymentOptionRequestModel.Id = _chosenPaymentOptionId;
+        testUpdatePaymentOptionRequestModel.NameAlias = "googlePay";
+        testUpdatePaymentOptionRequestModel.Name = "MyPaymentOptionUpdated";
+        testUpdatePaymentOptionRequestModel.Description = "My payment option description updated";
+        testUpdatePaymentOptionRequestModel.ExtraCost = 10;
+
+        //Act
+        HttpResponseMessage response = await httpClient.PutAsJsonAsync("api/paymentOption", testUpdatePaymentOptionRequestModel);
+        string? errorMessage = await TestUtilitiesLibrary.JsonUtilities.GetSingleStringValueFromBody(response, "errorMessage");
+
+        //Assert
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+        errorMessage.Should().NotBeNull().And.Contain("Invalid");
+    }
+
+    [Test, Order(120)]
+    public async Task UpdatePaymentOption_ShouldFailAndReturnNotFound_IfInvalidRequestModelFormat()
+    {
+        //Arrange
+        httpClient.DefaultRequestHeaders.Remove("X-API-KEY");
+        httpClient.DefaultRequestHeaders.Add("X-API-KEY", _chosenApiKey);
+        TestUpdatePaymentOptionRequestModel testUpdatePaymentOptionRequestModel = new TestUpdatePaymentOptionRequestModel();
+        testUpdatePaymentOptionRequestModel.NameAlias = "googlePay";
+        testUpdatePaymentOptionRequestModel.Name = "MyPaymentOptionUpdated";
+        testUpdatePaymentOptionRequestModel.Description = "My payment option description updated";
+        testUpdatePaymentOptionRequestModel.ExtraCost = 10;
+
+        //Act
+        HttpResponseMessage response = await httpClient.PutAsJsonAsync("api/paymentOption", testUpdatePaymentOptionRequestModel); //here the id is missing, which is required for the update
+
+        //Assert
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Test, Order(130)]
+    public async Task UpdatePaymentOption_ShouldFailAndReturnNotFound_IfPaymentOptionNotInSystem()
+    {
+        //Arrange
+        httpClient.DefaultRequestHeaders.Remove("X-API-KEY");
+        httpClient.DefaultRequestHeaders.Add("X-API-KEY", _chosenApiKey);
+        TestUpdatePaymentOptionRequestModel testUpdatePaymentOptionRequestModel = new TestUpdatePaymentOptionRequestModel();
+        testUpdatePaymentOptionRequestModel.Id = "bogusPaymentOptionId";
+        testUpdatePaymentOptionRequestModel.NameAlias = "googlePay";
+        testUpdatePaymentOptionRequestModel.Name = "MyPaymentOptionUpdated";
+        testUpdatePaymentOptionRequestModel.Description = "My payment option description updated";
+        testUpdatePaymentOptionRequestModel.ExtraCost = 10;
+
+        //Act
+        HttpResponseMessage response = await httpClient.PutAsJsonAsync("api/paymentOption", testUpdatePaymentOptionRequestModel);
+        string? errorMessage = await TestUtilitiesLibrary.JsonUtilities.GetSingleStringValueFromBody(response, "errorMessage");
+
+        //Assert
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+        errorMessage.Should().NotBeNull().And.Be("EntityNotFoundWithGivenId");
+    }
+
+    [Test, Order(140)]
+    public async Task UpdatePaymentOption_ShouldFailAndReturnBadRequest_IfDuplicatePaymentOptionName()
+    {
+        //Arrange
+        httpClient.DefaultRequestHeaders.Remove("X-API-KEY");
+        httpClient.DefaultRequestHeaders.Add("X-API-KEY", _chosenApiKey);
+        TestUpdatePaymentOptionRequestModel testUpdatePaymentOptionRequestModel = new TestUpdatePaymentOptionRequestModel();
+        testUpdatePaymentOptionRequestModel.Id = _chosenPaymentOptionId;
+        testUpdatePaymentOptionRequestModel.NameAlias = "googlePay";
+        testUpdatePaymentOptionRequestModel.Name = _otherPaymentOptionName;
+        testUpdatePaymentOptionRequestModel.Description = "My payment option description updated";
+        testUpdatePaymentOptionRequestModel.ExtraCost = 10;
+
+        //Act
+        HttpResponseMessage response = await httpClient.PutAsJsonAsync("api/paymentOption", testUpdatePaymentOptionRequestModel);
+        string? errorMessage = await TestUtilitiesLibrary.JsonUtilities.GetSingleStringValueFromBody(response, "errorMessage");
+
+        //Assert
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        errorMessage.Should().NotBeNull().And.Be("DuplicateEntityName");
+    }
+
+    [Test, Order(145)]
+    public async Task UpdatePaymentOption_ShouldFailAndReturnBadRequest_IfDuplicatePaymentOptionNameAlias()
+    {
+        //Arrange
+        httpClient.DefaultRequestHeaders.Remove("X-API-KEY");
+        httpClient.DefaultRequestHeaders.Add("X-API-KEY", _chosenApiKey);
+        TestUpdatePaymentOptionRequestModel testUpdatePaymentOptionRequestModel = new TestUpdatePaymentOptionRequestModel();
+        testUpdatePaymentOptionRequestModel.Id = _chosenPaymentOptionId;
+        testUpdatePaymentOptionRequestModel.NameAlias = _otherPaymentOptionNameAlias;
+        testUpdatePaymentOptionRequestModel.Name = "MyPaymentOptionUpdated";
+        testUpdatePaymentOptionRequestModel.Description = "My payment option description updated";
+        testUpdatePaymentOptionRequestModel.ExtraCost = 10;
+
+        //Act
+        HttpResponseMessage response = await httpClient.PutAsJsonAsync("api/paymentOption", testUpdatePaymentOptionRequestModel);
+        string? errorMessage = await TestUtilitiesLibrary.JsonUtilities.GetSingleStringValueFromBody(response, "errorMessage");
+
+        //Assert
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        errorMessage.Should().NotBeNull().And.Be("DuplicateEntityNameAlias");
+    }
+
+    [Test, Order(150)]
+    public async Task UpdatePaymentOption_ShouldSucceedAndUpdatePaymentOption()
+    {
+        //Arrange
+        httpClient.DefaultRequestHeaders.Remove("X-API-KEY");
+        httpClient.DefaultRequestHeaders.Add("X-API-KEY", _chosenApiKey);
+        TestUpdatePaymentOptionRequestModel testUpdatePaymentOptionRequestModel = new TestUpdatePaymentOptionRequestModel();
+        testUpdatePaymentOptionRequestModel.Id = _chosenPaymentOptionId;
+        testUpdatePaymentOptionRequestModel.NameAlias = "googlePay";
+        testUpdatePaymentOptionRequestModel.Name = "MyPaymentOptionUpdated";
+        testUpdatePaymentOptionRequestModel.Description = "My payment option description updated";
+        testUpdatePaymentOptionRequestModel.ExtraCost = 10;
+
+        //Act
+        HttpResponseMessage response = await httpClient.PutAsJsonAsync("api/paymentOption", testUpdatePaymentOptionRequestModel);
+        HttpResponseMessage getResponse = await httpClient.GetAsync($"api/paymentOption/{_chosenPaymentOptionId}/includeDeactivated/true");
+        string? getResponseBody = await getResponse.Content.ReadAsStringAsync();
+        TestPaymentOption? testPaymentOption = JsonSerializer.Deserialize<TestPaymentOption>(getResponseBody, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+
+        //Assert
+        response.StatusCode.Should().Be(HttpStatusCode.NoContent);
+        testPaymentOption!.Name.Should().NotBeNull().And.Be(testUpdatePaymentOptionRequestModel.Name);
+        testPaymentOption!.NameAlias.Should().NotBeNull().And.Be(testUpdatePaymentOptionRequestModel.NameAlias);
+        testPaymentOption!.Description.Should().NotBeNull().And.Be(testUpdatePaymentOptionRequestModel.Description);
+        testPaymentOption!.ExtraCost.Should().NotBeNull().And.Be(testUpdatePaymentOptionRequestModel.ExtraCost);
+        testPaymentOption.IsDeactivated.Should().BeFalse();
+        testPaymentOption.ExistsInOrder.Should().BeFalse();
+        testPaymentOption.PaymentDetails.Should().NotBeNull().And.HaveCount(0);
+    }
+
+    [Test, Order(160)]
+    public async Task DeletePaymentOption_ShouldFailAndReturnUnauthorized_IfAPIKeyIsInvalid()
+    {
+        //Arrange
+        httpClient.DefaultRequestHeaders.Remove("X-API-KEY");
+        httpClient.DefaultRequestHeaders.Add("X-API-KEY", "bogusKey");
+        string paymentOptionId = _chosenPaymentOptionId!;
+
+        //Act
+        HttpResponseMessage response = await httpClient.DeleteAsync($"api/paymentOption/{paymentOptionId}");
+        string? errorMessage = await TestUtilitiesLibrary.JsonUtilities.GetSingleStringValueFromBody(response, "errorMessage");
+
+        //Assert
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+        errorMessage.Should().NotBeNull().And.Contain("Invalid");
+    }
+
+    [Test, Order(170)]
+    public async Task DeletePaymentOption_ShouldFailAndReturnNotFound_IfPaymentOptionNotInSystem()
+    {
+        //Arrange
+        httpClient.DefaultRequestHeaders.Remove("X-API-KEY");
+        httpClient.DefaultRequestHeaders.Add("X-API-KEY", _chosenApiKey);
+        string bogusPaymentOptionId = "bogusPaymentOptionId";
+
+        //Act
+        HttpResponseMessage response = await httpClient.DeleteAsync($"api/paymentOption/{bogusPaymentOptionId}");
+
+        //Assert
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Test, Order(180)]
+    public async Task DeletePaymentOption_ShouldSucceedAndDeletePaymentOption()
+    {
+        //Arrange
+        httpClient.DefaultRequestHeaders.Remove("X-API-KEY");
+        httpClient.DefaultRequestHeaders.Add("X-API-KEY", _chosenApiKey);
+        string paymentOptionId = _chosenPaymentOptionId!;
+
+        //Act
+        HttpResponseMessage response = await httpClient.DeleteAsync($"api/paymentOption/{paymentOptionId}");
+        HttpResponseMessage secondResponse = await httpClient.DeleteAsync($"api/paymentOption/{paymentOptionId}");
+
+        //Assert
+        response.StatusCode.Should().Be(HttpStatusCode.NoContent);
+        secondResponse.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    //Rate Limit Test
+    [Test, Order(300)]
+    public async Task GetPaymentOptions_ShouldFail_IfRateLimitIsExceededAndBypassHeaderNotFilledCorrectly()
+    {
+        //Arrange
+        httpClient.DefaultRequestHeaders.Remove("X-Bypass-Rate-Limiting");
+        httpClient.DefaultRequestHeaders.Remove("X-API-KEY");
+        httpClient.DefaultRequestHeaders.Add("X-API-KEY", _chosenApiKey);
+
+        //Act
+        HttpResponseMessage response = new();
+        for (int i = 0; i < 101; i++)
+            response = await httpClient.GetAsync("api/paymentOption/amount/10/includeDeactivated/true");
+
+        //Assert
+        response.StatusCode.Should().Be(HttpStatusCode.TooManyRequests);
+    }
+
+    [OneTimeTearDown]
+    public void OnTimeTearDown()
+    {
+        httpClient.Dispose();
+        TestUtilitiesLibrary.DatabaseUtilities.ResetSqlAuthDatabase(
+            "Data Source=(localdb)\\MSSQLLocalDB;Initial Catalog=EshopAppDataDb;Integrated Security=True;Connect Timeout=30;Encrypt=False;TrustServerCertificate=False;ApplicationIntent=ReadWrite;MultiSubnetFailover=False",
+            new string[] { "dbo.Attributes", "dbo.Categories", "dbo.Products", "dbo.Variants", "dbo.Discounts", "dbo.Images", "dbo.VariantImages", "dbo.Orders", "dbo.Coupons", "dbo.UserCoupons", "dbo.ShippingOptions", "dbo.PaymentOptions" },
+            "Data Database Successfully Cleared!"
+        );
+    }
+}

--- a/EshopApp.DataLibraryAPI.Tests/IntegrationTests/ControllerTests/ProductControllerTests.cs
+++ b/EshopApp.DataLibraryAPI.Tests/IntegrationTests/ControllerTests/ProductControllerTests.cs
@@ -41,7 +41,7 @@ internal class ProductControllerTests
 
         TestUtilitiesLibrary.DatabaseUtilities.ResetSqlAuthDatabase(
             "Data Source=(localdb)\\MSSQLLocalDB;Initial Catalog=EshopAppDataDb;Integrated Security=True;Connect Timeout=30;Encrypt=False;TrustServerCertificate=False;ApplicationIntent=ReadWrite;MultiSubnetFailover=False",
-            new string[] { "dbo.Attributes", "dbo.Categories", "dbo.Products", "dbo.Variants", "dbo.Discounts", "dbo.Images", "dbo.VariantImages", "dbo.Coupons", "dbo.UserCoupons" },
+            new string[] { "dbo.Attributes", "dbo.Categories", "dbo.Products", "dbo.Variants", "dbo.Discounts", "dbo.Images", "dbo.VariantImages", "dbo.Orders", "dbo.Coupons", "dbo.UserCoupons", "dbo.ShippingOptions", "dbo.PaymentOptions" },
             "Data Database Successfully Cleared!"
         );
 
@@ -730,7 +730,7 @@ internal class ProductControllerTests
         httpClient.Dispose();
         TestUtilitiesLibrary.DatabaseUtilities.ResetSqlAuthDatabase(
             "Data Source=(localdb)\\MSSQLLocalDB;Initial Catalog=EshopAppDataDb;Integrated Security=True;Connect Timeout=30;Encrypt=False;TrustServerCertificate=False;ApplicationIntent=ReadWrite;MultiSubnetFailover=False",
-            new string[] { "dbo.Attributes", "dbo.Categories", "dbo.Products", "dbo.Variants", "dbo.Discounts", "dbo.Images", "dbo.VariantImages", "dbo.Coupons", "dbo.UserCoupons" },
+            new string[] { "dbo.Attributes", "dbo.Categories", "dbo.Products", "dbo.Variants", "dbo.Discounts", "dbo.Images", "dbo.VariantImages", "dbo.Orders", "dbo.Coupons", "dbo.UserCoupons", "dbo.ShippingOptions", "dbo.PaymentOptions" },
             "Data Database Successfully Cleared!"
         );
     }

--- a/EshopApp.DataLibraryAPI.Tests/IntegrationTests/ControllerTests/ShippingOptionControllerTests.cs
+++ b/EshopApp.DataLibraryAPI.Tests/IntegrationTests/ControllerTests/ShippingOptionControllerTests.cs
@@ -1,0 +1,447 @@
+﻿using EshopApp.DataLibrary.Models;
+using EshopApp.DataLibraryAPI.Tests.IntegrationTests.Models;
+using EshopApp.DataLibraryAPI.Tests.IntegrationTests.Models.ShippingOptionModels;
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc.Testing;
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+
+namespace EshopApp.DataLibraryAPI.Tests.IntegrationTests.ControllerTests;
+
+[TestFixture]
+[Category("Integration")]
+[Author("konstantinos kinnas", "kinnaskonstantinos0@gmail.com")]
+internal class ShippingOptionControllerTests
+{
+    private HttpClient httpClient;
+    private string? _chosenApiKey;
+    private string? _chosenShippingOptionId;
+    private string? _otherShippingOptionId;
+    private string? _otherShippingOptionName;
+
+    [OneTimeSetUp]
+    public async Task OnTimeSetup()
+    {
+        var webApplicationFactory = new WebApplicationFactory<Program>();
+        httpClient = webApplicationFactory.CreateClient();
+        httpClient.DefaultRequestHeaders.Add("X-Bypass-Rate-Limiting", "a7f3f1c6-3d2b-4e3a-8d70-4b6e8d6d53d8");
+        _chosenApiKey = "user_e1f7b8c0-3c79-4a1b-9e7a-9d8b1d4a5c6e";
+        httpClient.DefaultRequestHeaders.Add("X-API-KEY", _chosenApiKey);
+
+        TestUtilitiesLibrary.DatabaseUtilities.ResetSqlAuthDatabase(
+            "Data Source=(localdb)\\MSSQLLocalDB;Initial Catalog=EshopAppDataDb;Integrated Security=True;Connect Timeout=30;Encrypt=False;TrustServerCertificate=False;ApplicationIntent=ReadWrite;MultiSubnetFailover=False",
+            new string[] { "dbo.Attributes", "dbo.Categories", "dbo.Products", "dbo.Variants", "dbo.Discounts", "dbo.Images", "dbo.VariantImages", "dbo.Orders", "dbo.Coupons", "dbo.UserCoupons", "dbo.ShippingOptions", "dbo.PaymentOptions" },
+            "Data Database Successfully Cleared!"
+        );
+
+        /*************** Other Shipping Option ***************/
+        TestCreateShippingOptionRequestModel testCreateShippingOptionRequestModel = new TestCreateShippingOptionRequestModel();
+        testCreateShippingOptionRequestModel.Name = "OtherShippingOption";
+        testCreateShippingOptionRequestModel.ExtraCost = 5;
+        testCreateShippingOptionRequestModel.ContainsDelivery = true;
+
+        HttpResponseMessage response = await httpClient.PostAsJsonAsync("api/shippingOption", testCreateShippingOptionRequestModel);
+        string? responseBody = await response.Content.ReadAsStringAsync();
+        _otherShippingOptionId = JsonSerializer.Deserialize<TestShippingOption>(responseBody, new JsonSerializerOptions { PropertyNameCaseInsensitive = true })!.Id;
+        _otherShippingOptionName = JsonSerializer.Deserialize<TestShippingOption>(responseBody, new JsonSerializerOptions { PropertyNameCaseInsensitive = true })!.Name;
+    }
+
+    [Test, Order(10)]
+    public async Task CreateShippingOption_ShouldFailAndReturnUnauthorized_IfXAPIKEYHeaderIsMissing()
+    {
+        //Arrange
+        httpClient.DefaultRequestHeaders.Remove("X-API-KEY");
+        TestCreateShippingOptionRequestModel testCreateShippingOptionRequestModel = new TestCreateShippingOptionRequestModel();
+        testCreateShippingOptionRequestModel.Name = "MyShippingOption";
+        testCreateShippingOptionRequestModel.Description = "My shipping option description";
+        testCreateShippingOptionRequestModel.ExtraCost = 3;
+        testCreateShippingOptionRequestModel.ContainsDelivery = true;
+        testCreateShippingOptionRequestModel.IsDeactivated = false;
+        testCreateShippingOptionRequestModel.ExistsInOrder = false;
+
+        //Act
+        HttpResponseMessage response = await httpClient.PostAsJsonAsync("api/shippingOption", testCreateShippingOptionRequestModel);
+        string? errorMessage = await TestUtilitiesLibrary.JsonUtilities.GetSingleStringValueFromBody(response, "errorMessage");
+
+        //Assert
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+        errorMessage.Should().NotBeNull().And.Contain("X-API-KEY");
+    }
+
+    [Test, Order(20)]
+    public async Task CreateShippingOption_ShouldFailAndReturnUnauthorized_IfAPIKeyIsInvalid()
+    {
+        //Arrange
+        httpClient.DefaultRequestHeaders.Remove("X-API-KEY");
+        httpClient.DefaultRequestHeaders.Add("X-API-KEY", "bogusKey");
+        TestCreateShippingOptionRequestModel testCreateShippingOptionRequestModel = new TestCreateShippingOptionRequestModel();
+        testCreateShippingOptionRequestModel.Name = "MyShippingOption";
+        testCreateShippingOptionRequestModel.Description = "My shipping option description";
+        testCreateShippingOptionRequestModel.ExtraCost = 3;
+        testCreateShippingOptionRequestModel.ContainsDelivery = true;
+        testCreateShippingOptionRequestModel.IsDeactivated = false;
+        testCreateShippingOptionRequestModel.ExistsInOrder = false;
+
+        //Act
+        HttpResponseMessage response = await httpClient.PostAsJsonAsync("api/shippingOption", testCreateShippingOptionRequestModel);
+        string? errorMessage = await TestUtilitiesLibrary.JsonUtilities.GetSingleStringValueFromBody(response, "errorMessage");
+
+        //Assert
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+        errorMessage.Should().NotBeNull().And.Contain("Invalid");
+    }
+
+    [Test, Order(30)]
+    public async Task CreateShippingOption_ShouldFailAndReturnBadRequest_IfInvalidRequestModelFormat()
+    {
+        //Arrange
+        httpClient.DefaultRequestHeaders.Remove("X-API-KEY");
+        httpClient.DefaultRequestHeaders.Add("X-API-KEY", _chosenApiKey);
+        TestCreateShippingOptionRequestModel testCreateShippingOptionRequestModel = new TestCreateShippingOptionRequestModel();
+        testCreateShippingOptionRequestModel.Description = "My shipping option description";
+        testCreateShippingOptionRequestModel.ExtraCost = 3;
+        testCreateShippingOptionRequestModel.ContainsDelivery = true;
+        testCreateShippingOptionRequestModel.IsDeactivated = false;
+        testCreateShippingOptionRequestModel.ExistsInOrder = false;
+
+        //Act
+        HttpResponseMessage response = await httpClient.PostAsJsonAsync("api/shippingOption", testCreateShippingOptionRequestModel); //name property is missing and thus the request model is invalid
+
+        //Assert
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Test, Order(40)]
+    public async Task CreateShippingOption_ShouldFailAndReturnBadRequest_IfDuplicateShippingOptionName()
+    {
+        //Arrange
+        httpClient.DefaultRequestHeaders.Remove("X-API-KEY");
+        httpClient.DefaultRequestHeaders.Add("X-API-KEY", _chosenApiKey);
+        TestCreateShippingOptionRequestModel testCreateShippingOptionRequestModel = new TestCreateShippingOptionRequestModel();
+        testCreateShippingOptionRequestModel.Name = _otherShippingOptionName;
+        testCreateShippingOptionRequestModel.Description = "My shipping option description";
+        testCreateShippingOptionRequestModel.ExtraCost = 3;
+        testCreateShippingOptionRequestModel.ContainsDelivery = true;
+        testCreateShippingOptionRequestModel.IsDeactivated = false;
+        testCreateShippingOptionRequestModel.ExistsInOrder = false;
+
+        //Act
+        HttpResponseMessage response = await httpClient.PostAsJsonAsync("api/shippingOption", testCreateShippingOptionRequestModel);
+        string? errorMessage = await TestUtilitiesLibrary.JsonUtilities.GetSingleStringValueFromBody(response, "errorMessage");
+
+        //Assert
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        errorMessage.Should().NotBeNull().And.Be("DuplicateEntityName");
+    }
+
+    [Test, Order(50)]
+    public async Task CreateShippingOption_ShouldSucceedAndCreateShippingOption()
+    {
+        //Arrange
+        httpClient.DefaultRequestHeaders.Remove("X-API-KEY");
+        httpClient.DefaultRequestHeaders.Add("X-API-KEY", _chosenApiKey);
+        TestCreateShippingOptionRequestModel testCreateShippingOptionRequestModel = new TestCreateShippingOptionRequestModel();
+        testCreateShippingOptionRequestModel.Name = "MyShippingOption";
+        testCreateShippingOptionRequestModel.Description = "My shipping option description";
+        testCreateShippingOptionRequestModel.ExtraCost = 3;
+        testCreateShippingOptionRequestModel.ContainsDelivery = true;
+        testCreateShippingOptionRequestModel.IsDeactivated = false;
+        testCreateShippingOptionRequestModel.ExistsInOrder = false;
+
+        //Act
+        HttpResponseMessage response = await httpClient.PostAsJsonAsync("api/shippingOption", testCreateShippingOptionRequestModel);
+        string? responseBody = await response.Content.ReadAsStringAsync();
+        TestShippingOption? testShippingOption = JsonSerializer.Deserialize<TestShippingOption>(responseBody, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+
+        //Assert
+        response.StatusCode.Should().Be(HttpStatusCode.Created);
+        testShippingOption.Should().NotBeNull();
+        testShippingOption!.Id.Should().NotBeNull();
+        testShippingOption!.Name.Should().NotBeNull().And.Be(testCreateShippingOptionRequestModel.Name);
+        testShippingOption!.Description.Should().NotBeNull().And.Be(testCreateShippingOptionRequestModel.Description);
+        testShippingOption!.ExtraCost.Should().NotBeNull().And.Be(testCreateShippingOptionRequestModel.ExtraCost);
+        testShippingOption.ContainsDelivery.Should().BeTrue();
+        testShippingOption.IsDeactivated.Should().BeFalse();
+        testShippingOption.ExistsInOrder.Should().BeFalse();
+        _chosenShippingOptionId = testShippingOption.Id;
+    }
+
+    [Test, Order(60)]
+    public async Task GetShippingOptions_ShouldFailAndReturnUnauthorized_IfAPIKeyIsInvalid()
+    {
+        //Arrange
+        httpClient.DefaultRequestHeaders.Remove("X-API-KEY");
+        httpClient.DefaultRequestHeaders.Add("X-API-KEY", "bogusKey");
+
+        //Act
+        HttpResponseMessage response = await httpClient.GetAsync("api/shippingOption/amount/10/includeDeactivated/true"); //here 10 is just an arbitraty value for the amount
+        string? errorMessage = await TestUtilitiesLibrary.JsonUtilities.GetSingleStringValueFromBody(response, "errorMessage");
+
+        //Assert
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+        errorMessage.Should().NotBeNull().And.Contain("Invalid");
+    }
+
+    [Test, Order(70)]
+    public async Task GetShippingOptions_ShouldSucceedAndReturnShippingOptions()
+    {
+        //Arrange
+        httpClient.DefaultRequestHeaders.Remove("X-API-KEY");
+        httpClient.DefaultRequestHeaders.Add("X-API-KEY", _chosenApiKey);
+
+        //Act
+        HttpResponseMessage response = await httpClient.GetAsync("api/shippingOption/amount/10/includeDeactivated/true");
+        string? responseBody = await response.Content.ReadAsStringAsync();
+        List<TestShippingOption>? testShippingOptions = JsonSerializer.Deserialize<List<TestShippingOption>>(responseBody, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+
+        //Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        testShippingOptions.Should().NotBeNull().And.HaveCount(2);
+    }
+
+    [Test, Order(80)]
+    public async Task GetShippingOption_ShouldFailAndReturnUnauthorized_IfAPIKeyIsInvalid()
+    {
+        //Arrange
+        httpClient.DefaultRequestHeaders.Remove("X-API-KEY");
+        httpClient.DefaultRequestHeaders.Add("X-API-KEY", "bogusKey");
+        string shippingOptionId = _chosenShippingOptionId!;
+
+        //Act
+        HttpResponseMessage response = await httpClient.GetAsync($"api/shippingOption/{shippingOptionId}/includeDeactivated/true");
+        string? errorMessage = await TestUtilitiesLibrary.JsonUtilities.GetSingleStringValueFromBody(response, "errorMessage");
+
+        //Assert
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+        errorMessage.Should().NotBeNull().And.Contain("Invalid");
+    }
+
+    [Test, Order(90)]
+    public async Task GetShippingOption_ShouldFailAndReturnNotFound_IfShippingOptionNotInSystem()
+    {
+        //Arrange
+        httpClient.DefaultRequestHeaders.Remove("X-API-KEY");
+        httpClient.DefaultRequestHeaders.Add("X-API-KEY", _chosenApiKey);
+        string bogusShippingOptionId = "bogusShippingOptionId";
+
+        //Act
+        HttpResponseMessage response = await httpClient.GetAsync($"api/shippingOption/{bogusShippingOptionId}/includeDeactivated/true");
+
+        //Assert
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Test, Order(100)]
+    public async Task GetShippingOption_ShouldSucceedAndReturnShippingOption()
+    {
+        //Arrange
+        httpClient.DefaultRequestHeaders.Remove("X-API-KEY");
+        httpClient.DefaultRequestHeaders.Add("X-API-KEY", _chosenApiKey);
+        string shippingOptionId = _chosenShippingOptionId!;
+
+        //Act
+        HttpResponseMessage response = await httpClient.GetAsync($"api/shippingOption/{shippingOptionId}/includeDeactivated/true");
+        string? responseBody = await response.Content.ReadAsStringAsync();
+        TestShippingOption? testShippingOption = JsonSerializer.Deserialize<TestShippingOption>(responseBody, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+
+        //Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        testShippingOption.Should().NotBeNull();
+        testShippingOption!.Id.Should().NotBeNull().And.Be(shippingOptionId);
+        testShippingOption!.Name.Should().NotBeNull();
+        testShippingOption!.Description.Should().NotBeNull();
+        testShippingOption!.ExtraCost.Should().NotBeNull();
+        testShippingOption!.ContainsDelivery.Should().BeTrue();
+        testShippingOption!.IsDeactivated.Should().BeFalse();
+        testShippingOption!.ExistsInOrder.Should().BeFalse();
+    }
+
+    [Test, Order(110)]
+    public async Task UpdateShippingOption_ShouldFailAndReturnUnauthorized_IfAPIKeyIsInvalid()
+    {
+        //Arrange
+        httpClient.DefaultRequestHeaders.Remove("X-API-KEY");
+        httpClient.DefaultRequestHeaders.Add("X-API-KEY", "bogusKey");
+        TestUpdateShippingOptionRequestModel testUpdateShippingOptionRequestModel = new TestUpdateShippingOptionRequestModel();
+        testUpdateShippingOptionRequestModel.Id = _chosenShippingOptionId;
+        testUpdateShippingOptionRequestModel.Name = "MyShippingOptionUpdated";
+        testUpdateShippingOptionRequestModel.Description = "My shipping option description updated";
+        testUpdateShippingOptionRequestModel.ExtraCost = 10;
+
+        //Act
+        HttpResponseMessage response = await httpClient.PutAsJsonAsync("api/shippingOption", testUpdateShippingOptionRequestModel);
+        string? errorMessage = await TestUtilitiesLibrary.JsonUtilities.GetSingleStringValueFromBody(response, "errorMessage");
+
+        //Assert
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+        errorMessage.Should().NotBeNull().And.Contain("Invalid");
+    }
+
+    [Test, Order(120)]
+    public async Task UpdateShippingOption_ShouldFailAndReturnNotFound_IfInvalidRequestModelFormat()
+    {
+        //Arrange
+        httpClient.DefaultRequestHeaders.Remove("X-API-KEY");
+        httpClient.DefaultRequestHeaders.Add("X-API-KEY", _chosenApiKey);
+        TestUpdateShippingOptionRequestModel testUpdateShippingOptionRequestModel = new TestUpdateShippingOptionRequestModel();
+        testUpdateShippingOptionRequestModel.Name = "MyShippingOptionUpdated";
+        testUpdateShippingOptionRequestModel.Description = "My shipping option description updated";
+        testUpdateShippingOptionRequestModel.ExtraCost = 10;
+
+        //Act
+        HttpResponseMessage response = await httpClient.PutAsJsonAsync("api/shippingOption", testUpdateShippingOptionRequestModel); //here the id is missing, which is required for the update
+
+        //Assert
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Test, Order(130)]
+    public async Task UpdateShippingOption_ShouldFailAndReturnNotFound_IfShippingOptionNotInSystem()
+    {
+        //Arrange
+        httpClient.DefaultRequestHeaders.Remove("X-API-KEY");
+        httpClient.DefaultRequestHeaders.Add("X-API-KEY", _chosenApiKey);
+        TestUpdateShippingOptionRequestModel testUpdateShippingOptionRequestModel = new TestUpdateShippingOptionRequestModel();
+        testUpdateShippingOptionRequestModel.Id = "bogusShippingOptionId";
+        testUpdateShippingOptionRequestModel.Name = "MyShippingOptionUpdated";
+        testUpdateShippingOptionRequestModel.Description = "My shipping option description updated";
+        testUpdateShippingOptionRequestModel.ExtraCost = 10;
+
+        //Act
+        HttpResponseMessage response = await httpClient.PutAsJsonAsync("api/shippingOption", testUpdateShippingOptionRequestModel);
+        string? errorMessage = await TestUtilitiesLibrary.JsonUtilities.GetSingleStringValueFromBody(response, "errorMessage");
+
+        //Assert
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+        errorMessage.Should().NotBeNull().And.Be("EntityNotFoundWithGivenId");
+    }
+
+    [Test, Order(140)]
+    public async Task UpdateShippingOption_ShouldFailAndReturnBadRequest_IfDuplicateShippingOptionName()
+    {
+        //Arrange
+        httpClient.DefaultRequestHeaders.Remove("X-API-KEY");
+        httpClient.DefaultRequestHeaders.Add("X-API-KEY", _chosenApiKey);
+        TestUpdateShippingOptionRequestModel testUpdateShippingOptionRequestModel = new TestUpdateShippingOptionRequestModel();
+        testUpdateShippingOptionRequestModel.Id = _chosenShippingOptionId;
+        testUpdateShippingOptionRequestModel.Name = _otherShippingOptionName;
+        testUpdateShippingOptionRequestModel.Description = "My shipping option description updated";
+        testUpdateShippingOptionRequestModel.ExtraCost = 10;
+
+        //Act
+        HttpResponseMessage response = await httpClient.PutAsJsonAsync("api/shippingOption", testUpdateShippingOptionRequestModel);
+        string? errorMessage = await TestUtilitiesLibrary.JsonUtilities.GetSingleStringValueFromBody(response, "errorMessage");
+
+        //Assert
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        errorMessage.Should().NotBeNull().And.Be("DuplicateEntityName");
+    }
+
+    [Test, Order(150)]
+    public async Task UpdateShippingOption_ShouldSucceedAndUpdateShippingOption()
+    {
+        //Arrange
+        httpClient.DefaultRequestHeaders.Remove("X-API-KEY");
+        httpClient.DefaultRequestHeaders.Add("X-API-KEY", _chosenApiKey);
+        TestUpdateShippingOptionRequestModel testUpdateShippingOptionRequestModel = new TestUpdateShippingOptionRequestModel();
+        testUpdateShippingOptionRequestModel.Id = _chosenShippingOptionId;
+        testUpdateShippingOptionRequestModel.Name = "MyShippingOptionUpdated";
+        testUpdateShippingOptionRequestModel.Description = "My shipping option description updated";
+        testUpdateShippingOptionRequestModel.ExtraCost = 10;
+
+        //Act
+        HttpResponseMessage response = await httpClient.PutAsJsonAsync("api/shippingOption", testUpdateShippingOptionRequestModel);
+        HttpResponseMessage getResponse = await httpClient.GetAsync($"api/shippingOption/{_chosenShippingOptionId}/includeDeactivated/true");
+        string? getResponseBody = await getResponse.Content.ReadAsStringAsync();
+        TestShippingOption? testShippingOption = JsonSerializer.Deserialize<TestShippingOption>(getResponseBody, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+
+        //Assert
+        response.StatusCode.Should().Be(HttpStatusCode.NoContent);
+        testShippingOption!.Name.Should().NotBeNull().And.Be(testUpdateShippingOptionRequestModel.Name);
+        testShippingOption!.Description.Should().NotBeNull().And.Be(testUpdateShippingOptionRequestModel.Description);
+        testShippingOption!.ExtraCost.Should().NotBeNull().And.Be(testUpdateShippingOptionRequestModel.ExtraCost);
+        testShippingOption.ContainsDelivery.Should().BeTrue();
+        testShippingOption.IsDeactivated.Should().BeFalse();
+        testShippingOption.ExistsInOrder.Should().BeFalse();
+        testShippingOption.Orders.Should().NotBeNull().And.HaveCount(0);
+    }
+
+    [Test, Order(160)]
+    public async Task DeleteShippingOption_ShouldFailAndReturnUnauthorized_IfAPIKeyIsInvalid()
+    {
+        //Arrange
+        httpClient.DefaultRequestHeaders.Remove("X-API-KEY");
+        httpClient.DefaultRequestHeaders.Add("X-API-KEY", "bogusKey");
+        string shippingOptionId = _chosenShippingOptionId!;
+
+        //Act
+        HttpResponseMessage response = await httpClient.DeleteAsync($"api/shippingOption/{shippingOptionId}");
+        string? errorMessage = await TestUtilitiesLibrary.JsonUtilities.GetSingleStringValueFromBody(response, "errorMessage");
+
+        //Assert
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+        errorMessage.Should().NotBeNull().And.Contain("Invalid");
+    }
+
+    [Test, Order(170)]
+    public async Task DeleteShippingOption_ShouldFailAndReturnNotFound_IfShippingOptionNotInSystem()
+    {
+        //Arrange
+        httpClient.DefaultRequestHeaders.Remove("X-API-KEY");
+        httpClient.DefaultRequestHeaders.Add("X-API-KEY", _chosenApiKey);
+        string bogusShippingOptionId = "bogusShippingOptionId";
+
+        //Act
+        HttpResponseMessage response = await httpClient.DeleteAsync($"api/shippingOption/{bogusShippingOptionId}");
+
+        //Assert
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Test, Order(180)]
+    public async Task DeleteShippingOption_ShouldSucceedAndDeleteShippingOption()
+    {
+        //Arrange
+        httpClient.DefaultRequestHeaders.Remove("X-API-KEY");
+        httpClient.DefaultRequestHeaders.Add("X-API-KEY", _chosenApiKey);
+        string shippingOptionId = _chosenShippingOptionId!;
+
+        //Act
+        HttpResponseMessage response = await httpClient.DeleteAsync($"api/shippingOption/{shippingOptionId}");
+        HttpResponseMessage secondResponse = await httpClient.DeleteAsync($"api/shippingOption/{shippingOptionId}");
+
+        //Assert
+        response.StatusCode.Should().Be(HttpStatusCode.NoContent);
+        secondResponse.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    //Rate Limit Test
+    [Test, Order(300)]
+    public async Task GetShippingOptions_ShouldFail_IfRateLimitIsExceededAndBypassHeaderNotFilledCorrectly()
+    {
+        //Arrange
+        httpClient.DefaultRequestHeaders.Remove("X-Bypass-Rate-Limiting");
+        httpClient.DefaultRequestHeaders.Remove("X-API-KEY");
+        httpClient.DefaultRequestHeaders.Add("X-API-KEY", _chosenApiKey);
+
+        //Act
+        HttpResponseMessage response = new();
+        for (int i = 0; i < 101; i++)
+            response = await httpClient.GetAsync("api/shippingOption/amount/10/includeDeactivated/true");
+
+        //Assert
+        response.StatusCode.Should().Be(HttpStatusCode.TooManyRequests);
+    }
+
+    [OneTimeTearDown]
+    public void OnTimeTearDown()
+    {
+        httpClient.Dispose();
+        TestUtilitiesLibrary.DatabaseUtilities.ResetSqlAuthDatabase(
+            "Data Source=(localdb)\\MSSQLLocalDB;Initial Catalog=EshopAppDataDb;Integrated Security=True;Connect Timeout=30;Encrypt=False;TrustServerCertificate=False;ApplicationIntent=ReadWrite;MultiSubnetFailover=False",
+            new string[] { "dbo.Attributes", "dbo.Categories", "dbo.Products", "dbo.Variants", "dbo.Discounts", "dbo.Images", "dbo.VariantImages", "dbo.Orders", "dbo.Coupons", "dbo.UserCoupons", "dbo.ShippingOptions", "dbo.PaymentOptions" },
+            "Data Database Successfully Cleared!"
+        );
+    }
+}

--- a/EshopApp.DataLibraryAPI.Tests/IntegrationTests/ControllerTests/VariantControllerTests.cs
+++ b/EshopApp.DataLibraryAPI.Tests/IntegrationTests/ControllerTests/VariantControllerTests.cs
@@ -42,7 +42,7 @@ internal class VariantControllerTests
 
         TestUtilitiesLibrary.DatabaseUtilities.ResetSqlAuthDatabase(
             "Data Source=(localdb)\\MSSQLLocalDB;Initial Catalog=EshopAppDataDb;Integrated Security=True;Connect Timeout=30;Encrypt=False;TrustServerCertificate=False;ApplicationIntent=ReadWrite;MultiSubnetFailover=False",
-            new string[] { "dbo.Attributes", "dbo.Categories", "dbo.Products", "dbo.Variants", "dbo.Discounts", "dbo.Images", "dbo.VariantImages", "dbo.Coupons", "dbo.UserCoupons" },
+            new string[] { "dbo.Attributes", "dbo.Categories", "dbo.Products", "dbo.Variants", "dbo.Discounts", "dbo.Images", "dbo.VariantImages", "dbo.Orders", "dbo.Coupons", "dbo.UserCoupons", "dbo.ShippingOptions", "dbo.PaymentOptions" },
             "Data Database Successfully Cleared!"
         );
 
@@ -742,7 +742,7 @@ internal class VariantControllerTests
         httpClient.Dispose();
         TestUtilitiesLibrary.DatabaseUtilities.ResetSqlAuthDatabase(
             "Data Source=(localdb)\\MSSQLLocalDB;Initial Catalog=EshopAppDataDb;Integrated Security=True;Connect Timeout=30;Encrypt=False;TrustServerCertificate=False;ApplicationIntent=ReadWrite;MultiSubnetFailover=False",
-            new string[] { "dbo.Attributes", "dbo.Categories", "dbo.Products", "dbo.Variants", "dbo.Discounts", "dbo.Images", "dbo.VariantImages", "dbo.Coupons", "dbo.UserCoupons" },
+            new string[] { "dbo.Attributes", "dbo.Categories", "dbo.Products", "dbo.Variants", "dbo.Discounts", "dbo.Images", "dbo.VariantImages", "dbo.Orders", "dbo.Coupons", "dbo.UserCoupons", "dbo.ShippingOptions", "dbo.PaymentOptions" },
             "Data Database Successfully Cleared!"
         );
     }

--- a/EshopApp.DataLibraryAPI.Tests/IntegrationTests/Models/OrderModels/TestCreateOrderRequestModel.cs
+++ b/EshopApp.DataLibraryAPI.Tests/IntegrationTests/Models/OrderModels/TestCreateOrderRequestModel.cs
@@ -1,59 +1,27 @@
-﻿using System.ComponentModel.DataAnnotations;
-
-namespace EshopApp.DataLibraryAPI.Models.RequestModels.OrderModels;
-
-public class CreateOrderRequestModel
+﻿namespace EshopApp.DataLibraryAPI.Tests.IntegrationTests.Models.OrderModels;
+internal class TestCreateOrderRequestModel
 {
     public string? Comment { get; set; }
-    [Required]
-    [EmailAddress]
     public string? Email { get; set; }
-    [Required]
-    [MaxLength(50)]
     public string? FirstName { get; set; }
-    [Required]
-    [MaxLength(50)]
     public string? LastName { get; set; }
-    [Required]
-    [MaxLength(50)]
     public string? Country { get; set; }
-    [Required]
-    [MaxLength(50)]
     public string? City { get; set; }
-    [Required]
-    [MaxLength(50)]
     public string? PostalCode { get; set; }
-    [Required]
-    [MaxLength(50)]
     public string? Address { get; set; }
-    [Required]
-    [MaxLength(50)]
     public string? PhoneNumber { get; set; }
     public bool? IsShippingAddressDifferent { get; set; }
-    [MaxLength(50)]
     public string? AltFirstName { get; set; }
-    [MaxLength(50)]
     public string? AltLastName { get; set; }
-    [MaxLength(50)]
     public string? AltCountry { get; set; }
-    [MaxLength(50)]
     public string? AltCity { get; set; }
-    [MaxLength(50)]
     public string? AltPostalCode { get; set; }
-    [MaxLength(50)]
     public string? AltAddress { get; set; }
-    [MaxLength(50)]
     public string? AltPhoneNumber { get; set; }
-    [Required]
     public string? UserId { get; set; }
-    [Required]
-    public List<OrderItemRequestModel> OrderItemRequestModels { get; set; } = new List<OrderItemRequestModel>();
-    [Required]
+    public List<TestOrderItemRequestModel> OrderItemRequestModels { get; set; } = new List<TestOrderItemRequestModel>();
     public string? PaymentProcessorSessionId { get; set; }
-    [Required]
-    [MaxLength(50)]
     public string? PaymentOptionId { get; set; }
-    [Required]
     public string? ShippingOptionId { get; set; }
     public string? UserCouponId { get; set; }
 }

--- a/EshopApp.DataLibraryAPI.Tests/IntegrationTests/Models/OrderModels/TestOrderItemRequestModel.cs
+++ b/EshopApp.DataLibraryAPI.Tests/IntegrationTests/Models/OrderModels/TestOrderItemRequestModel.cs
@@ -1,0 +1,6 @@
+﻿namespace EshopApp.DataLibraryAPI.Tests.IntegrationTests.Models.OrderModels;
+internal class TestOrderItemRequestModel
+{
+    public int? Quantity { get; set; }
+    public string? VariantId { get; set; }
+}

--- a/EshopApp.DataLibraryAPI.Tests/IntegrationTests/Models/OrderModels/TestUpdateOrderRequestModel.cs
+++ b/EshopApp.DataLibraryAPI.Tests/IntegrationTests/Models/OrderModels/TestUpdateOrderRequestModel.cs
@@ -1,54 +1,29 @@
-﻿using System.ComponentModel.DataAnnotations;
-
-namespace EshopApp.DataLibraryAPI.Models.RequestModels.OrderModels;
-
-public class UpdateOrderRequestModel
+﻿namespace EshopApp.DataLibraryAPI.Tests.IntegrationTests.Models.OrderModels;
+internal class TestUpdateOrderRequestModel
 {
-    [MaxLength(50)]
     public string? Id { get; set; }
     public string? PaymentProcessorSessionId { get; set; }
-    [EmailAddress]
     public string? Email { get; set; }
-    [MaxLength(50)]
     public string? FirstName { get; set; }
-    [MaxLength(50)]
     public string? LastName { get; set; }
-    [MaxLength(50)]
     public string? Country { get; set; }
-    [MaxLength(50)]
     public string? City { get; set; }
-    [MaxLength(50)]
     public string? PostalCode { get; set; }
-    [MaxLength(50)]
     public string? Address { get; set; }
-    [MaxLength(50)]
     public string? PhoneNumber { get; set; }
     public bool? IsShippingAddressDifferent { get; set; }
-    [MaxLength(50)]
     public string? AltFirstName { get; set; }
-    [MaxLength(50)]
     public string? AltLastName { get; set; }
-    [MaxLength(50)]
     public string? AltCountry { get; set; }
-    [MaxLength(50)]
     public string? AltCity { get; set; }
-    [MaxLength(50)]
     public string? AltPostalCode { get; set; }
-    [MaxLength(50)]
     public string? AltAddress { get; set; }
-    [MaxLength(50)]
     public string? AltPhoneNumber { get; set; }
-
-    [MaxLength(50)]
     public string? PaymentStatus { get; set; }
-    [MaxLength(5)]
     public string? PaymentCurrency { get; set; }
-    [Range(0, int.MaxValue, ErrorMessage = "The AmountPaidInCustomerCurrency property can not be negative")]
     public decimal? AmountPaidInCustomerCurrency { get; set; }
-    [Range(0, int.MaxValue, ErrorMessage = "The AmountPaidInEuro property can not be negative")]
     public decimal? AmountPaidInEuro { get; set; }
-    [Range(0, int.MaxValue, ErrorMessage = "The NetAmountPaidInEuro property can not be negative")]
     public decimal? NetAmountPaidInEuro { get; set; }
-    public List<OrderItemRequestModel>? OrderItemRequestModels { get; set; }
+    public List<TestOrderItemRequestModel>? OrderItemRequestModels { get; set; }
     public string? UserCouponId { get; set; }
 }

--- a/EshopApp.DataLibraryAPI.Tests/IntegrationTests/Models/OrderModels/TestUpdateOrderStatusRequestModel.cs
+++ b/EshopApp.DataLibraryAPI.Tests/IntegrationTests/Models/OrderModels/TestUpdateOrderStatusRequestModel.cs
@@ -1,0 +1,6 @@
+﻿namespace EshopApp.DataLibraryAPI.Tests.IntegrationTests.Models.OrderModels;
+internal class TestUpdateOrderStatusRequestModel
+{
+    public string? NewOrderStatus { get; set; }
+    public string? OrderId { get; set; }
+}

--- a/EshopApp.DataLibraryAPI.Tests/IntegrationTests/Models/PaymentOptionModels/TestCreatePaymentOptionRequestModel.cs
+++ b/EshopApp.DataLibraryAPI.Tests/IntegrationTests/Models/PaymentOptionModels/TestCreatePaymentOptionRequestModel.cs
@@ -1,0 +1,10 @@
+﻿namespace EshopApp.DataLibraryAPI.Tests.IntegrationTests.Models.PaymentOptionModels;
+internal class TestCreatePaymentOptionRequestModel
+{
+    public string? Name { get; set; }
+    public string? NameAlias { get; set; }
+    public string? Description { get; set; }
+    public decimal? ExtraCost { get; set; }
+    public bool? IsDeactivated { get; set; }
+    public bool? ExistsInOrder { get; set; }
+}

--- a/EshopApp.DataLibraryAPI.Tests/IntegrationTests/Models/PaymentOptionModels/TestUpdatePaymentOptionRequestModel.cs
+++ b/EshopApp.DataLibraryAPI.Tests/IntegrationTests/Models/PaymentOptionModels/TestUpdatePaymentOptionRequestModel.cs
@@ -1,0 +1,13 @@
+﻿namespace EshopApp.DataLibraryAPI.Tests.IntegrationTests.Models.PaymentOptionModels;
+internal class TestUpdatePaymentOptionRequestModel
+{
+    public string? Id { get; set; }
+    public string? Name { get; set; }
+    public string? NameAlias { get; set; }
+    public string? Description { get; set; }
+    public decimal? ExtraCost { get; set; }
+    public bool? IsDeactivated { get; set; }
+    public bool? ExistsInOrder { get; set; }
+    public List<string>? PaymentDetailsIds { get; set; }
+
+}

--- a/EshopApp.DataLibraryAPI.Tests/IntegrationTests/Models/ShippingOptionModels/TestCreateShippingOptionRequestModel.cs
+++ b/EshopApp.DataLibraryAPI.Tests/IntegrationTests/Models/ShippingOptionModels/TestCreateShippingOptionRequestModel.cs
@@ -1,0 +1,10 @@
+﻿namespace EshopApp.DataLibraryAPI.Tests.IntegrationTests.Models.ShippingOptionModels;
+internal class TestCreateShippingOptionRequestModel
+{
+    public string? Name { get; set; }
+    public string? Description { get; set; }
+    public decimal? ExtraCost { get; set; }
+    public bool? ContainsDelivery { get; set; }
+    public bool? IsDeactivated { get; set; }
+    public bool? ExistsInOrder { get; set; }
+}

--- a/EshopApp.DataLibraryAPI.Tests/IntegrationTests/Models/ShippingOptionModels/TestUpdateShippingOptionRequestModel.cs
+++ b/EshopApp.DataLibraryAPI.Tests/IntegrationTests/Models/ShippingOptionModels/TestUpdateShippingOptionRequestModel.cs
@@ -1,0 +1,13 @@
+﻿namespace EshopApp.DataLibraryAPI.Tests.IntegrationTests.Models.ShippingOptionModels;
+internal class TestUpdateShippingOptionRequestModel
+{
+    public string? Id { get; set; }
+    public string? Name { get; set; }
+    public string? Description { get; set; }
+    public decimal? ExtraCost { get; set; }
+    public bool? ContainsDelivery { get; set; }
+    public bool? IsDeactivated { get; set; }
+    public bool? ExistsInOrder { get; set; }
+    public List<string>? OrderIds { get; set; }
+
+}

--- a/EshopApp.DataLibraryAPI.Tests/IntegrationTests/Models/TestOrder.cs
+++ b/EshopApp.DataLibraryAPI.Tests/IntegrationTests/Models/TestOrder.cs
@@ -1,0 +1,22 @@
+﻿using EshopApp.DataLibrary.Models;
+
+namespace EshopApp.DataLibraryAPI.Tests.IntegrationTests.Models;
+internal class TestOrder
+{
+    public string? Id { get; set; }
+    public string? Comment { get; set; }
+    public string? OrderStatus { get; set; } //Pending - Confirmed - Processing - Shipped - Delivered - Canceled - Refunded - Failed
+    public decimal? FinalPrice { get; set; }
+    public decimal? ShippingCostAtOrder { get; set; }
+    public int? CouponDiscountPercentageAtOrder { get; set; }
+    public DateTime CreatedAt { get; set; }
+    public DateTime ModifiedAt { get; set; }
+    public string? UserId { get; set; }
+    public OrderAddress? OrderAddress { get; set; }
+    public List<OrderItem> OrderItems { get; set; } = new List<OrderItem>();
+    public PaymentDetails? PaymentDetails { get; set; }
+    public string? ShippingOptionId { get; set; }
+    public ShippingOption? ShippingOption { get; set; }
+    public string? UserCouponId { get; set; }
+    public UserCoupon? UserCoupon { get; set; }
+}

--- a/EshopApp.DataLibraryAPI.Tests/IntegrationTests/Models/TestPaymentOption.cs
+++ b/EshopApp.DataLibraryAPI.Tests/IntegrationTests/Models/TestPaymentOption.cs
@@ -1,0 +1,16 @@
+﻿using EshopApp.DataLibrary.Models;
+
+namespace EshopApp.DataLibraryAPI.Tests.IntegrationTests.Models;
+internal class TestPaymentOption
+{
+    public string? Id { get; set; }
+    public string? Name { get; set; }
+    public string? NameAlias { get; set; }
+    public string? Description { get; set; }
+    public decimal? ExtraCost { get; set; }
+    public bool? IsDeactivated { get; set; }
+    public bool? ExistsInOrder { get; set; }
+    public DateTime? CreatedAt { get; set; }
+    public DateTime? ModifiedAt { get; set; }
+    public List<PaymentDetails> PaymentDetails { get; set; } = new List<PaymentDetails>();
+}

--- a/EshopApp.DataLibraryAPI.Tests/IntegrationTests/Models/TestShippingOption.cs
+++ b/EshopApp.DataLibraryAPI.Tests/IntegrationTests/Models/TestShippingOption.cs
@@ -1,0 +1,17 @@
+﻿using EshopApp.DataLibrary.Models;
+
+namespace EshopApp.DataLibraryAPI.Tests.IntegrationTests.Models;
+internal class TestShippingOption
+{
+    public string? Id { get; set; }
+    public string? Name { get; set; }
+    public string? Description { get; set; }
+    public decimal? ExtraCost { get; set; }
+    public bool? ContainsDelivery { get; set; }
+    public bool? IsDeactivated { get; set; }
+    public bool? ExistsInOrder { get; set; }
+    public List<Order> Orders { get; set; } = new List<Order>();
+    public DateTime CreatedAt { get; set; }
+    public DateTime ModifiedAt { get; set; }
+
+}

--- a/EshopApp.DataLibraryAPI/Controllers/DiscountController.cs
+++ b/EshopApp.DataLibraryAPI/Controllers/DiscountController.cs
@@ -121,5 +121,4 @@ public class DiscountController : ControllerBase
             return StatusCode(500);
         }
     }
-
 }

--- a/EshopApp.DataLibraryAPI/Controllers/OrderController.cs
+++ b/EshopApp.DataLibraryAPI/Controllers/OrderController.cs
@@ -86,7 +86,7 @@ public class OrderController : ControllerBase
                 PaymentOptionId = createOrderRequestModel.PaymentOptionId
             };
 
-            foreach (OrderItemRequestModel createOrderItemRequestModel in createOrderRequestModel.CreateOrderItemRequestModels)
+            foreach (OrderItemRequestModel createOrderItemRequestModel in createOrderRequestModel.OrderItemRequestModels)
             {
                 OrderItem orderItem = new OrderItem();
                 orderItem.Quantity = createOrderItemRequestModel.Quantity;
@@ -110,8 +110,12 @@ public class OrderController : ControllerBase
                 return NotFound(new { ErrorMessage = "InvalidCouponIdWasGiven" });
             else if (response.ReturnedCode == DataLibraryReturnedCodes.CouponCodeCurrentlyDeactivated)
                 return BadRequest(new { ErrorMessage = "CouponCodeCurrentlyDeactivated" });
-            else if (response.ReturnedCode == DataLibraryReturnedCodes.TheOrderItemsOfTheOrderWereAllInvalid)
-                return BadRequest(new { ErrorMessage = "TheOrderItemsOfTheOrderWereAllInvalid" });
+            else if (response.ReturnedCode == DataLibraryReturnedCodes.CouponUsageLimitExceeded)
+                return BadRequest(new { ErrorMessage = "CouponUsageLimitExceeded" });
+            else if (response.ReturnedCode == DataLibraryReturnedCodes.InvalidVariantIdWasGiven)
+                return NotFound(new { ErrorMessage = "InvalidVariantIdWasGiven" });
+            else if (response.ReturnedCode == DataLibraryReturnedCodes.InsufficientStockForVariant)
+                return BadRequest(new { ErrorMessage = "InsufficientStockForVariant" });
 
             return CreatedAtAction(nameof(GetOrderById), new { id = response.Order!.Id }, response.Order);
         }
@@ -158,7 +162,7 @@ public class OrderController : ControllerBase
                 NetAmountPaidInEuro = updateOrderRequestModel.NetAmountPaidInEuro
             };
 
-            foreach (OrderItemRequestModel createOrderItemRequestModel in updateOrderRequestModel.CreateOrderItemRequestModels ?? Enumerable.Empty<OrderItemRequestModel>())
+            foreach (OrderItemRequestModel createOrderItemRequestModel in updateOrderRequestModel.OrderItemRequestModels ?? Enumerable.Empty<OrderItemRequestModel>())
             {
                 OrderItem orderItem = new OrderItem();
                 orderItem.Quantity = createOrderItemRequestModel.Quantity;
@@ -178,8 +182,16 @@ public class OrderController : ControllerBase
                 return BadRequest(new { ErrorMessage = "TheOrderIdAndThePaymentProcessorSessionIdCanNotBeBothNull" });
             else if (returnedCode == DataLibraryReturnedCodes.OrderStatusHasBeenFinalizedAndThusTheOrderCanNotBeAltered)
                 return BadRequest(new { ErrorMessage = "OrderStatusHasBeenFinalizedAndThusTheOrderCanNotBeAltered" });
-            else if (returnedCode == DataLibraryReturnedCodes.TheOrderItemsOfTheOrderWereAllInvalid)
-                return BadRequest(new { ErrorMessage = "TheOrderItemsOfTheOrderWereAllInvalid" });
+            else if (returnedCode == DataLibraryReturnedCodes.InvalidCouponIdWasGiven)
+                return NotFound(new { ErrorMessage = "InvalidCouponIdWasGiven" });
+            else if (returnedCode == DataLibraryReturnedCodes.CouponCodeCurrentlyDeactivated)
+                return BadRequest(new { ErrorMessage = "CouponCodeCurrentlyDeactivated" });
+            else if (returnedCode == DataLibraryReturnedCodes.CouponUsageLimitExceeded)
+                return BadRequest(new { ErrorMessage = "CouponUsageLimitExceeded" });
+            else if (returnedCode == DataLibraryReturnedCodes.InvalidVariantIdWasGiven)
+                return NotFound(new { ErrorMessage = "InvalidVariantIdWasGiven" });
+            else if (returnedCode == DataLibraryReturnedCodes.InsufficientStockForVariant)
+                return BadRequest(new { ErrorMessage = "InsufficientStockForVariant" });
 
             return NoContent();
         }
@@ -189,8 +201,8 @@ public class OrderController : ControllerBase
         }
     }
 
-    [HttpPut]
-    public async Task<IActionResult> UpdateOrderStatus(UpdateOrderStatusRequestModels updateOrderStatusRequestModels)
+    [HttpPut("UpdateOrderStatus")]
+    public async Task<IActionResult> UpdateOrderStatus(UpdateOrderStatusRequestModel updateOrderStatusRequestModels)
     {
         try
         {
@@ -201,6 +213,8 @@ public class OrderController : ControllerBase
                 return BadRequest(new { ErrorMessage = "OrderStatusHasBeenFinalizedAndThusOrderStatusCanNotBeAltered" });
             else if (returnedCode == DataLibraryReturnedCodes.InvalidOrderStatus)
                 return BadRequest(new { ErrorMessage = "InvalidOrderState" });
+            else if (returnedCode == DataLibraryReturnedCodes.InvalidNewOrderState)
+                return BadRequest(new { ErrorMessage = "InvalidNewOrderState" });
             else if (returnedCode == DataLibraryReturnedCodes.ThisOrderDoesNotContainShippingAndThusTheShippedStatusIsInvalid)
                 return BadRequest(new { ErrorMessage = "ThisOrderDoesNotContainShippingAndThusTheShippedStatusIsInvalid" });
 

--- a/EshopApp.DataLibraryAPI/Models/RequestModels/OrderModels/UpdateOrderStatusRequestModel.cs
+++ b/EshopApp.DataLibraryAPI/Models/RequestModels/OrderModels/UpdateOrderStatusRequestModel.cs
@@ -2,7 +2,7 @@
 
 namespace EshopApp.DataLibraryAPI.Models.RequestModels.OrderModels;
 
-public class UpdateOrderStatusRequestModels
+public class UpdateOrderStatusRequestModel
 {
     [Required]
     [MaxLength(50)]

--- a/EshopApp.DataLibraryAPI/Models/RequestModels/ShippingOptionModels/CreateShippingOptionRequestModel.cs
+++ b/EshopApp.DataLibraryAPI/Models/RequestModels/ShippingOptionModels/CreateShippingOptionRequestModel.cs
@@ -4,7 +4,6 @@ namespace EshopApp.DataLibraryAPI.Models.RequestModels.ShippingOptionModels;
 
 public class CreateShippingOptionRequestModel
 {
-
     [MaxLength(50)]
     [Required]
     public string? Name { get; set; }


### PR DESCRIPTION
…on Endpoints

I added all the necessary tests for the Order, PaymentOption and ShippingOption endpoints, which were added in the previous commit. Most of the tests were added to test the Order endpoints, which contain the most complicated logic and potentionally more will be added for it in the future, if it is deemed necessary. The tests for the PaymentOption and ShippingOption should suffice. That being said with the addition of the Order entity all the entities that are connected with it(Variant, Image, PaymentOption, ShippingOption etc) could have some extra tests on their end, which test what happens when the order exists and they admin tries to remove them. I do not think this is necessary for now, but if errors start appearing I will also test for those scenarios.