### PR TITLE
Added Endpoints In The API For The CRUD Operations That Correspond To…

### DIFF
--- a/EshopApp.DataLibrary/DataAccess/CartDataAccess.cs
+++ b/EshopApp.DataLibrary/DataAccess/CartDataAccess.cs
@@ -6,7 +6,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 
 namespace EshopApp.DataLibrary.DataAccess;
-public class CartDataAccess
+public class CartDataAccess : ICartDataAccess
 {
     private readonly AppDataDbContext _appDataDbContext;
     private readonly ILogger<CartDataAccess> _logger;
@@ -73,6 +73,8 @@ public class CartDataAccess
             {
                 if (!variantIds.Contains(cartItem.Id))
                     return new ReturnCartAndCodeResponseModel(null!, DataLibraryReturnedCodes.InvalidVariantIdWasGiven);
+
+                cartItem.CartId = cart.Id; //this is not needed, but I want this to be explicit
             }
 
             DateTime dateTimeNow = DateTime.Now;
@@ -110,7 +112,7 @@ public class CartDataAccess
                 existingVariantAlreadyInCart.Quantity += newCartItem.Quantity;
                 await _appDataDbContext.SaveChangesAsync();
                 _logger.LogInformation(new EventId(9999, "CreateCartItemSuccess"), "The cart item already existed in the cart with CartId={cartId} and thus only the quantity was updated.", newCartItem.CartId);
-                return new ReturnCartItemAndCodeResponseModel(existingVariantAlreadyInCart, DataLibraryReturnedCodes.NoError);
+                return new ReturnCartItemAndCodeResponseModel(existingVariantAlreadyInCart, DataLibraryReturnedCodes.VariantAlreadyInCartAndThusOnlyTheQuantityValueWasAdjusted);
             }
 
             newCartItem.Id = Guid.NewGuid().ToString();

--- a/EshopApp.DataLibrary/DataAccess/ICartDataAccess.cs
+++ b/EshopApp.DataLibrary/DataAccess/ICartDataAccess.cs
@@ -1,0 +1,16 @@
+﻿using EshopApp.DataLibrary.Models;
+using EshopApp.DataLibrary.Models.ResponseModels;
+using EshopApp.DataLibrary.Models.ResponseModels.CartModels;
+
+namespace EshopApp.DataLibrary.DataAccess;
+public interface ICartDataAccess
+{
+    Task<ReturnCartAndCodeResponseModel> CreateCartAsync(Cart cart);
+    Task<ReturnCartItemAndCodeResponseModel> CreateCartItemAsync(CartItem newCartItem);
+    Task<DataLibraryReturnedCodes> DeleteCartByIdAsync(string id);
+    Task<DataLibraryReturnedCodes> DeleteCartItemAsync(string id);
+    Task<DataLibraryReturnedCodes> DeleteUserCartAsync(string userId);
+    Task<ReturnCartAndCodeResponseModel> GetCardByIdAsync(string id);
+    Task<ReturnCartAndCodeResponseModel> GetCardOfUserAsync(string userId);
+    Task<DataLibraryReturnedCodes> UpdateCartItemAsync(CartItem updatedCartItem);
+}

--- a/EshopApp.DataLibrary/Models/ResponseModels/DataLibraryReturnedCodes.cs
+++ b/EshopApp.DataLibrary/Models/ResponseModels/DataLibraryReturnedCodes.cs
@@ -38,5 +38,6 @@ public enum DataLibraryReturnedCodes
     TheOrderIdAndThePaymentProcessorSessionIdCanNotBeBothNull,
     InsufficientStockForVariant,
     InvalidCartIdWasGiven,
-    UserAlreadyHasACart
+    UserAlreadyHasACart,
+    VariantAlreadyInCartAndThusOnlyTheQuantityValueWasAdjusted
 }

