### PR TITLE
Added Role Management Endpoints In The Gateway Api

### DIFF
--- a/EshopApp.AuthLibrary/AuthLogic/AdminProcedures.cs
+++ b/EshopApp.AuthLibrary/AuthLogic/AdminProcedures.cs
@@ -51,11 +51,11 @@ public class AdminProcedures : IAdminProcedures
             var filteredFoundUsers = new List<AppUser>();
             foreach (AppUser foundUser in foundUsers)
             {
-                IList<string> editedUserRoleNames = await _userManager.GetRolesAsync(foundUser);
-                AppRole? editedUserRole = editedUserRoleNames is null || editedUserRoleNames.Count == 0 ? null : await _roleManager.FindByNameAsync(editedUserRoleNames.FirstOrDefault()!);
-                IList<Claim>? editedUserClaims = editedUserRole is null ? null : await _roleManager.GetClaimsAsync(editedUserRole);
+                IList<string> foundUserRoleNames = await _userManager.GetRolesAsync(foundUser);
+                AppRole? foundUserRole = foundUserRoleNames is null || foundUserRoleNames.Count == 0 ? null : await _roleManager.FindByNameAsync(foundUserRoleNames.FirstOrDefault()!);
+                IList<Claim>? foundUserClaims = foundUserRole is null ? null : await _roleManager.GetClaimsAsync(foundUserRole);
 
-                if (editedUserClaims is null || !editedUserClaims.Any(claim => claim.Type == "Protection" && claim.Value == "CanOnlyBeManagedByElevatedUsers"))
+                if (foundUserClaims is null || !foundUserClaims.Any(claim => claim.Type == "Protection" && claim.Value == "CanOnlyBeManagedByElevatedUsers"))
                     filteredFoundUsers.Add(foundUser);
             }
 

