### PR TITLE
Added Authorization Endpoints In The Gateway Api

### DIFF
--- a/EshopApp.AuthLibraryAPI/Models/RequestModels/AdminModels/ApiUpdateUserRequestModel.cs
+++ b/EshopApp.AuthLibraryAPI/Models/RequestModels/AdminModels/ApiUpdateUserRequestModel.cs
@@ -1,9 +1,11 @@
 ﻿using EshopApp.AuthLibrary.Models;
+using System.ComponentModel.DataAnnotations;
 
 namespace EshopApp.AuthLibraryAPI.Models.RequestModels.AdminModels;
 
 public class ApiUpdateUserRequestModel
 {
+    [Required]
     public AppUser? AppUser { get; set; }
     public string? Password { get; set; }
     public bool ActivateEmail { get; set; } = true;

--- a/EshopApp.GatewayAPI/Controllers/GatewayAdminController.cs
+++ b/EshopApp.GatewayAPI/Controllers/GatewayAdminController.cs
@@ -1,0 +1,394 @@
+﻿using EshopApp.GatewayAPI.HelperMethods;
+using EshopApp.GatewayAPI.Models;
+using EshopApp.GatewayAPI.Models.RequestModels.GatewayAdminControllerRequestModels;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.RateLimiting;
+using System.Net;
+using System.Text.Json;
+
+namespace EshopApp.GatewayAPI.Controllers;
+
+[ApiController]
+[EnableRateLimiting("DefaultWindowLimiter")]
+[Route("api/[controller]")]
+public class GatewayAdminController : ControllerBase
+{
+    private readonly HttpClient authHttpClient;
+    private readonly HttpClient dataHttpClient;
+    private readonly HttpClient emailHttpClient;
+    private readonly IUtilityMethods _utilityMethods;
+    private readonly IConfiguration _configuration;
+
+    public GatewayAdminController(IHttpClientFactory httpClientFactory, IUtilityMethods utilityMethods, IConfiguration configuration)
+    {
+        authHttpClient = httpClientFactory.CreateClient("AuthApiClient");
+        dataHttpClient = httpClientFactory.CreateClient("DataApiClient");
+        emailHttpClient = httpClientFactory.CreateClient("EmailApiClient");
+        _utilityMethods = utilityMethods;
+        _configuration = configuration;
+    }
+
+    [HttpGet]
+    public async Task<IActionResult> GetUsers()
+    {
+        //maybe add the user carts and their coupons? Probably only for single user since the performance hit might be significant
+        try
+        {
+            //get the users
+            _utilityMethods.SetDefaultHeadersForClient(true, authHttpClient, _configuration["AuthApiKey"]!, _configuration["AuthRateLimitingBypassCode"]!, HttpContext.Request);
+            HttpResponseMessage? response = await authHttpClient.GetAsync("Admin");
+
+            //validate that getting the users has worked
+            int retries = 3;
+            while ((int)response.StatusCode >= 500)
+            {
+                if (retries == 0)
+                    return StatusCode(500, "Internal Server Error");
+
+                response = await authHttpClient.GetAsync("Admin");
+                retries--;
+            }
+
+            if ((int)response.StatusCode >= 400 && (int)response.StatusCode < 500)
+                return await CommonValidationForRequestClientErrorCodesAsync(response);
+
+            string? responseBody = await response.Content.ReadAsStringAsync();
+            List<GatewayAppUser>? appUsers = JsonSerializer.Deserialize<List<GatewayAppUser>>(responseBody, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+
+            return Ok(appUsers);
+        }
+        catch (Exception)
+        {
+            return StatusCode(500);
+        }
+    }
+
+    [HttpGet("GetUserById/{userId}")]
+    public async Task<IActionResult> GetUserById(string userId)
+    {
+        //eventually get user coupons and cart
+        try
+        {
+            //start by doing healthchecks for the endpoints this is calling
+            //if (!(await _utilityMethods.CheckIfMicroservicesFullyOnlineAsync(new List<HttpClient>() { authHttpClient, dataHttpClient })))
+            //    return StatusCode(503, new { ErrorMessage = "OneOrMoreMicroservicesAreUnavailable" });
+
+            _utilityMethods.SetDefaultHeadersForClient(true, authHttpClient, _configuration["AuthApiKey"]!, _configuration["AuthRateLimitingBypassCode"]!, HttpContext.Request);
+            HttpResponseMessage? response = await authHttpClient.GetAsync($"Admin/GetUserById/{userId}");
+
+            //validate that getting the user has worked
+            int retries = 3;
+            while ((int)response.StatusCode >= 500)
+            {
+                if (retries == 0)
+                    return StatusCode(500, "Internal Server Error");
+
+                response = await authHttpClient.GetAsync($"Admin/GetUserById/{userId}");
+                retries--;
+            }
+
+            if ((int)response.StatusCode >= 400 && (int)response.StatusCode < 500)
+                return await CommonValidationForRequestClientErrorCodesAsync(response);
+
+            string? responseBody = await response.Content.ReadAsStringAsync();
+            GatewayAppUser? appUser = JsonSerializer.Deserialize<GatewayAppUser>(responseBody, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+
+            return Ok(appUser);
+        }
+        catch (Exception)
+        {
+            return StatusCode(500);
+        }
+    }
+
+    [HttpGet("GetUserByEmail/{email}")]
+    public async Task<IActionResult> GetUserByEmail(string email)
+    {
+        //eventually get user coupons and cart
+        try
+        {
+            //start by doing healthchecks for the endpoints this is calling
+            //if (!(await _utilityMethods.CheckIfMicroservicesFullyOnlineAsync(new List<HttpClient>() { authHttpClient, dataHttpClient })))
+            //    return StatusCode(503, new { ErrorMessage = "OneOrMoreMicroservicesAreUnavailable" });
+
+            _utilityMethods.SetDefaultHeadersForClient(true, authHttpClient, _configuration["AuthApiKey"]!, _configuration["AuthRateLimitingBypassCode"]!, HttpContext.Request);
+            HttpResponseMessage? response = await authHttpClient.GetAsync($"Admin/GetUserByEmail/{email}");
+
+            //validate that getting the user has worked
+            int retries = 3;
+            while ((int)response.StatusCode >= 500)
+            {
+                if (retries == 0)
+                    return StatusCode(500, "Internal Server Error");
+
+                response = await authHttpClient.GetAsync($"Admin/GetUserByEmail/{email}");
+                retries--;
+            }
+
+            if ((int)response.StatusCode >= 400 && (int)response.StatusCode < 500)
+                return await CommonValidationForRequestClientErrorCodesAsync(response);
+
+            string? responseBody = await response.Content.ReadAsStringAsync();
+            GatewayAppUser? appUser = JsonSerializer.Deserialize<GatewayAppUser>(responseBody, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+
+            return Ok(appUser);
+        }
+        catch (Exception)
+        {
+            return StatusCode(500);
+        }
+    }
+
+    [HttpPost]
+    public async Task<IActionResult> CreateUserAccount([FromBody] GatewayApiCreateUserRequestModel gatewayApiCreateUserRequestModel)
+    {
+        try
+        {
+            //start by doing healthchecks for the endpoints this is calling
+            if (gatewayApiCreateUserRequestModel.SendEmailNotification && !(await _utilityMethods.CheckIfMicroservicesFullyOnlineAsync(new List<HttpClient>() { authHttpClient, dataHttpClient, emailHttpClient })))
+                return StatusCode(503, new { ErrorMessage = "OneOrMoreMicroservicesAreUnavailable" });
+            else if (!(await _utilityMethods.CheckIfMicroservicesFullyOnlineAsync(new List<HttpClient>() { authHttpClient, dataHttpClient, emailHttpClient })))
+                return StatusCode(503, new { ErrorMessage = "OneOrMoreMicroservicesAreUnavailable" });
+
+            //send request to create the user
+            _utilityMethods.SetDefaultHeadersForClient(true, authHttpClient, _configuration["AuthApiKey"]!, _configuration["AuthRateLimitingBypassCode"]!, HttpContext.Request);
+            HttpResponseMessage? response = await authHttpClient.PostAsJsonAsync("Admin",
+                new { Email = gatewayApiCreateUserRequestModel.Email, Password = gatewayApiCreateUserRequestModel.Password, PhoneNumber = gatewayApiCreateUserRequestModel.PhoneNumber });
+
+            //validate that creating the user has worked
+            int retries = 3;
+            while ((int)response.StatusCode >= 500)
+            {
+                if (retries == 0)
+                    return StatusCode(500, "Internal Server Error");
+
+                response = await authHttpClient.PostAsJsonAsync("Admin",
+                    new { Email = gatewayApiCreateUserRequestModel.Email, Password = gatewayApiCreateUserRequestModel.Password, PhoneNumber = gatewayApiCreateUserRequestModel.PhoneNumber });
+                retries--;
+            }
+
+            if ((int)response.StatusCode >= 400 && (int)response.StatusCode < 500)
+                return await CommonValidationForRequestClientErrorCodesAsync(response);
+
+            string? responseBody = await response.Content.ReadAsStringAsync();
+            GatewayAppUser? appUser = JsonSerializer.Deserialize<GatewayAppUser>(responseBody, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+
+            //send request to create the user cart
+            _utilityMethods.SetDefaultHeadersForClient(false, authHttpClient, _configuration["DataApiKey"]!, _configuration["DataRateLimitingBypassCode"]!);
+            response = await authHttpClient.PostAsJsonAsync("Cart", new { UserId = appUser!.Id });
+
+            //validate that creating the user cart has worked
+            retries = 3;
+            while ((int)response.StatusCode >= 500)
+            {
+                if (retries == 0)
+                    return StatusCode(500, "Internal Server Error");
+
+                response = await authHttpClient.PostAsJsonAsync("Cart", new { UserId = appUser!.Id });
+                retries--;
+            }
+
+            if ((int)response.StatusCode >= 400 && (int)response.StatusCode < 500)
+                return await CommonValidationForRequestClientErrorCodesAsync(response);
+
+            //string? responseBody = await response.Content.ReadAsStringAsync();
+            //GatewayCart? cart = JsonSerializer.Deserialize<GatewayCart>(responseBody, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+
+            //here just connect the user with the cart
+            //appUser.Cart = cart;
+
+            //send an email to the user to notify them that their account has been deleted
+            if (gatewayApiCreateUserRequestModel.SendEmailNotification)
+            {
+                var apiSendEmailModel = new Dictionary<string, string>
+                {
+                   { "receiver", gatewayApiCreateUserRequestModel.Email! },
+                    { "title", "Account Deletion" },
+                    { "message", "An administrator has deleted your account. If you have any questions you can contact us at kinnaskonstantinos0@gmail.com ." }
+                };
+                _ = Task.Run(async () =>
+                {
+                    _utilityMethods.SetDefaultHeadersForClient(false, emailHttpClient, _configuration["EmailApiKey"]!, _configuration["EmailRateLimitingBypassCode"]!);
+                    await _utilityMethods.AttemptToSendEmailAsync(emailHttpClient, 3, apiSendEmailModel);
+                });
+            }
+
+            return CreatedAtAction(nameof(GetUserById), new { userId = appUser.Id }, appUser);
+        }
+        catch (Exception)
+        {
+            return StatusCode(500);
+        }
+    }
+
+    [HttpPut]
+    public async Task<IActionResult> UpdateUserAccount([FromBody] GatewayApiUpdateUserRequestModel gatewayApiUpdateUserRequestModel)
+    {
+        //maybe sent in app notification for update user account. Think about it
+        try
+        {
+            //send request to update the user
+            _utilityMethods.SetDefaultHeadersForClient(true, authHttpClient, _configuration["AuthApiKey"]!, _configuration["AuthRateLimitingBypassCode"]!, HttpContext.Request);
+            HttpResponseMessage? response = await authHttpClient.PutAsJsonAsync("Admin",
+                new { AppUser = gatewayApiUpdateUserRequestModel.AppUser, Password = gatewayApiUpdateUserRequestModel.Password, PhoneNumber = gatewayApiUpdateUserRequestModel.ActivateEmail });
+
+            //validate that updating the user has worked
+            int retries = 3;
+            while ((int)response.StatusCode >= 500)
+            {
+                if (retries == 0)
+                    return StatusCode(500, "Internal Server Error");
+
+                response = await authHttpClient.PutAsJsonAsync("Admin",
+                    new { AppUser = gatewayApiUpdateUserRequestModel.AppUser, Password = gatewayApiUpdateUserRequestModel.Password, PhoneNumber = gatewayApiUpdateUserRequestModel.ActivateEmail });
+                retries--;
+            }
+
+            if ((int)response.StatusCode >= 400 && (int)response.StatusCode < 500)
+                return await CommonValidationForRequestClientErrorCodesAsync(response);
+
+            return NoContent();
+        }
+        catch (Exception)
+        {
+            return StatusCode(500);
+        }
+    }
+
+    [HttpDelete("{userId}/userEmail/{userEmail}/sendEmailNotification/{sendEmailNotification}")]
+    public async Task<IActionResult> DeleteUserAccount(string userId, string userEmail, bool sendEmailNotification)
+    {
+        try
+        {
+            //start by doing healthchecks for the endpoints this is calling
+            if (sendEmailNotification && !(await _utilityMethods.CheckIfMicroservicesFullyOnlineAsync(new List<HttpClient>() { authHttpClient, dataHttpClient, emailHttpClient })))
+                return StatusCode(503, new { ErrorMessage = "OneOrMoreMicroservicesAreUnavailable" });
+            else if (!(await _utilityMethods.CheckIfMicroservicesFullyOnlineAsync(new List<HttpClient>() { authHttpClient, dataHttpClient, emailHttpClient })))
+                return StatusCode(503, new { ErrorMessage = "OneOrMoreMicroservicesAreUnavailable" });
+
+            //send request to delete the user
+            _utilityMethods.SetDefaultHeadersForClient(true, authHttpClient, _configuration["AuthApiKey"]!, _configuration["AuthRateLimitingBypassCode"]!, HttpContext.Request);
+            HttpResponseMessage? response = await authHttpClient.DeleteAsync($"Admin/{userId}");
+
+            //validate that deleting the user has worked
+            int retries = 3;
+            while ((int)response.StatusCode >= 500)
+            {
+                if (retries == 0)
+                    return StatusCode(500, "Internal Server Error");
+
+                response = await authHttpClient.DeleteAsync($"Admin/{userId}");
+                retries--;
+            }
+
+            if ((int)response.StatusCode >= 400 && (int)response.StatusCode < 500)
+                return await CommonValidationForRequestClientErrorCodesAsync(response);
+
+            //send request to delete the user cart
+            _utilityMethods.SetDefaultHeadersForClient(false, authHttpClient, _configuration["DataApiKey"]!, _configuration["DataRateLimitingBypassCode"]!);
+            response = await authHttpClient.DeleteAsync($"Cart/UserId/{userId}");
+
+            //validate that deleting the user cart has worked
+            retries = 3;
+            while ((int)response.StatusCode >= 500)
+            {
+                if (retries == 0)
+                    return StatusCode(500, "Internal Server Error");
+
+                response = await authHttpClient.DeleteAsync($"Cart/UserId/{userId}");
+                retries--;
+            }
+
+            if ((int)response.StatusCode >= 400 && (int)response.StatusCode < 500)
+                return await CommonValidationForRequestClientErrorCodesAsync(response);
+
+            //send request to delete the coupons of the user
+            _utilityMethods.SetDefaultHeadersForClient(false, authHttpClient, _configuration["DataApiKey"]!, _configuration["DataRateLimitingBypassCode"]!);
+            response = await authHttpClient.DeleteAsync($"Coupon/RemoveAllUserCoupons/userId/{userId}");
+
+            //validate that deleting the coupons of the user has worked
+            retries = 3;
+            while ((int)response.StatusCode >= 500)
+            {
+                if (retries == 0)
+                    return StatusCode(500, "Internal Server Error");
+
+                response = await authHttpClient.DeleteAsync($"Coupon/RemoveAllUserCoupons/userId/{userId}");
+                retries--;
+            }
+
+            if ((int)response.StatusCode >= 400 && (int)response.StatusCode < 500)
+                return await CommonValidationForRequestClientErrorCodesAsync(response);
+
+            //send an email to the user to notify them that their account has been deleted
+            if (sendEmailNotification)
+            {
+                var apiSendEmailModel = new Dictionary<string, string>
+                {
+                   { "receiver", userEmail },
+                    { "title", "Account Deletion" },
+                    { "message", "An administrator has deleted your account. If you have any questions you can contact us at kinnaskonstantinos0@gmail.com ." }
+                };
+                _ = Task.Run(async () =>
+                {
+                    _utilityMethods.SetDefaultHeadersForClient(false, emailHttpClient, _configuration["EmailApiKey"]!, _configuration["EmailRateLimitingBypassCode"]!);
+                    await _utilityMethods.AttemptToSendEmailAsync(emailHttpClient, 3, apiSendEmailModel);
+                });
+            }
+
+            return NoContent();
+        }
+        catch (Exception)
+        {
+            return StatusCode(500);
+        }
+    }
+
+    private async Task<IActionResult> CommonValidationForRequestClientErrorCodesAsync(HttpResponseMessage response)
+    {
+        string responseBody = await response.Content.ReadAsStringAsync();
+        //in the case there is no body
+        if (string.IsNullOrEmpty(responseBody))
+        {
+            if (response.StatusCode == HttpStatusCode.Unauthorized)
+                return Unauthorized();
+            else if (response.StatusCode == HttpStatusCode.Forbidden)
+                return StatusCode(StatusCodes.Status403Forbidden);
+            else if (response.StatusCode == HttpStatusCode.BadRequest)
+                return BadRequest();
+            else if (response.StatusCode == HttpStatusCode.NotFound)
+                return NotFound();
+            else if (response.StatusCode == HttpStatusCode.MethodNotAllowed)
+                return NotFound();
+
+            return BadRequest(); //this will probably never happen
+        }
+
+        //otherwise
+        var keyValue = JsonSerializer.Deserialize<Dictionary<string, object>>(responseBody);
+        keyValue!.TryGetValue("errorMessage", out object? errorMessageObject);
+        string? errorMessage = errorMessageObject?.ToString() ?? null;
+        keyValue!.TryGetValue("errors", out var errors);
+
+        if (response.StatusCode == HttpStatusCode.Unauthorized && errorMessage is not null)
+            return Unauthorized(new { ErrorMessage = errorMessage });
+        else if (response.StatusCode == HttpStatusCode.Unauthorized)
+            return Unauthorized();
+        else if (response.StatusCode == HttpStatusCode.Forbidden && errorMessage is not null)
+            return StatusCode(StatusCodes.Status403Forbidden, new { ErrorMessage = errorMessage });
+        else if (response.StatusCode == HttpStatusCode.Forbidden)
+            return StatusCode(StatusCodes.Status403Forbidden);
+        else if (response.StatusCode == HttpStatusCode.BadRequest && errorMessage is not null)
+            return BadRequest(new { ErrorMessage = errorMessage });
+        else if (response.StatusCode == HttpStatusCode.BadRequest && errors is not null) //this is for request validation errors
+            return BadRequest(new { Errors = errors });
+        else if (response.StatusCode == HttpStatusCode.NotFound && errorMessage is not null)
+            return NotFound(new { ErrorMessage = errorMessage });
+        else if (response.StatusCode == HttpStatusCode.NotFound)
+            return NotFound();
+        else if (response.StatusCode == HttpStatusCode.MethodNotAllowed)
+            return StatusCode(StatusCodes.Status405MethodNotAllowed);
+
+        return BadRequest(); //this will probably never happen
+    }
+}

--- a/EshopApp.GatewayAPI/HelperMethods/IUtilityMethods.cs
+++ b/EshopApp.GatewayAPI/HelperMethods/IUtilityMethods.cs
@@ -1,0 +1,10 @@
+﻿
+namespace EshopApp.GatewayAPI.HelperMethods;
+
+public interface IUtilityMethods
+{
+    Task AttemptToSendEmailAsync(HttpClient emailHttpClient, int retries, Dictionary<string, string> jsonObject);
+    Task<bool> CheckIfMicroservicesFullyOnlineAsync(List<HttpClient> httpClients);
+    bool CheckIfUrlIsTrusted(string redirectUrl, IConfiguration configuration);
+    string? SetDefaultHeadersForClient(bool includeJWTAuthenticationHeaders, HttpClient httpClient, string apiKey, string rateLimitingBypassCode, HttpRequest? httpRequest = null);
+}

--- a/EshopApp.GatewayAPI/HelperMethods/UtilityMethods.cs
+++ b/EshopApp.GatewayAPI/HelperMethods/UtilityMethods.cs
@@ -1,0 +1,75 @@
+﻿using System.Net;
+using System.Net.Http.Headers;
+
+namespace EshopApp.GatewayAPI.HelperMethods;
+
+public class UtilityMethods : IUtilityMethods
+{
+    public async Task AttemptToSendEmailAsync(HttpClient emailHttpClient, int retries, Dictionary<string, string> jsonObject)
+    {
+        if (retries == 0)
+            return;
+
+        HttpResponseMessage response = await emailHttpClient.PostAsJsonAsync("Emails", jsonObject);
+        if (response.StatusCode == HttpStatusCode.OK)
+            return;
+
+        await Task.Delay(1000);
+        retries--;
+        await AttemptToSendEmailAsync(emailHttpClient, retries, jsonObject);
+    }
+
+    public string? SetDefaultHeadersForClient(bool includeJWTAuthenticationHeaders, HttpClient httpClient, string apiKey, string rateLimitingBypassCode, HttpRequest? httpRequest = null)
+    {
+        string? returnedAccessToken = null;
+        if (includeJWTAuthenticationHeaders)
+        {
+            string authorizationHeader = httpRequest!.Headers["Authorization"]!;
+            string accessToken = authorizationHeader.Substring("Bearer ".Length).Trim();
+            httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
+            returnedAccessToken = accessToken;
+        }
+
+        httpClient.DefaultRequestHeaders.Add("X-API-KEY", apiKey);
+        httpClient.DefaultRequestHeaders.Add("X-Bypass-Rate-Limiting", rateLimitingBypassCode);
+        return returnedAccessToken;
+    }
+
+    public bool CheckIfUrlIsTrusted(string redirectUrl, IConfiguration configuration)
+    {
+        List<string> trustedDomains = configuration["TrustedOrigins"]!.Split(" ").ToList();
+        var redirectUri = new Uri(redirectUrl);
+
+        foreach (string trustedDomain in trustedDomains)
+        {
+            var trustedUri = new Uri(trustedDomain);
+            if (Uri.Compare(redirectUri, trustedUri, UriComponents.SchemeAndServer, UriFormat.Unescaped, StringComparison.OrdinalIgnoreCase) == 0)
+                return true;
+        }
+
+        return false;
+    }
+
+    public async Task<bool> CheckIfMicroservicesFullyOnlineAsync(List<HttpClient> httpClients)
+    {
+        try
+        {
+            if (httpClients is null || !httpClients.Any())
+                return true;
+
+            foreach (HttpClient httpClient in httpClients)
+            {
+                var healthResponse = await httpClient.GetAsync("Health");
+                if (healthResponse.StatusCode != HttpStatusCode.OK)
+                    return false;
+            }
+
+            return true;
+        }
+        //the exception can happen if one of the microservices are not online. In this case just return false
+        catch
+        {
+            return false;
+        }
+    }
+}

--- a/EshopApp.GatewayAPI/Models/RequestModels/GatewayAdminControllerRequestModels/GatewayApiCreateUserRequestModel.cs
+++ b/EshopApp.GatewayAPI/Models/RequestModels/GatewayAdminControllerRequestModels/GatewayApiCreateUserRequestModel.cs
@@ -1,0 +1,15 @@
+﻿using System.ComponentModel.DataAnnotations;
+
+namespace EshopApp.GatewayAPI.Models.RequestModels.GatewayAdminControllerRequestModels;
+
+public class GatewayApiCreateUserRequestModel
+{
+    [Required]
+    [EmailAddress]
+    public string? Email { get; set; }
+    [Required]
+    public string? Password { get; set; }
+    [Phone]
+    public string? PhoneNumber { get; set; }
+    public bool SendEmailNotification { get; set; }
+}

--- a/EshopApp.GatewayAPI/Models/RequestModels/GatewayAdminControllerRequestModels/GatewayApiUpdateUserRequestModel.cs
+++ b/EshopApp.GatewayAPI/Models/RequestModels/GatewayAdminControllerRequestModels/GatewayApiUpdateUserRequestModel.cs
@@ -1,0 +1,11 @@
+﻿using System.ComponentModel.DataAnnotations;
+
+namespace EshopApp.GatewayAPI.Models.RequestModels.GatewayAdminControllerRequestModels;
+
+public class GatewayApiUpdateUserRequestModel
+{
+    [Required]
+    public GatewayAppUser? AppUser { get; set; }
+    public bool ActivateEmail { get; set; }
+    public string? Password { get; set; }
+}

--- a/EshopApp.GatewayAPI/Models/RequestModels/GatewayAuthenticationControllerRequestModels/GatewayApiChangeEmailRequestModel.cs
+++ b/EshopApp.GatewayAPI/Models/RequestModels/GatewayAuthenticationControllerRequestModels/GatewayApiChangeEmailRequestModel.cs
@@ -1,6 +1,6 @@
 ﻿using System.ComponentModel.DataAnnotations;
 
-namespace EshopApp.GatewayAPI.Models.RequestModels;
+namespace EshopApp.GatewayAPI.Models.RequestModels.GatewayAuthenticationControllerRequestModels;
 
 public class GatewayApiChangeEmailRequestModel
 {

--- a/EshopApp.GatewayAPI/Models/RequestModels/GatewayAuthenticationControllerRequestModels/GatewayApiChangePasswordRequestModel.cs
+++ b/EshopApp.GatewayAPI/Models/RequestModels/GatewayAuthenticationControllerRequestModels/GatewayApiChangePasswordRequestModel.cs
@@ -1,6 +1,6 @@
 ﻿using System.ComponentModel.DataAnnotations;
 
-namespace EshopApp.GatewayAPI.Models.RequestModels;
+namespace EshopApp.GatewayAPI.Models.RequestModels.GatewayAuthenticationControllerRequestModels;
 
 public class GatewayApiChangePasswordRequestModel
 {

--- a/EshopApp.GatewayAPI/Models/RequestModels/GatewayAuthenticationControllerRequestModels/GatewayApiExternalSignInRequestModel.cs
+++ b/EshopApp.GatewayAPI/Models/RequestModels/GatewayAuthenticationControllerRequestModels/GatewayApiExternalSignInRequestModel.cs
@@ -1,6 +1,6 @@
 ﻿using System.ComponentModel.DataAnnotations;
 
-namespace EshopApp.GatewayAPI.Models.RequestModels;
+namespace EshopApp.GatewayAPI.Models.RequestModels.GatewayAuthenticationControllerRequestModels;
 
 public class GatewayApiExternalSignInRequestModel
 {

--- a/EshopApp.GatewayAPI/Models/RequestModels/GatewayAuthenticationControllerRequestModels/GatewayApiForgotPasswordRequestModel.cs
+++ b/EshopApp.GatewayAPI/Models/RequestModels/GatewayAuthenticationControllerRequestModels/GatewayApiForgotPasswordRequestModel.cs
@@ -1,6 +1,6 @@
 ﻿using System.ComponentModel.DataAnnotations;
 
-namespace EshopApp.GatewayAPI.Models.RequestModels;
+namespace EshopApp.GatewayAPI.Models.RequestModels.GatewayAuthenticationControllerRequestModels;
 
 public class GatewayApiForgotPasswordRequestModel
 {

--- a/EshopApp.GatewayAPI/Models/RequestModels/GatewayAuthenticationControllerRequestModels/GatewayApiResetPasswordRequestModel.cs
+++ b/EshopApp.GatewayAPI/Models/RequestModels/GatewayAuthenticationControllerRequestModels/GatewayApiResetPasswordRequestModel.cs
@@ -1,6 +1,6 @@
 ﻿using System.ComponentModel.DataAnnotations;
 
-namespace EshopApp.GatewayAPI.Models.RequestModels;
+namespace EshopApp.GatewayAPI.Models.RequestModels.GatewayAuthenticationControllerRequestModels;
 
 public class GatewayApiResetPasswordRequestModel
 {

--- a/EshopApp.GatewayAPI/Models/RequestModels/GatewayAuthenticationControllerRequestModels/GatewayApiSignInRequestModel.cs
+++ b/EshopApp.GatewayAPI/Models/RequestModels/GatewayAuthenticationControllerRequestModels/GatewayApiSignInRequestModel.cs
@@ -1,4 +1,4 @@
-﻿namespace EshopApp.GatewayAPI.Models.RequestModels;
+﻿namespace EshopApp.GatewayAPI.Models.RequestModels.GatewayAuthenticationControllerRequestModels;
 
 public class GatewayApiSignInRequestModel
 {

--- a/EshopApp.GatewayAPI/Models/RequestModels/GatewayAuthenticationControllerRequestModels/GatewayApiSignUpRequestModel.cs
+++ b/EshopApp.GatewayAPI/Models/RequestModels/GatewayAuthenticationControllerRequestModels/GatewayApiSignUpRequestModel.cs
@@ -1,6 +1,6 @@
 ﻿using System.ComponentModel.DataAnnotations;
 
-namespace EshopApp.GatewayAPI.Models.RequestModels;
+namespace EshopApp.GatewayAPI.Models.RequestModels.GatewayAuthenticationControllerRequestModels;
 
 public class GatewayApiSignUpRequestModel
 {

--- a/EshopApp.GatewayAPI/Program.cs
+++ b/EshopApp.GatewayAPI/Program.cs
@@ -1,3 +1,4 @@
+using EshopApp.GatewayAPI.HelperMethods;
 using EshopApp.GatewayAPI.Middlewares;
 using Microsoft.AspNetCore.RateLimiting;
 
@@ -41,6 +42,8 @@ public class Program()
                 options.Window = TimeSpan.FromMinutes(1);
             });
         });
+
+        builder.Services.AddSingleton<IUtilityMethods, UtilityMethods>();
 
         List<string> apiKeys = new List<string>();
         if (configuration["ApiKeys"] is not null)


### PR DESCRIPTION
I added all the necessary authorization endpoints that are needed to cover the admincontroller of the Auth microservice(CRUD operations that the admin can access). I also fixed a bug that made the endpoints of the gateway api to only sent health checks to the auth microservice. When I start working on the Data controllers of the gateway api I will also add some logic for the cart and the user coupons, but as it stands I will leave it as it is. On a final note maybe I should add in app notifications(for userupdate and other stuff). I am not certain about this yet.