--- a/EshopApp.DataLibraryAPI/Controllers/AttributeController.cs
+++ b/EshopApp.DataLibraryAPI/Controllers/AttributeController.cs
@@ -103,8 +103,6 @@ public class AttributeController : ControllerBase
         try
         {
             DataLibraryReturnedCodes returnedCode = await _attributeDataAccess.DeleteAttributeAsync(id);
-            if (returnedCode == DataLibraryReturnedCodes.TheIdOfTheEntityCanNotBeNull)
-                return BadRequest(new { ErrorMessage = "TheIdOfTheEntityCanNotBeNull" });
             if (returnedCode == DataLibraryReturnedCodes.EntityNotFoundWithGivenId)
                 return NotFound();
 

--- a/EshopApp.DataLibraryAPI/Controllers/CartController.cs
+++ b/EshopApp.DataLibraryAPI/Controllers/CartController.cs
@@ -1,0 +1,184 @@
+﻿using EshopApp.DataLibrary.DataAccess;
+using EshopApp.DataLibrary.Models;
+using EshopApp.DataLibrary.Models.ResponseModels;
+using EshopApp.DataLibrary.Models.ResponseModels.CartModels;
+using EshopApp.DataLibraryAPI.Models.RequestModels.CartModels;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.RateLimiting;
+
+namespace EshopApp.DataLibraryAPI.Controllers;
+
+[ApiController]
+[EnableRateLimiting("DefaultWindowLimiter")]
+[Route("api/[controller]")]
+public class CartController : ControllerBase
+{
+    private readonly ICartDataAccess _cartDataAccess;
+
+    public CartController(ICartDataAccess cartDataAccess)
+    {
+        _cartDataAccess = cartDataAccess;
+    }
+
+    [HttpGet("Id/{id}")]
+    public async Task<IActionResult> GetCartById(string id)
+    {
+        try
+        {
+            ReturnCartAndCodeResponseModel response = await _cartDataAccess.GetCardByIdAsync(id);
+            if (response.Cart is null)
+                return NotFound();
+
+            return Ok(response.Cart);
+        }
+        catch (Exception)
+        {
+            return StatusCode(500);
+        }
+    }
+
+    [HttpGet("UserId/{userId}")]
+    public async Task<IActionResult> GetCartOfUser(string userId)
+    {
+        try
+        {
+            ReturnCartAndCodeResponseModel response = await _cartDataAccess.GetCardOfUserAsync(userId);
+            if (response.Cart is null)
+                return NotFound();
+
+            return Ok(response.Cart);
+        }
+        catch (Exception)
+        {
+            return StatusCode(500);
+        }
+    }
+
+    [HttpPost]
+    public async Task<IActionResult> CreateCart(CreateCartRequestModel createCartRequestModel)
+    {
+        try
+        {
+            Cart cart = new Cart();
+
+            cart.UserId = createCartRequestModel.UserId;
+            List<CartItem> cartItems = new List<CartItem>();
+            foreach (CreateCartItemRequestModel createCartItemRequestModel in createCartRequestModel.CreateCartItemRequestModels)
+                cartItems.Add(new CartItem() { Quantity = createCartItemRequestModel.Quantity, VariantId = createCartItemRequestModel.VariantId });
+
+            cart.CartItems = cartItems;
+
+            ReturnCartAndCodeResponseModel response = await _cartDataAccess.CreateCartAsync(cart);
+            if (response.ReturnedCode == DataLibraryReturnedCodes.UserAlreadyHasACart)
+                return BadRequest(new { ErrorMessage = "UserAlreadyHasACart" });
+            else if (response.ReturnedCode == DataLibraryReturnedCodes.InvalidVariantIdWasGiven)
+                return NotFound(new { ErrorMessage = "InvalidVariantIdWasGiven" });
+
+            return CreatedAtAction(nameof(GetCartById), new { id = response.Cart!.Id }, response.Cart);
+        }
+        catch (Exception)
+        {
+            return StatusCode(500);
+        }
+    }
+
+    [HttpPost("CartItem")]
+    public async Task<IActionResult> CreateCartItem(CreateCartItemRequestModel createCartItemRequestModel)
+    {
+        try
+        {
+            CartItem cartItem = new CartItem();
+            cartItem.CartId = createCartItemRequestModel.CartId;
+            cartItem.VariantId = createCartItemRequestModel.VariantId;
+            cartItem.Quantity = createCartItemRequestModel.Quantity;
+
+            ReturnCartItemAndCodeResponseModel response = await _cartDataAccess.CreateCartItemAsync(cartItem);
+            if (response.ReturnedCode == DataLibraryReturnedCodes.InvalidVariantIdWasGiven)
+                return NotFound(new { ErrorMessage = "InvalidVariantIdWasGiven" });
+            else if (response.ReturnedCode == DataLibraryReturnedCodes.InvalidCartIdWasGiven)
+                return NotFound(new { ErrorMessage = "InvalidCartIdWasGiven" });
+            else if (response.ReturnedCode == DataLibraryReturnedCodes.VariantAlreadyInCartAndThusOnlyTheQuantityValueWasAdjusted)
+                return Ok(response.CartItem);
+
+            return Created("", response.CartItem);
+        }
+        catch (Exception)
+        {
+            return StatusCode(500);
+        }
+    }
+
+    [HttpPut("CartItem")]
+    public async Task<IActionResult> UpdateCartItem(UpdateCartItemRequestModel updateCartItemRequestModel)
+    {
+        try
+        {
+            CartItem cartItem = new CartItem();
+            cartItem.CartId = updateCartItemRequestModel.CartId;
+            cartItem.Quantity = updateCartItemRequestModel.Quantity;
+            cartItem.VariantId = updateCartItemRequestModel.VariantId;
+
+            DataLibraryReturnedCodes returnedCode = await _cartDataAccess.UpdateCartItemAsync(cartItem);
+            if (returnedCode == DataLibraryReturnedCodes.EntityNotFoundWithGivenId)
+                return NotFound(new { ErrorMessage = "EntityNotFoundWithGivenId" });
+
+            return NoContent();
+        }
+        catch (Exception)
+        {
+            return StatusCode(500);
+        }
+    }
+
+    [HttpDelete("CartItem/{id}")]
+    public async Task<IActionResult> DeleteCartItem(string id)
+    {
+        try
+        {
+            DataLibraryReturnedCodes returnedCode = await _cartDataAccess.DeleteCartItemAsync(id);
+            if (returnedCode == DataLibraryReturnedCodes.EntityNotFoundWithGivenId)
+                return NotFound();
+
+            return NoContent();
+        }
+        catch (Exception)
+        {
+            return StatusCode(500);
+        }
+    }
+
+    [HttpDelete("Id/{id}")]
+    public async Task<IActionResult> DeleteCartById(string id)
+    {
+        try
+        {
+            DataLibraryReturnedCodes returnedCode = await _cartDataAccess.DeleteCartByIdAsync(id);
+            if (returnedCode == DataLibraryReturnedCodes.EntityNotFoundWithGivenId)
+                return NotFound();
+
+            return NoContent();
+        }
+        catch (Exception)
+        {
+            return StatusCode(500);
+        }
+    }
+
+    [HttpDelete("UserId/{userId}")]
+    public async Task<IActionResult> DeleteCartByUserId(string userId)
+    {
+        try
+        {
+            DataLibraryReturnedCodes returnedCode = await _cartDataAccess.DeleteUserCartAsync(userId);
+            if (returnedCode == DataLibraryReturnedCodes.EntityNotFoundWithGivenId)
+                return NotFound();
+
+            return NoContent();
+        }
+        catch (Exception)
+        {
+            return StatusCode(500);
+        }
+    }
+
+}

--- a/EshopApp.DataLibraryAPI/Controllers/CategoryController.cs
+++ b/EshopApp.DataLibraryAPI/Controllers/CategoryController.cs
@@ -102,9 +102,7 @@ public class CategoryController : ControllerBase
         try
         {
             DataLibraryReturnedCodes returnedCode = await _categoryDataAccess.DeleteCategoryAsync(id);
-            if (returnedCode == DataLibraryReturnedCodes.TheIdOfTheEntityCanNotBeNull)
-                return BadRequest(new { ErrorMessage = "TheIdOfTheEntityCanNotBeNull" });
-            else if (returnedCode == DataLibraryReturnedCodes.EntityNotFoundWithGivenId)
+            if (returnedCode == DataLibraryReturnedCodes.EntityNotFoundWithGivenId)
                 return NotFound();
 
             return NoContent();
@@ -114,5 +112,4 @@ public class CategoryController : ControllerBase
             return StatusCode(500);
         }
     }