--- a/EshopApp.GatewayAPI/Controllers/GatewayRoleController.cs
+++ b/EshopApp.GatewayAPI/Controllers/GatewayRoleController.cs
@@ -1,0 +1,479 @@
+﻿using EshopApp.GatewayAPI.HelperMethods;
+using EshopApp.GatewayAPI.Models;
+using EshopApp.GatewayAPI.Models.RequestModels.GatewayRoleControllerRequestModels;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.RateLimiting;
+using System.Net;
+using System.Text.Json;
+
+namespace EshopApp.GatewayAPI.Controllers;
+
+[ApiController]
+[EnableRateLimiting("DefaultWindowLimiter")]
+[Route("api/[controller]")]
+public class GatewayRoleController : ControllerBase
+{
+    private readonly HttpClient authHttpClient;
+    //private readonly HttpClient dataHttpClient;
+    //private readonly HttpClient emailHttpClient;
+    private readonly IUtilityMethods _utilityMethods;
+    private readonly IConfiguration _configuration;
+
+    public GatewayRoleController(IHttpClientFactory httpClientFactory, IUtilityMethods utilityMethods, IConfiguration configuration)
+    {
+        authHttpClient = httpClientFactory.CreateClient("AuthApiClient");
+        //dataHttpClient = httpClientFactory.CreateClient("DataApiClient");
+        //emailHttpClient = httpClientFactory.CreateClient("EmailApiClient");
+        _utilityMethods = utilityMethods;
+        _configuration = configuration;
+    }
+
+    [HttpGet]
+    [Authorize(Policy = "CanManageRolesPolicy")]
+    public async Task<IActionResult> GetRoles()
+    {
+        try
+        {
+            //get the roles
+            _utilityMethods.SetDefaultHeadersForClient(true, authHttpClient, _configuration["AuthApiKey"]!, _configuration["AuthRateLimitingBypassCode"]!, HttpContext.Request);
+            HttpResponseMessage? response = await authHttpClient.GetAsync("Role");
+
+            //validate that getting the roles has worked
+            int retries = 3;
+            while ((int)response.StatusCode >= 500)
+            {
+                if (retries == 0)
+                    return StatusCode(500, "Internal Server Error");
+
+                response = await authHttpClient.GetAsync("Role");
+                retries--;
+            }
+
+            if ((int)response.StatusCode >= 400 && (int)response.StatusCode < 500)
+                return await CommonValidationForRequestClientErrorCodesAsync(response);
+
+            string? responseBody = await response.Content.ReadAsStringAsync();
+            List<GatewayAppRole>? appRoles = JsonSerializer.Deserialize<List<GatewayAppRole>>(responseBody, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+
+            return Ok(appRoles);
+        }
+        catch (Exception)
+        {
+            return StatusCode(500);
+        }
+    }
+
+    [HttpGet("GetRoleById/{roleId}")]
+    public async Task<IActionResult> GetRoleById(string roleId)
+    {
+        try
+        {
+            //get the role
+            _utilityMethods.SetDefaultHeadersForClient(true, authHttpClient, _configuration["AuthApiKey"]!, _configuration["AuthRateLimitingBypassCode"]!, HttpContext.Request);
+            HttpResponseMessage? response = await authHttpClient.GetAsync($"Role/GetRoleById/{roleId}");
+
+            //validate that getting the role has worked
+            int retries = 3;
+            while ((int)response.StatusCode >= 500)
+            {
+                if (retries == 0)
+                    return StatusCode(500, "Internal Server Error");
+
+                response = await authHttpClient.GetAsync($"Role/GetRoleById/{roleId}");
+                retries--;
+            }
+
+            if ((int)response.StatusCode >= 400 && (int)response.StatusCode < 500)
+                return await CommonValidationForRequestClientErrorCodesAsync(response);
+
+            string? responseBody = await response.Content.ReadAsStringAsync();
+            //appRole can not be null, because if it would have been caught in the 400 error codes check
+            GatewayAppRole appRole = JsonSerializer.Deserialize<GatewayAppRole>(responseBody, new JsonSerializerOptions { PropertyNameCaseInsensitive = true })!;
+
+            return Ok(appRole);
+        }
+        catch (Exception)
+        {
+            return StatusCode(500);
+        }
+    }
+
+    [HttpGet("GetRoleByName/{roleName}")]
+    public async Task<IActionResult> GetRoleByName(string roleName)
+    {
+        try
+        {
+            //get the role
+            _utilityMethods.SetDefaultHeadersForClient(true, authHttpClient, _configuration["AuthApiKey"]!, _configuration["AuthRateLimitingBypassCode"]!, HttpContext.Request);
+            HttpResponseMessage? response = await authHttpClient.GetAsync($"Role/GetRoleByName/{roleName}");
+
+            //validate that getting the role has worked
+            int retries = 3;
+            while ((int)response.StatusCode >= 500)
+            {
+                if (retries == 0)
+                    return StatusCode(500, "Internal Server Error");
+
+                response = await authHttpClient.GetAsync($"Role/GetRoleByName/{roleName}");
+                retries--;
+            }
+
+            if ((int)response.StatusCode >= 400 && (int)response.StatusCode < 500)
+                return await CommonValidationForRequestClientErrorCodesAsync(response);
+
+            string? responseBody = await response.Content.ReadAsStringAsync();
+            //appRole can not be null, because if it would have been caught in the 400 error codes check
+            GatewayAppRole appRole = JsonSerializer.Deserialize<GatewayAppRole>(responseBody, new JsonSerializerOptions { PropertyNameCaseInsensitive = true })!;
+
+            return Ok(appRole);
+        }
+        catch (Exception)
+        {
+            return StatusCode(500);
+        }
+    }
+
+    [HttpGet("GetRolesOfUser/{userId}")]
+    public async Task<IActionResult> GetRolesOfUser(string userId)
+    {
+        try
+        {
+            //get the user's roles
+            _utilityMethods.SetDefaultHeadersForClient(true, authHttpClient, _configuration["AuthApiKey"]!, _configuration["AuthRateLimitingBypassCode"]!, HttpContext.Request);
+            HttpResponseMessage? response = await authHttpClient.GetAsync($"Role/GetRolesOfUser/{userId}");
+
+            //validate that getting the roles of the user has worked
+            int retries = 3;
+            while ((int)response.StatusCode >= 500)
+            {
+                if (retries == 0)
+                    return StatusCode(500, "Internal Server Error");
+
+                response = await authHttpClient.GetAsync($"Role/GetRolesOfUser/{userId}");
+                retries--;
+            }
+
+            if ((int)response.StatusCode >= 400 && (int)response.StatusCode < 500)
+                return await CommonValidationForRequestClientErrorCodesAsync(response);
+
+            string? responseBody = await response.Content.ReadAsStringAsync();
+            List<GatewayAppRole> appRoles = JsonSerializer.Deserialize<List<GatewayAppRole>>(responseBody, new JsonSerializerOptions { PropertyNameCaseInsensitive = true })!;
+
+            return Ok(appRoles);
+        }
+        catch (Exception)
+        {
+            return StatusCode(500);
+        }
+    }
+
+    [HttpPost]
+    public async Task<IActionResult> CreateRole([FromBody] GatewayApiCreateRoleRequestModel gatewayApiCreateRoleRequestModel)
+    {
+        try
+        {
+            //create the role
+            _utilityMethods.SetDefaultHeadersForClient(true, authHttpClient, _configuration["AuthApiKey"]!, _configuration["AuthRateLimitingBypassCode"]!, HttpContext.Request);
+            HttpResponseMessage? response = await authHttpClient.PostAsJsonAsync("Role", new { RoleName = gatewayApiCreateRoleRequestModel.RoleName, Claims = gatewayApiCreateRoleRequestModel.Claims });
+
+            //validate that creating the role has worked
+            int retries = 3;
+            while ((int)response.StatusCode >= 500)
+            {
+                if (retries == 0)
+                    return StatusCode(500, "Internal Server Error");
+
+                response = await authHttpClient.PostAsJsonAsync("Role", new { RoleName = gatewayApiCreateRoleRequestModel.RoleName, Claims = gatewayApiCreateRoleRequestModel.Claims });
+                retries--;
+            }
+
+            if ((int)response.StatusCode >= 400 && (int)response.StatusCode < 500)
+                return await CommonValidationForRequestClientErrorCodesAsync(response);
+
+            string? responseBody = await response.Content.ReadAsStringAsync();
+            GatewayAppRole appRole = JsonSerializer.Deserialize<GatewayAppRole>(responseBody, new JsonSerializerOptions { PropertyNameCaseInsensitive = true })!;
+
+            return Ok(appRole);
+        }
+        catch (Exception)
+        {
+            return StatusCode(500);
+        }
+    }
+
+    [HttpDelete("{roleId}")]
+    public async Task<IActionResult> DeleteRole(string roleId)
+    {
+        try
+        {
+            //delete the role
+            _utilityMethods.SetDefaultHeadersForClient(true, authHttpClient, _configuration["AuthApiKey"]!, _configuration["AuthRateLimitingBypassCode"]!, HttpContext.Request);
+            HttpResponseMessage? response = await authHttpClient.DeleteAsync($"Role/{roleId}");
+
+            //validate that deleting the role has worked
+            int retries = 3;
+            while ((int)response.StatusCode >= 500)
+            {
+                if (retries == 0)
+                    return StatusCode(500, "Internal Server Error");
+
+                response = await authHttpClient.DeleteAsync($"Role/{roleId}");
+                retries--;
+            }
+
+            if ((int)response.StatusCode >= 400 && (int)response.StatusCode < 500)
+                return await CommonValidationForRequestClientErrorCodesAsync(response);
+
+            return NoContent();
+        }
+        catch (Exception)
+        {
+            return StatusCode(500);
+        }
+    }
+
+    [HttpGet("GetUsersOfRole/{roleId}")]
+    public async Task<IActionResult> GetUsersOfRole(string roleId)
+    {
+        try
+        {
+            //get the users of the role
+            _utilityMethods.SetDefaultHeadersForClient(true, authHttpClient, _configuration["AuthApiKey"]!, _configuration["AuthRateLimitingBypassCode"]!, HttpContext.Request);
+            HttpResponseMessage? response = await authHttpClient.GetAsync($"Role/GetUsersOfRole/{roleId}");
+
+            //validate that getting the users of the role has worked
+            int retries = 3;
+            while ((int)response.StatusCode >= 500)
+            {
+                if (retries == 0)
+                    return StatusCode(500, "Internal Server Error");
+
+                response = await authHttpClient.GetAsync($"Role/GetUsersOfRole/{roleId}");
+                retries--;
+            }
+
+            if ((int)response.StatusCode >= 400 && (int)response.StatusCode < 500)
+                return await CommonValidationForRequestClientErrorCodesAsync(response);
+
+            string? responseBody = await response.Content.ReadAsStringAsync();
+            List<GatewayAppUser> appUsers = JsonSerializer.Deserialize<List<GatewayAppUser>>(responseBody, new JsonSerializerOptions { PropertyNameCaseInsensitive = true })!;
+
+            return Ok(appUsers);
+        }
+        catch (Exception)
+        {
+            return StatusCode(500);
+        }
+    }
+
+    [HttpPost("AddRoleToUser")]
+    public async Task<IActionResult> AddRoleToUser([FromBody] GatewayApiAddRoleToUserRequestModel gatewayApiAddRoleToUserRequestModel)
+    {
+        try
+        {
+            //add the role to the user
+            _utilityMethods.SetDefaultHeadersForClient(true, authHttpClient, _configuration["AuthApiKey"]!, _configuration["AuthRateLimitingBypassCode"]!, HttpContext.Request);
+            HttpResponseMessage? response = await authHttpClient.PostAsJsonAsync("Role/addRoleToUser", new { RoleId = gatewayApiAddRoleToUserRequestModel.RoleId, UserId = gatewayApiAddRoleToUserRequestModel.UserId });
+
+            //validate that adding the role to the user worked
+            int retries = 3;
+            while ((int)response.StatusCode >= 500)
+            {
+                if (retries == 0)
+                    return StatusCode(500, "Internal Server Error");
+
+                response = await authHttpClient.PostAsJsonAsync("Role/addRoleToUser", new { RoleId = gatewayApiAddRoleToUserRequestModel.RoleId, UserId = gatewayApiAddRoleToUserRequestModel.UserId });
+                retries--;
+            }
+
+            if ((int)response.StatusCode >= 400 && (int)response.StatusCode < 500)
+                return await CommonValidationForRequestClientErrorCodesAsync(response);
+
+            return NoContent();
+        }
+        catch (Exception)
+        {
+            return StatusCode(500);
+        }
+    }
+
+    [HttpPost("ReplaceRoleOfUser")]
+    public async Task<IActionResult> ReplaceRoleOfUser([FromBody] GatewayApiReplaceRoleOfUserRequestModel gatewayApiReplaceRoleOfUserRequestModel)
+    {
+        try
+        {
+            //replace the role of the user
+            _utilityMethods.SetDefaultHeadersForClient(true, authHttpClient, _configuration["AuthApiKey"]!, _configuration["AuthRateLimitingBypassCode"]!, HttpContext.Request);
+            HttpResponseMessage? response = await authHttpClient.PostAsJsonAsync("Role/ReplaceRoleOfUser",
+                new { CurrentRoleId = gatewayApiReplaceRoleOfUserRequestModel.CurrentRoleId, NewRoleId = gatewayApiReplaceRoleOfUserRequestModel.NewRoleId, UserId = gatewayApiReplaceRoleOfUserRequestModel.UserId });
+
+            //validate that replacing the role of the user has worked
+            int retries = 3;
+            while ((int)response.StatusCode >= 500)
+            {
+                if (retries == 0)
+                    return StatusCode(500, "Internal Server Error");
+
+                response = await authHttpClient.PostAsJsonAsync("Role/ReplaceRoleOfUser",
+                    new { CurrentRoleId = gatewayApiReplaceRoleOfUserRequestModel.CurrentRoleId, NewRoleId = gatewayApiReplaceRoleOfUserRequestModel.NewRoleId, UserId = gatewayApiReplaceRoleOfUserRequestModel.UserId });
+                retries--;
+            }
+
+            if ((int)response.StatusCode >= 400 && (int)response.StatusCode < 500)
+                return await CommonValidationForRequestClientErrorCodesAsync(response);
+
+            return NoContent();
+        }
+        catch (Exception)
+        {
+            return StatusCode(500);
+        }
+    }
+
+    [HttpDelete("RemoveRoleFromUser/{userId}/role/{roleId}")]
+    public async Task<IActionResult> RemoveRoleFromUser(string userId, string roleId)
+    {
+        try
+        {
+            //remove the role from the user
+            _utilityMethods.SetDefaultHeadersForClient(true, authHttpClient, _configuration["AuthApiKey"]!, _configuration["AuthRateLimitingBypassCode"]!, HttpContext.Request);
+            HttpResponseMessage? response = await authHttpClient.DeleteAsync($"Role/RemoveRoleFromUser/{userId}/role/{roleId}");
+
+            //validate that removing the role from the user has worked
+            int retries = 3;
+            while ((int)response.StatusCode >= 500)
+            {
+                if (retries == 0)
+                    return StatusCode(500, "Internal Server Error");
+
+                response = await authHttpClient.DeleteAsync($"Role/RemoveRoleFromUser/{userId}/role/{roleId}");
+                retries--;
+            }
+
+            if ((int)response.StatusCode >= 400 && (int)response.StatusCode < 500)
+                return await CommonValidationForRequestClientErrorCodesAsync(response);
+
+            return NoContent();
+        }
+        catch (Exception)
+        {
+            return StatusCode(500);
+        }
+    }
+
+    [HttpGet("GetClaims")]
+    public async Task<IActionResult> GetClaimsInSystem()
+    {
+        try
+        {
+            //get the claims of the system
+            _utilityMethods.SetDefaultHeadersForClient(true, authHttpClient, _configuration["AuthApiKey"]!, _configuration["AuthRateLimitingBypassCode"]!, HttpContext.Request);
+            HttpResponseMessage? response = await authHttpClient.GetAsync($"Role/GetClaims");
+
+            //validate that getting the claims of the system has worked
+            int retries = 3;
+            while ((int)response.StatusCode >= 500)
+            {
+                if (retries == 0)
+                    return StatusCode(500, "Internal Server Error");
+
+                response = await authHttpClient.GetAsync($"Role/GetClaims");
+                retries--;
+            }
+
+            if ((int)response.StatusCode >= 400 && (int)response.StatusCode < 500)
+                return await CommonValidationForRequestClientErrorCodesAsync(response);
+
+            string? responseBody = await response.Content.ReadAsStringAsync();
+            List<GatewayClaim> CustomClaims = JsonSerializer.Deserialize<List<GatewayClaim>>(responseBody, new JsonSerializerOptions { PropertyNameCaseInsensitive = true })!;
+
+            return Ok(CustomClaims);
+        }
+        catch (Exception)
+        {
+            return StatusCode(500);
+        }
+    }
+
+    [HttpPost("UpdateClaimsOfRole")]
+    public async Task<IActionResult> UpdateClaimsOfRole([FromBody] GatewayApiUpdateClaimsOfRoleRequestModel gatewayApiUpdateClaimsOfRoleRequestModel)
+    {
+        try
+        {
+            //update the claims of the role
+            _utilityMethods.SetDefaultHeadersForClient(true, authHttpClient, _configuration["AuthApiKey"]!, _configuration["AuthRateLimitingBypassCode"]!, HttpContext.Request);
+            HttpResponseMessage? response = await authHttpClient.PostAsJsonAsync("Role/UpdateClaimsOfRole",
+                new { RoleId = gatewayApiUpdateClaimsOfRoleRequestModel.RoleId, NewClaims = gatewayApiUpdateClaimsOfRoleRequestModel.NewClaims });
+
+            //validate that removing the claims from the role has worked
+            int retries = 3;
+            while ((int)response.StatusCode >= 500)
+            {
+                if (retries == 0)
+                    return StatusCode(500, "Internal Server Error");
+
+                response = await authHttpClient.PostAsJsonAsync("Role/UpdateClaimsOfRole",
+                    new { RoleId = gatewayApiUpdateClaimsOfRoleRequestModel.RoleId, NewClaims = gatewayApiUpdateClaimsOfRoleRequestModel.NewClaims });
+                retries--;
+            }
+
+            if ((int)response.StatusCode >= 400 && (int)response.StatusCode < 500)
+                return await CommonValidationForRequestClientErrorCodesAsync(response);
+
+            return NoContent();
+        }
+        catch (Exception)
+        {
+            return StatusCode(500);
+        }
+    }
+
+    private async Task<IActionResult> CommonValidationForRequestClientErrorCodesAsync(HttpResponseMessage response)
+    {
+        string responseBody = await response.Content.ReadAsStringAsync();
+        //in the case there is no body
+        if (string.IsNullOrEmpty(responseBody))
+        {
+            if (response.StatusCode == HttpStatusCode.Unauthorized)
+                return Unauthorized();
+            else if (response.StatusCode == HttpStatusCode.Forbidden)
+                return StatusCode(StatusCodes.Status403Forbidden);
+            else if (response.StatusCode == HttpStatusCode.BadRequest)
+                return BadRequest();
+            else if (response.StatusCode == HttpStatusCode.NotFound)
+                return NotFound();
+            else if (response.StatusCode == HttpStatusCode.MethodNotAllowed)
+                return NotFound();
+
+            return BadRequest(); //this will probably never happen
+        }
+
+        //otherwise
+        var keyValue = JsonSerializer.Deserialize<Dictionary<string, object>>(responseBody);
+        keyValue!.TryGetValue("errorMessage", out object? errorMessageObject);
+        string? errorMessage = errorMessageObject?.ToString() ?? null;
+        keyValue!.TryGetValue("errors", out var errors);
+
+        if (response.StatusCode == HttpStatusCode.Unauthorized && errorMessage is not null)
+            return Unauthorized(new { ErrorMessage = errorMessage });
+        else if (response.StatusCode == HttpStatusCode.Unauthorized)
+            return Unauthorized();
+        else if (response.StatusCode == HttpStatusCode.Forbidden && errorMessage is not null)
+            return StatusCode(StatusCodes.Status403Forbidden, new { ErrorMessage = errorMessage });
+        else if (response.StatusCode == HttpStatusCode.Forbidden)
+            return StatusCode(StatusCodes.Status403Forbidden);
+        else if (response.StatusCode == HttpStatusCode.BadRequest && errorMessage is not null)
+            return BadRequest(new { ErrorMessage = errorMessage });
+        else if (response.StatusCode == HttpStatusCode.BadRequest && errors is not null) //this is for request validation errors
+            return BadRequest(new { Errors = errors });
+        else if (response.StatusCode == HttpStatusCode.NotFound && errorMessage is not null)
+            return NotFound(new { ErrorMessage = errorMessage });
+        else if (response.StatusCode == HttpStatusCode.NotFound)
+            return NotFound();
+        else if (response.StatusCode == HttpStatusCode.MethodNotAllowed)
+            return StatusCode(StatusCodes.Status405MethodNotAllowed);
+
+        return BadRequest(); //this will probably never happen
+    }
+}

--- a/EshopApp.GatewayAPI/Models/GatewayAppRole.cs
+++ b/EshopApp.GatewayAPI/Models/GatewayAppRole.cs
@@ -1,0 +1,12 @@
+﻿using Microsoft.AspNetCore.Identity;
+
+namespace EshopApp.GatewayAPI.Models;
+
+public class GatewayAppRole : IdentityRole
+{
+    public List<GatewayClaim> Claims { get; set; } = new List<GatewayClaim>();
+
+    public GatewayAppRole() { }
+
+    public GatewayAppRole(string givenRoleName) : base(roleName: givenRoleName) { }
+}

--- a/EshopApp.GatewayAPI/Models/GatewayClaim.cs
+++ b/EshopApp.GatewayAPI/Models/GatewayClaim.cs
@@ -1,0 +1,21 @@
+﻿using System.ComponentModel.DataAnnotations;
+using System.Security.Claims;
+
+namespace EshopApp.GatewayAPI.Models;
+
+public class GatewayClaim
+{
+    [Required]
+    public string? Type { get; set; }
+    [Required]
+    public string? Value { get; set; }
+
+    public GatewayClaim() { }
+
+    public GatewayClaim(Claim claim)
+    {
+        Type = claim.Type;
+        Value = claim.Value;
+    }
+
+}

--- a/EshopApp.GatewayAPI/Models/RequestModels/GatewayRoleControllerRequestModels/GatewayApiAddRoleToUserRequestModel.cs
+++ b/EshopApp.GatewayAPI/Models/RequestModels/GatewayRoleControllerRequestModels/GatewayApiAddRoleToUserRequestModel.cs
@@ -1,0 +1,12 @@
+﻿using System.ComponentModel.DataAnnotations;
+
+namespace EshopApp.GatewayAPI.Models.RequestModels.GatewayRoleControllerRequestModels;
+
+public class GatewayApiAddRoleToUserRequestModel
+{
+    [Required]
+    public string? UserId { get; set; }
+
+    [Required]
+    public string? RoleId { get; set; }
+}

--- a/EshopApp.GatewayAPI/Models/RequestModels/GatewayRoleControllerRequestModels/GatewayApiCreateRoleRequestModel.cs
+++ b/EshopApp.GatewayAPI/Models/RequestModels/GatewayRoleControllerRequestModels/GatewayApiCreateRoleRequestModel.cs
@@ -1,0 +1,10 @@
+﻿using System.ComponentModel.DataAnnotations;
+
+namespace EshopApp.GatewayAPI.Models.RequestModels.GatewayRoleControllerRequestModels;
+
+public class GatewayApiCreateRoleRequestModel
+{
+    [Required]
+    public string? RoleName { get; set; }
+    public List<GatewayClaim> Claims { get; set; } = new List<GatewayClaim>();
+}

--- a/EshopApp.GatewayAPI/Models/RequestModels/GatewayRoleControllerRequestModels/GatewayApiReplaceRoleOfUserRequestModel.cs
+++ b/EshopApp.GatewayAPI/Models/RequestModels/GatewayRoleControllerRequestModels/GatewayApiReplaceRoleOfUserRequestModel.cs
@@ -1,0 +1,14 @@
+﻿using System.ComponentModel.DataAnnotations;
+
+namespace EshopApp.GatewayAPI.Models.RequestModels.GatewayRoleControllerRequestModels;
+
+public class GatewayApiReplaceRoleOfUserRequestModel
+{
+    [Required]
+    public string? UserId { get; set; }
+
+    [Required]
+    public string? CurrentRoleId { get; set; }
+    [Required]
+    public string? NewRoleId { get; set; }
+}

--- a/EshopApp.GatewayAPI/Models/RequestModels/GatewayRoleControllerRequestModels/GatewayApiUpdateClaimsOfRoleRequestModel.cs
+++ b/EshopApp.GatewayAPI/Models/RequestModels/GatewayRoleControllerRequestModels/GatewayApiUpdateClaimsOfRoleRequestModel.cs
@@ -1,0 +1,11 @@
+﻿using System.ComponentModel.DataAnnotations;
+
+namespace EshopApp.GatewayAPI.Models.RequestModels.GatewayRoleControllerRequestModels;
+
+public class GatewayApiUpdateClaimsOfRoleRequestModel
+{
+    [Required]
+    public string? RoleId { get; set; }
+    [Required]
+    public List<GatewayClaim> NewClaims { get; set; } = new List<GatewayClaim>();
+}


### PR DESCRIPTION
I added role management endpoints in the gateway api that correspond to each one of the endpoints of the RoleController of the AuthLibraryApi module. There is no much more to add since the tests to those endpoints will be added in the next update, but if I have planned correctly there should not be any further chagnes. One thing I noticed is that in case of getUsers as it stands the user roles are not retrieved, which might cause issues in user management. Yes for each user there is a way to get their role, but that will be a 1 + n requests and database queries, which is totally unacceptable. So if I decide that this needs to be done the auth microservice might change slightly, which might cause also the gateway api to also change, but as it stands I have not changed anything.