-
 }

--- a/EshopApp.DataLibraryAPI/Controllers/CouponController.cs
+++ b/EshopApp.DataLibraryAPI/Controllers/CouponController.cs
@@ -122,9 +122,7 @@ public class CouponController : ControllerBase
         try
         {
             DataLibraryReturnedCodes returnedCode = await _couponDataAccess.DeleteCouponAsync(id);
-            if (returnedCode == DataLibraryReturnedCodes.TheIdOfTheEntityCanNotBeNull)
-                return BadRequest(new { ErrorMessage = "TheIdOfTheEntityCanNotBeNull" });
-            else if (returnedCode == DataLibraryReturnedCodes.EntityNotFoundWithGivenId)
+            if (returnedCode == DataLibraryReturnedCodes.EntityNotFoundWithGivenId)
                 return NotFound();
             else if (returnedCode == DataLibraryReturnedCodes.NoErrorButNotFullyDeleted)
                 return Ok(new { WarningMessage = "NoErrorButNotFullyDeleted" });
@@ -218,9 +216,7 @@ public class CouponController : ControllerBase
         try
         {
             DataLibraryReturnedCodes returnedCode = await _couponDataAccess.RemoveCouponFromUser(userCouponId);
-            if (returnedCode == DataLibraryReturnedCodes.TheIdOfTheEntityCanNotBeNull)
-                return BadRequest(new { ErrorMessage = "TheIdOfTheEntityCanNotBeNull" });
-            else if (returnedCode == DataLibraryReturnedCodes.EntityNotFoundWithGivenId)
+            if (returnedCode == DataLibraryReturnedCodes.EntityNotFoundWithGivenId)
                 return NotFound();
             else if (returnedCode == DataLibraryReturnedCodes.NoErrorButNotFullyDeleted)
                 return Ok(new { WarningMessage = "NoErrorButNotFullyDeleted" });
@@ -232,5 +228,4 @@ public class CouponController : ControllerBase
             return StatusCode(500);
         }
     }
-
 }

--- a/EshopApp.DataLibraryAPI/Controllers/DiscountController.cs
+++ b/EshopApp.DataLibraryAPI/Controllers/DiscountController.cs
@@ -107,9 +107,7 @@ public class DiscountController : ControllerBase
         try
         {
             DataLibraryReturnedCodes returnedCode = await _discountDataAccess.DeleteDiscountAsync(id);
-            if (returnedCode == DataLibraryReturnedCodes.TheIdOfTheEntityCanNotBeNull)
-                return BadRequest(new { ErrorMessage = "TheIdOfTheEntityCanNotBeNull" });
-            else if (returnedCode == DataLibraryReturnedCodes.EntityNotFoundWithGivenId)
+            if (returnedCode == DataLibraryReturnedCodes.EntityNotFoundWithGivenId)
                 return NotFound();
             else if (returnedCode == DataLibraryReturnedCodes.NoErrorButNotFullyDeleted)
                 return Ok(new { WarningMessage = "NoErrorButNotFullyDeleted" });

--- a/EshopApp.DataLibraryAPI/Controllers/ImageController.cs
+++ b/EshopApp.DataLibraryAPI/Controllers/ImageController.cs
@@ -122,8 +122,6 @@ public class ImageController : ControllerBase
         try
         {
             DataLibraryReturnedCodes returnedCode = await _imageDataAccess.DeleteImageAsync(id);
-            if (returnedCode == DataLibraryReturnedCodes.TheIdOfTheEntityCanNotBeNull)
-                return BadRequest(new { ErrorMessage = "TheIdOfTheEntityCanNotBeNull" });
             if (returnedCode == DataLibraryReturnedCodes.EntityNotFoundWithGivenId)
                 return NotFound();
             else if (returnedCode == DataLibraryReturnedCodes.NoErrorButNotFullyDeleted)

--- a/EshopApp.DataLibraryAPI/Controllers/OrderController.cs
+++ b/EshopApp.DataLibraryAPI/Controllers/OrderController.cs
@@ -232,9 +232,7 @@ public class OrderController : ControllerBase
         try
         {
             DataLibraryReturnedCodes returnedCode = await _orderDataAccess.DeleteOrderAsync(id);
-            if (returnedCode == DataLibraryReturnedCodes.TheIdOfTheEntityCanNotBeNull)
-                return BadRequest(new { ErrorMessage = "TheIdOfTheEntityCanNotBeNull" });
-            else if (returnedCode == DataLibraryReturnedCodes.EntityNotFoundWithGivenId)
+            if (returnedCode == DataLibraryReturnedCodes.EntityNotFoundWithGivenId)
                 return NotFound();
 
             return NoContent();

--- a/EshopApp.DataLibraryAPI/Controllers/PaymentOptionController.cs
+++ b/EshopApp.DataLibraryAPI/Controllers/PaymentOptionController.cs
@@ -118,9 +118,7 @@ public class PaymentOptionController : ControllerBase
         try
         {
             DataLibraryReturnedCodes returnedCode = await _paymentOptionDataAccess.DeletePaymentOptionAsync(id);
-            if (returnedCode == DataLibraryReturnedCodes.TheIdOfTheEntityCanNotBeNull)
-                return BadRequest(new { ErrorMessage = "TheIdOfTheEntityCanNotBeNull" });
-            else if (returnedCode == DataLibraryReturnedCodes.EntityNotFoundWithGivenId)
+            if (returnedCode == DataLibraryReturnedCodes.EntityNotFoundWithGivenId)
                 return NotFound();
             else if (returnedCode == DataLibraryReturnedCodes.NoErrorButNotFullyDeleted)
                 return Ok(new { WarningMessage = "NoErrorButNotFullyDeleted" });

--- a/EshopApp.DataLibraryAPI/Controllers/ProductController.cs
+++ b/EshopApp.DataLibraryAPI/Controllers/ProductController.cs
@@ -149,9 +149,7 @@ public class ProductController : ControllerBase
         try
         {
             DataLibraryReturnedCodes returnedCode = await _productDataAccess.DeleteProductAsync(id);
-            if (returnedCode == DataLibraryReturnedCodes.TheIdOfTheEntityCanNotBeNull)
-                return BadRequest(new { ErrorMessage = "TheIdOfTheEntityCanNotBeNull" });
-            else if (returnedCode == DataLibraryReturnedCodes.EntityNotFoundWithGivenId)
+            if (returnedCode == DataLibraryReturnedCodes.EntityNotFoundWithGivenId)
                 return NotFound(new { ErrorMessage = "EntityNotFoundWithGivenId" });
             else if (returnedCode == DataLibraryReturnedCodes.NoErrorButNotFullyDeleted)
                 return Ok(new { WarningMessage = "NoErrorButNotFullyDeleted" });

--- a/EshopApp.DataLibraryAPI/Controllers/ShippingOptionController.cs
+++ b/EshopApp.DataLibraryAPI/Controllers/ShippingOptionController.cs
@@ -114,9 +114,7 @@ public class ShippingOptionController : ControllerBase
         try
         {
             DataLibraryReturnedCodes returnedCode = await _shippingOptionDataAccess.DeleteShippingOptionAsync(id);
-            if (returnedCode == DataLibraryReturnedCodes.TheIdOfTheEntityCanNotBeNull)
-                return BadRequest(new { ErrorMessage = "TheIdOfTheEntityCanNotBeNull" });
-            else if (returnedCode == DataLibraryReturnedCodes.EntityNotFoundWithGivenId)
+            if (returnedCode == DataLibraryReturnedCodes.EntityNotFoundWithGivenId)
                 return NotFound();
             else if (returnedCode == DataLibraryReturnedCodes.NoErrorButNotFullyDeleted)
                 return Ok(new { WarningMessage = "NoErrorButNotFullyDeleted" });

--- a/EshopApp.DataLibraryAPI/Controllers/VariantController.cs
+++ b/EshopApp.DataLibraryAPI/Controllers/VariantController.cs
@@ -140,9 +140,7 @@ public class VariantController : ControllerBase
         try
         {
             DataLibraryReturnedCodes returnedCode = await _variantDataAccess.DeleteVariantAsync(id);
-            if (returnedCode == DataLibraryReturnedCodes.TheIdOfTheEntityCanNotBeNull)
-                return BadRequest(new { ErrorMessage = "TheIdOfTheEntityCanNotBeNull" });
-            else if (returnedCode == DataLibraryReturnedCodes.EntityNotFoundWithGivenId)
+            if (returnedCode == DataLibraryReturnedCodes.EntityNotFoundWithGivenId)
                 return NotFound();
             else if (returnedCode == DataLibraryReturnedCodes.NoErrorButNotFullyDeleted)
                 return Ok(new { WarningMessage = "NoErrorButNotFullyDeleted" });

--- a/EshopApp.DataLibraryAPI/Models/RequestModels/CartModels/CreateCartItemRequestModel.cs
+++ b/EshopApp.DataLibraryAPI/Models/RequestModels/CartModels/CreateCartItemRequestModel.cs
@@ -1,0 +1,16 @@
+﻿using System.ComponentModel.DataAnnotations;
+
+namespace EshopApp.DataLibraryAPI.Models.RequestModels.CartModels;
+
+public class CreateCartItemRequestModel
+{
+    [Required]
+    [Range(1, int.MaxValue, ErrorMessage = "The quantity property have a value of 1 or greater.")]
+    public int Quantity { get; set; }
+    [Required]
+    [MaxLength(50)]
+    public string? CartId { get; set; }
+    [Required]
+    [MaxLength(50)]
+    public string? VariantId { get; set; }
+}

--- a/EshopApp.DataLibraryAPI/Models/RequestModels/CartModels/CreateCartRequestModel.cs
+++ b/EshopApp.DataLibraryAPI/Models/RequestModels/CartModels/CreateCartRequestModel.cs
@@ -1,0 +1,10 @@
+﻿using System.ComponentModel.DataAnnotations;
+
+namespace EshopApp.DataLibraryAPI.Models.RequestModels.CartModels;
+
+public class CreateCartRequestModel
+{
+    [Required]
+    public string? UserId { get; set; }
+    public List<CreateCartItemRequestModel> CreateCartItemRequestModels { get; set; } = new List<CreateCartItemRequestModel>();
+}

--- a/EshopApp.DataLibraryAPI/Models/RequestModels/CartModels/UpdateCartItemRequestModel.cs
+++ b/EshopApp.DataLibraryAPI/Models/RequestModels/CartModels/UpdateCartItemRequestModel.cs
@@ -1,0 +1,13 @@
+﻿using System.ComponentModel.DataAnnotations;
+
+namespace EshopApp.DataLibraryAPI.Models.RequestModels.CartModels;
+
+public class UpdateCartItemRequestModel
+{
+    [Required]
+    public string? CartId { get; set; }
+    [Range(1, int.MaxValue, ErrorMessage = "The quantity property have a value of 1 or greater.")]
+    public int? Quantity { get; set; }
+    [MaxLength(50)]
+    public string? VariantId { get; set; }
+}

--- a/EshopApp.DataLibraryAPI/Program.cs
+++ b/EshopApp.DataLibraryAPI/Program.cs
@@ -52,6 +52,7 @@ public class Program()
         builder.Services.AddScoped<IPaymentOptionDataAccess, PaymentOptionDataAccess>();
         builder.Services.AddScoped<IShippingOptionDataAccess, ShippingOptionDataAccess>();
         builder.Services.AddScoped<IOrderDataAccess, OrderDataAccess>();
+        builder.Services.AddScoped<ICartDataAccess, CartDataAccess>();
 
         var app = builder.Build();
 


### PR DESCRIPTION
… The Cart And CartItems

I added all the necessary endpoints that allow the user to use the CRUD operations of the Cart and CartItems entities, which were added in the previous commit. To achieve this reason the CreateCartItemRequestModel.cs, CreateCartRequestModel.cs and the UpdateCartItemRequestModel.cs classes were also added and are used by the Post and Put endpoints. I also deleted a useless if statement that existed in all controllers in their delete endpoints. That was not a functional bug, but it helps with improved clarity. The test for the added endpoints will be added in the next update.