### PR TITLE
Added Coupon And Discount Related Endpoints In The Gateway API

### DIFF
--- a/EshopApp.DataLibrary/DataAccess/ImageDataAccess.cs
+++ b/EshopApp.DataLibrary/DataAccess/ImageDataAccess.cs
@@ -7,7 +7,6 @@ using Microsoft.Extensions.Logging.Abstractions;
 
 namespace EshopApp.DataLibrary.DataAccess;
 
-//TODO update this class when orders entity is also added
 public class ImageDataAccess : IImageDataAccess
 {
     private readonly AppDataDbContext _appDataDbContext;

--- a/EshopApp.DataLibraryAPI/Controllers/CouponController.cs
+++ b/EshopApp.DataLibraryAPI/Controllers/CouponController.cs
@@ -229,6 +229,7 @@ public class CouponController : ControllerBase
         }
     }
 
+    //this is only used when the user is deleted, I do not think this should be added in the gateway api as a standalone action
     [HttpDelete("RemoveAllUserCoupons/userId/{userId}")]
     public async Task<IActionResult> RemoveAllUserCoupons(string userId)
     {

--- a/EshopApp.DataLibraryAPI/Models/RequestModels/VariantModels/CreateVariantRequestModel.cs
+++ b/EshopApp.DataLibraryAPI/Models/RequestModels/VariantModels/CreateVariantRequestModel.cs
@@ -22,7 +22,6 @@ public class CreateVariantRequestModel
     public string? ProductId { get; set; }
     [MaxLength(50)]
     public string? DiscountId { get; set; }
-    //TODO can not validate individually each stupid element maybe do something about it in the future..
     public List<string> AttributeIds { get; set; } = new List<string>();
     public List<CreateVariantImageRequestModel> VariantImageRequestModels { get; set; } = new List<CreateVariantImageRequestModel>();
 }

--- a/EshopApp.GatewayAPI/AuthMicroService/SharedModels/GatewayAppUser.cs
+++ b/EshopApp.GatewayAPI/AuthMicroService/SharedModels/GatewayAppUser.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Identity;
+﻿using EshopApp.GatewayAPI.DataMicroService.SharedModels;
+using Microsoft.AspNetCore.Identity;
 
 namespace EshopApp.GatewayAPI.AuthMicroService.Models;
 
@@ -6,5 +7,5 @@ namespace EshopApp.GatewayAPI.AuthMicroService.Models;
 public class GatewayAppUser : IdentityUser
 {
     //TODO add cart here when the other models are added
-    //TODO add user coupons here when the other models are added
+    public List<GatewayUserCoupon> UserCoupons { get; set; } = new List<GatewayUserCoupon>();
 }

--- a/EshopApp.GatewayAPI/DataMicroService/Coupon/GatewayCouponController.cs
+++ b/EshopApp.GatewayAPI/DataMicroService/Coupon/GatewayCouponController.cs
@@ -1,0 +1,544 @@
+﻿using EshopApp.GatewayAPI.DataMicroService.Coupon.Models.RequestModels;
+using EshopApp.GatewayAPI.DataMicroService.SharedModels;
+using EshopApp.GatewayAPI.HelperMethods;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.RateLimiting;
+using System.Net;
+using System.Text.Json;
+
+namespace EshopApp.GatewayAPI.DataMicroService.Coupon;
+
+[ApiController]
+[EnableRateLimiting("DefaultWindowLimiter")]
+[Route("api/[controller]")]
+public class GatewayCouponController : ControllerBase
+{
+    private readonly HttpClient authHttpClient;
+    private readonly HttpClient dataHttpClient;
+    private readonly IConfiguration _configuration;
+    private readonly IUtilityMethods _utilityMethods;
+
+    public GatewayCouponController(IConfiguration configuration, IHttpClientFactory httpClientFactory, IUtilityMethods utilityMethods)
+    {
+        _configuration = configuration;
+        _utilityMethods = utilityMethods;
+        authHttpClient = httpClientFactory.CreateClient("AuthApiClient");
+        dataHttpClient = httpClientFactory.CreateClient("DataApiClient");
+    }
+
+    [HttpGet("Amount/{amount}/includeDeactivated/{includeDeactivated}")]
+    public async Task<IActionResult> GetCoupons(int amount, bool includeDeactivated)
+    {
+        try
+        {
+            //check that an access token has been supplied, this check is made to avoid unnecessary requests
+            if (HttpContext?.Request == null || !HttpContext.Request.Headers.ContainsKey("Authorization") || string.IsNullOrEmpty(HttpContext.Request.Headers["Authorization"]) ||
+                !HttpContext.Request.Headers["Authorization"].ToString().StartsWith("Bearer ", StringComparison.OrdinalIgnoreCase))
+                return Unauthorized(new { ErrorMessage = "NoValidAccessTokenWasProvided" });
+
+            //here there is no reason to check if both microservices are fully online since changes can only occur in the second and final call
+            //authenticate and authorize the user
+            _utilityMethods.SetDefaultHeadersForClient(true, authHttpClient, _configuration["AuthApiKey"]!, _configuration["AuthRateLimitingBypassCode"]!, HttpContext.Request);
+            HttpResponseMessage? response = await authHttpClient.GetAsync("Authentication/GetCurrentUserAndValidateThatTheyHaveGivenClaimsByToken/claimType/Permission/claimValue/CanManageProducts");
+
+            //validate that the authentication and authorization has worked
+            int retries = 3;
+            while ((int)response.StatusCode >= 500)
+            {
+                if (retries == 0)
+                    return StatusCode(500, "Internal Server Error");
+
+                response = await authHttpClient.GetAsync("Authentication/GetCurrentUserAndValidateThatTheyHaveGivenClaimsByToken/claimType/Permission/claimValue/CanManageProducts");
+                retries--;
+            }
+
+            if ((int)response.StatusCode >= 400 && (int)response.StatusCode < 500)
+                return await _utilityMethods.CommonValidationForRequestClientErrorCodesAsync(response);
+
+            //get the coupons
+            _utilityMethods.SetDefaultHeadersForClient(false, dataHttpClient, _configuration["DataApiKey"]!, _configuration["DataRateLimitingBypassCode"]!);
+            response = await dataHttpClient.GetAsync($"Coupon/Amount/{amount}/includeDeactivated/{includeDeactivated}");
+
+            //validate that getting the coupons has worked
+            retries = 3;
+            while ((int)response.StatusCode >= 500)
+            {
+                if (retries == 0)
+                    return StatusCode(500, "Internal Server Error");
+
+                response = await dataHttpClient.GetAsync($"Coupon/Amount/{amount}/includeDeactivated/{includeDeactivated}");
+                retries--;
+            }
+
+            if ((int)response.StatusCode >= 400 && (int)response.StatusCode < 500)
+                return await _utilityMethods.CommonValidationForRequestClientErrorCodesAsync(response);
+
+            string? responseBody = await response.Content.ReadAsStringAsync();
+            List<GatewayCoupon>? coupons = JsonSerializer.Deserialize<List<GatewayCoupon>>(responseBody, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+
+            return Ok(coupons);
+        }
+        catch (Exception)
+        {
+            return StatusCode(500);
+        }
+    }
+
+    [HttpGet("{id}/includeDeactivated/{includeDeactivated}")]
+    public async Task<IActionResult> GetCouponById(string id, bool includeDeactivated)
+    {
+        try
+        {
+            //check that an access token has been supplied, this check is made to avoid unnecessary requests
+            if (HttpContext?.Request == null || !HttpContext.Request.Headers.ContainsKey("Authorization") || string.IsNullOrEmpty(HttpContext.Request.Headers["Authorization"]) ||
+                !HttpContext.Request.Headers["Authorization"].ToString().StartsWith("Bearer ", StringComparison.OrdinalIgnoreCase))
+                return Unauthorized(new { ErrorMessage = "NoValidAccessTokenWasProvided" });
+
+            //here there is no reason to check if both microservices are fully online since changes can only occur in the second and final call
+            //authenticate and authorize the user
+            _utilityMethods.SetDefaultHeadersForClient(true, authHttpClient, _configuration["AuthApiKey"]!, _configuration["AuthRateLimitingBypassCode"]!, HttpContext.Request);
+            HttpResponseMessage? response = await authHttpClient.GetAsync("Authentication/GetCurrentUserAndValidateThatTheyHaveGivenClaimsByToken/claimType/Permission/claimValue/CanManageProducts");
+
+            //validate that the authentication and authorization has worked
+            int retries = 3;
+            while ((int)response.StatusCode >= 500)
+            {
+                if (retries == 0)
+                    return StatusCode(500, "Internal Server Error");
+
+                response = await authHttpClient.GetAsync("Authentication/GetCurrentUserAndValidateThatTheyHaveGivenClaimsByToken/claimType/Permission/claimValue/CanManageProducts");
+                retries--;
+            }
+
+            if ((int)response.StatusCode >= 400 && (int)response.StatusCode < 500)
+                return await _utilityMethods.CommonValidationForRequestClientErrorCodesAsync(response);
+
+            //get the coupon
+            _utilityMethods.SetDefaultHeadersForClient(false, dataHttpClient, _configuration["DataApiKey"]!, _configuration["DataRateLimitingBypassCode"]!);
+            response = await dataHttpClient.GetAsync($"Coupon/{id}/includeDeactivated/{includeDeactivated}");
+
+            //validate that getting the coupon has worked
+            retries = 3;
+            while ((int)response.StatusCode >= 500)
+            {
+                if (retries == 0)
+                    return StatusCode(500, "Internal Server Error");
+
+                response = await dataHttpClient.GetAsync($"Coupon/{id}/includeDeactivated/{includeDeactivated}");
+                retries--;
+            }
+
+            if ((int)response.StatusCode >= 400 && (int)response.StatusCode < 500)
+                return await _utilityMethods.CommonValidationForRequestClientErrorCodesAsync(response);
+
+            string? responseBody = await response.Content.ReadAsStringAsync();
+            GatewayCoupon? coupon = JsonSerializer.Deserialize<GatewayCoupon>(responseBody, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+
+            return Ok(coupon);
+        }
+        catch (Exception)
+        {
+            return StatusCode(500);
+        }
+    }
+
+    [HttpPost]
+    public async Task<IActionResult> CreateCoupon(GatewayCreateCouponRequestModel gatewayCreateCouponRequestModel)
+    {
+        try
+        {
+            //check that an access token has been supplied, this check is made to avoid unnecessary requests
+            if (HttpContext?.Request == null || !HttpContext.Request.Headers.ContainsKey("Authorization") || string.IsNullOrEmpty(HttpContext.Request.Headers["Authorization"]) ||
+                !HttpContext.Request.Headers["Authorization"].ToString().StartsWith("Bearer ", StringComparison.OrdinalIgnoreCase))
+                return Unauthorized(new { ErrorMessage = "NoValidAccessTokenWasProvided" });
+
+            //here there is no reason to check if both microservices are fully online since changes can only occur in the second and final call
+            //authenticate and authorize the user
+            _utilityMethods.SetDefaultHeadersForClient(true, authHttpClient, _configuration["AuthApiKey"]!, _configuration["AuthRateLimitingBypassCode"]!, HttpContext.Request);
+            HttpResponseMessage? response = await authHttpClient.GetAsync("Authentication/GetCurrentUserAndValidateThatTheyHaveGivenClaimsByToken/claimType/Permission/claimValue/CanManageProducts");
+
+            //validate that the authentication and authorization has worked
+            int retries = 3;
+            while ((int)response.StatusCode >= 500)
+            {
+                if (retries == 0)
+                    return StatusCode(500, "Internal Server Error");
+
+                response = await authHttpClient.GetAsync("Authentication/GetCurrentUserAndValidateThatTheyHaveGivenClaimsByToken/claimType/Permission/claimValue/CanManageProducts");
+                retries--;
+            }
+
+            if ((int)response.StatusCode >= 400 && (int)response.StatusCode < 500)
+                return await _utilityMethods.CommonValidationForRequestClientErrorCodesAsync(response);
+
+            //create the coupon
+            _utilityMethods.SetDefaultHeadersForClient(false, dataHttpClient, _configuration["DataApiKey"]!, _configuration["DataRateLimitingBypassCode"]!);
+            response = await dataHttpClient.PostAsJsonAsync("Coupon", gatewayCreateCouponRequestModel);
+
+            //validate that creating the coupon has worked
+            retries = 3;
+            while ((int)response.StatusCode >= 500)
+            {
+                if (retries == 0)
+                    return StatusCode(500, "Internal Server Error");
+
+                response = await dataHttpClient.PostAsJsonAsync("Coupon", gatewayCreateCouponRequestModel);
+                retries--;
+            }
+
+            if ((int)response.StatusCode >= 400 && (int)response.StatusCode < 500)
+                return await _utilityMethods.CommonValidationForRequestClientErrorCodesAsync(response);
+
+            string? responseBody = await response.Content.ReadAsStringAsync();
+            GatewayCoupon? coupon = JsonSerializer.Deserialize<GatewayCoupon>(responseBody, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+
+            return CreatedAtAction(nameof(GetCouponById), new { id = coupon!.Id, includeDeactivated = true }, coupon);
+        }
+        catch (Exception)
+        {
+            return StatusCode(500);
+        }
+    }
+
+    [HttpPut]
+    public async Task<IActionResult> UpdateCoupon(GatewayUpdateCouponRequestModel gatewayUpdateCouponRequestModel)
+    {
+        try
+        {
+            //check that an access token has been supplied, this check is made to avoid unnecessary requests
+            if (HttpContext?.Request == null || !HttpContext.Request.Headers.ContainsKey("Authorization") || string.IsNullOrEmpty(HttpContext.Request.Headers["Authorization"]) ||
+                !HttpContext.Request.Headers["Authorization"].ToString().StartsWith("Bearer ", StringComparison.OrdinalIgnoreCase))
+                return Unauthorized(new { ErrorMessage = "NoValidAccessTokenWasProvided" });
+
+            //here there is no reason to check if both microservices are fully online since changes can only occur in the second and final call
+            //authenticate and authorize the user
+            _utilityMethods.SetDefaultHeadersForClient(true, authHttpClient, _configuration["AuthApiKey"]!, _configuration["AuthRateLimitingBypassCode"]!, HttpContext.Request);
+            HttpResponseMessage? response = await authHttpClient.GetAsync("Authentication/GetCurrentUserAndValidateThatTheyHaveGivenClaimsByToken/claimType/Permission/claimValue/CanManageProducts");
+
+            //validate that the authentication and authorization has worked
+            int retries = 3;
+            while ((int)response.StatusCode >= 500)
+            {
+                if (retries == 0)
+                    return StatusCode(500, "Internal Server Error");
+
+                response = await authHttpClient.GetAsync("Authentication/GetCurrentUserAndValidateThatTheyHaveGivenClaimsByToken/claimType/Permission/claimValue/CanManageProducts");
+                retries--;
+            }
+
+            if ((int)response.StatusCode >= 400 && (int)response.StatusCode < 500)
+                return await _utilityMethods.CommonValidationForRequestClientErrorCodesAsync(response);
+
+            //update the coupon
+            _utilityMethods.SetDefaultHeadersForClient(false, dataHttpClient, _configuration["DataApiKey"]!, _configuration["DataRateLimitingBypassCode"]!);
+            response = await dataHttpClient.PutAsJsonAsync("Coupon", gatewayUpdateCouponRequestModel);
+
+            //validate that updating the coupon has worked
+            retries = 3;
+            while ((int)response.StatusCode >= 500)
+            {
+                if (retries == 0)
+                    return StatusCode(500, "Internal Server Error");
+
+                response = await dataHttpClient.PutAsJsonAsync("Coupon", gatewayUpdateCouponRequestModel);
+                retries--;
+            }
+
+            if ((int)response.StatusCode >= 400 && (int)response.StatusCode < 500)
+                return await _utilityMethods.CommonValidationForRequestClientErrorCodesAsync(response);
+
+            return NoContent();
+        }
+        catch (Exception)
+        {
+            return StatusCode(500);
+        }
+    }
+
+    [HttpDelete("{id}")]
+    public async Task<IActionResult> DeleteCoupon(string id)
+    {
+        try
+        {
+            //check that an access token has been supplied, this check is made to avoid unnecessary requests
+            if (HttpContext?.Request == null || !HttpContext.Request.Headers.ContainsKey("Authorization") || string.IsNullOrEmpty(HttpContext.Request.Headers["Authorization"]) ||
+                !HttpContext.Request.Headers["Authorization"].ToString().StartsWith("Bearer ", StringComparison.OrdinalIgnoreCase))
+                return Unauthorized(new { ErrorMessage = "NoValidAccessTokenWasProvided" });
+
+            //here there is no reason to check if both microservices are fully online since changes can only occur in the second and final call
+            //authenticate and authorize the user
+            _utilityMethods.SetDefaultHeadersForClient(true, authHttpClient, _configuration["AuthApiKey"]!, _configuration["AuthRateLimitingBypassCode"]!, HttpContext.Request);
+            HttpResponseMessage? response = await authHttpClient.GetAsync("Authentication/GetCurrentUserAndValidateThatTheyHaveGivenClaimsByToken/claimType/Permission/claimValue/CanManageProducts");
+
+            //validate that the authentication and authorization has worked
+            int retries = 3;
+            while ((int)response.StatusCode >= 500)
+            {
+                if (retries == 0)
+                    return StatusCode(500, "Internal Server Error");
+
+                response = await authHttpClient.GetAsync("Authentication/GetCurrentUserAndValidateThatTheyHaveGivenClaimsByToken/claimType/Permission/claimValue/CanManageProducts");
+                retries--;
+            }
+
+            if ((int)response.StatusCode >= 400 && (int)response.StatusCode < 500)
+                return await _utilityMethods.CommonValidationForRequestClientErrorCodesAsync(response);
+
+            //delete the coupon
+            _utilityMethods.SetDefaultHeadersForClient(false, dataHttpClient, _configuration["DataApiKey"]!, _configuration["DataRateLimitingBypassCode"]!);
+            response = await dataHttpClient.DeleteAsync($"Coupon/{id}");
+
+            //validate that deleting the coupon has worked
+            retries = 3;
+            while ((int)response.StatusCode >= 500)
+            {
+                if (retries == 0)
+                    return StatusCode(500, "Internal Server Error");
+
+                response = await dataHttpClient.DeleteAsync($"Coupon/{id}");
+                retries--;
+            }
+
+            if ((int)response.StatusCode >= 400 && (int)response.StatusCode < 500)
+                return await _utilityMethods.CommonValidationForRequestClientErrorCodesAsync(response);
+
+            if (response.StatusCode == HttpStatusCode.OK) //this can happen if the coupon exists in an order and thus it only becomes deactivated/soft deleted
+                return Ok(new { WarningMessage = "NoErrorButNotFullyDeleted" });
+
+            return NoContent();
+        }
+        catch (Exception)
+        {
+            return StatusCode(500);
+        }
+    }
+
+    [HttpGet("userId/{userId}/includeDeactivated/{includeDeactivated}")]
+    public async Task<IActionResult> GetCouponsOfUser(string userId, bool includeDeactivated)
+    {
+        try
+        {
+            //check that an access token has been supplied, this check is made to avoid unnecessary requests
+            if (HttpContext?.Request == null || !HttpContext.Request.Headers.ContainsKey("Authorization") || string.IsNullOrEmpty(HttpContext.Request.Headers["Authorization"]) ||
+                !HttpContext.Request.Headers["Authorization"].ToString().StartsWith("Bearer ", StringComparison.OrdinalIgnoreCase))
+                return Unauthorized(new { ErrorMessage = "NoValidAccessTokenWasProvided" });
+
+            //here there is no reason to check if both microservices are fully online since changes can only occur in the second and final call
+            //authenticate and authorize the user, in this case the user needs to be able to manage users
+            _utilityMethods.SetDefaultHeadersForClient(true, authHttpClient, _configuration["AuthApiKey"]!, _configuration["AuthRateLimitingBypassCode"]!, HttpContext.Request);
+            HttpResponseMessage? response = await authHttpClient.GetAsync("Authentication/GetCurrentUserAndValidateThatTheyHaveGivenClaimsByToken/claimType/Permission/claimValue/CanManageUsers");
+
+            //validate that the authentication and authorization has worked
+            int retries = 3;
+            while ((int)response.StatusCode >= 500)
+            {
+                if (retries == 0)
+                    return StatusCode(500, "Internal Server Error");
+
+                response = await authHttpClient.GetAsync("Authentication/GetCurrentUserAndValidateThatTheyHaveGivenClaimsByToken/claimType/Permission/claimValue/CanManageUsers");
+                retries--;
+            }
+
+            if ((int)response.StatusCode >= 400 && (int)response.StatusCode < 500)
+                return await _utilityMethods.CommonValidationForRequestClientErrorCodesAsync(response);
+
+            //get the user coupons
+            _utilityMethods.SetDefaultHeadersForClient(false, dataHttpClient, _configuration["DataApiKey"]!, _configuration["DataRateLimitingBypassCode"]!);
+            response = await dataHttpClient.GetAsync($"Coupon/userId/{userId}/includeDeactivated/{includeDeactivated}");
+
+            //validate that getting the user coupons has worked
+            retries = 3;
+            while ((int)response.StatusCode >= 500)
+            {
+                if (retries == 0)
+                    return StatusCode(500, "Internal Server Error");
+
+                response = await dataHttpClient.GetAsync($"Coupon/userId/{userId}/includeDeactivated/{includeDeactivated}");
+                retries--;
+            }
+
+            if ((int)response.StatusCode >= 400 && (int)response.StatusCode < 500)
+                return await _utilityMethods.CommonValidationForRequestClientErrorCodesAsync(response);
+
+            string? responseBody = await response.Content.ReadAsStringAsync();
+            List<GatewayUserCoupon>? userCoupons = JsonSerializer.Deserialize<List<GatewayUserCoupon>>(responseBody, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+
+            return Ok(userCoupons);
+        }
+        catch (Exception)
+        {
+            return StatusCode(500);
+        }
+    }
+
+    [HttpPost("AddCouponToUser")]
+    public async Task<IActionResult> AddCouponToUser(GatewayAddCouponToUserRequestModel gatewayAddCouponToUserRequestModel)
+    {
+        try
+        {
+            //check that an access token has been supplied, this check is made to avoid unnecessary requests
+            if (HttpContext?.Request == null || !HttpContext.Request.Headers.ContainsKey("Authorization") || string.IsNullOrEmpty(HttpContext.Request.Headers["Authorization"]) ||
+                !HttpContext.Request.Headers["Authorization"].ToString().StartsWith("Bearer ", StringComparison.OrdinalIgnoreCase))
+                return Unauthorized(new { ErrorMessage = "NoValidAccessTokenWasProvided" });
+
+            //here there is no reason to check if both microservices are fully online since changes can only occur in the second and final call
+            //authenticate and authorize the user
+            _utilityMethods.SetDefaultHeadersForClient(true, authHttpClient, _configuration["AuthApiKey"]!, _configuration["AuthRateLimitingBypassCode"]!, HttpContext.Request);
+            HttpResponseMessage? response = await authHttpClient.GetAsync("Authentication/GetCurrentUserAndValidateThatTheyHaveGivenClaimsByToken/claimType/Permission/claimValue/CanManageUsers");
+
+            //validate that the authentication and authorization has worked
+            int retries = 3;
+            while ((int)response.StatusCode >= 500)
+            {
+                if (retries == 0)
+                    return StatusCode(500, "Internal Server Error");
+
+                response = await authHttpClient.GetAsync("Authentication/GetCurrentUserAndValidateThatTheyHaveGivenClaimsByToken/claimType/Permission/claimValue/CanManageUsers");
+                retries--;
+            }
+
+            if ((int)response.StatusCode >= 400 && (int)response.StatusCode < 500)
+                return await _utilityMethods.CommonValidationForRequestClientErrorCodesAsync(response);
+
+            //add the coupon to the user
+            _utilityMethods.SetDefaultHeadersForClient(false, dataHttpClient, _configuration["DataApiKey"]!, _configuration["DataRateLimitingBypassCode"]!);
+            response = await dataHttpClient.PostAsJsonAsync("Coupon/addCouponToUser", gatewayAddCouponToUserRequestModel);
+
+            //validate that adding the coupon to the user has worked
+            retries = 3;
+            while ((int)response.StatusCode >= 500)
+            {
+                if (retries == 0)
+                    return StatusCode(500, "Internal Server Error");
+
+                response = await dataHttpClient.PostAsJsonAsync("Coupon/addCouponToUser", gatewayAddCouponToUserRequestModel);
+                retries--;
+            }
+
+            if ((int)response.StatusCode >= 400 && (int)response.StatusCode < 500)
+                return await _utilityMethods.CommonValidationForRequestClientErrorCodesAsync(response);
+
+            string? responseBody = await response.Content.ReadAsStringAsync();
+            GatewayUserCoupon? userCoupon = JsonSerializer.Deserialize<GatewayUserCoupon>(responseBody, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+
+            return Created("", userCoupon);
+        }
+        catch (Exception)
+        {
+            return StatusCode(500);
+        }
+    }
+
+    [HttpPut("UpdateUserCoupon")]
+    public async Task<IActionResult> UpdateUserCoupon(GatewayUpdateUserCouponRequestModel gatewayUpdateUserCouponRequestModel)
+    {
+        try
+        {
+            //check that an access token has been supplied, this check is made to avoid unnecessary requests
+            if (HttpContext?.Request == null || !HttpContext.Request.Headers.ContainsKey("Authorization") || string.IsNullOrEmpty(HttpContext.Request.Headers["Authorization"]) ||
+                !HttpContext.Request.Headers["Authorization"].ToString().StartsWith("Bearer ", StringComparison.OrdinalIgnoreCase))
+                return Unauthorized(new { ErrorMessage = "NoValidAccessTokenWasProvided" });
+
+            //here there is no reason to check if both microservices are fully online since changes can only occur in the second and final call
+            //authenticate and authorize the user
+            _utilityMethods.SetDefaultHeadersForClient(true, authHttpClient, _configuration["AuthApiKey"]!, _configuration["AuthRateLimitingBypassCode"]!, HttpContext.Request);
+            HttpResponseMessage? response = await authHttpClient.GetAsync("Authentication/GetCurrentUserAndValidateThatTheyHaveGivenClaimsByToken/claimType/Permission/claimValue/CanManageUsers");
+
+            //validate that the authentication and authorization has worked
+            int retries = 3;
+            while ((int)response.StatusCode >= 500)
+            {
+                if (retries == 0)
+                    return StatusCode(500, "Internal Server Error");
+
+                response = await authHttpClient.GetAsync("Authentication/GetCurrentUserAndValidateThatTheyHaveGivenClaimsByToken/claimType/Permission/claimValue/CanManageUsers");
+                retries--;
+            }
+
+            if ((int)response.StatusCode >= 400 && (int)response.StatusCode < 500)
+                return await _utilityMethods.CommonValidationForRequestClientErrorCodesAsync(response);
+
+            //update the user coupon
+            _utilityMethods.SetDefaultHeadersForClient(false, dataHttpClient, _configuration["DataApiKey"]!, _configuration["DataRateLimitingBypassCode"]!);
+            response = await dataHttpClient.PutAsJsonAsync("Coupon/UpdateUserCoupon", gatewayUpdateUserCouponRequestModel);
+
+            //validate that updating the user coupon has worked
+            retries = 3;
+            while ((int)response.StatusCode >= 500)
+            {
+                if (retries == 0)
+                    return StatusCode(500, "Internal Server Error");
+
+                response = await dataHttpClient.PutAsJsonAsync("Coupon/UpdateUserCoupon", gatewayUpdateUserCouponRequestModel);
+                retries--;
+            }
+
+            if ((int)response.StatusCode >= 400 && (int)response.StatusCode < 500)
+                return await _utilityMethods.CommonValidationForRequestClientErrorCodesAsync(response);
+
+            return NoContent();
+        }
+        catch (Exception)
+        {
+            return StatusCode(500);
+        }
+    }
+
+    [HttpDelete("RemoveCouponFromUser/userCouponId/{userCouponId}")]
+    public async Task<IActionResult> RemoveCouponFromUser(string userCouponId)
+    {
+        try
+        {
+            //check that an access token has been supplied, this check is made to avoid unnecessary requests
+            if (HttpContext?.Request == null || !HttpContext.Request.Headers.ContainsKey("Authorization") || string.IsNullOrEmpty(HttpContext.Request.Headers["Authorization"]) ||
+                !HttpContext.Request.Headers["Authorization"].ToString().StartsWith("Bearer ", StringComparison.OrdinalIgnoreCase))
+                return Unauthorized(new { ErrorMessage = "NoValidAccessTokenWasProvided" });
+
+            //here there is no reason to check if both microservices are fully online since changes can only occur in the second and final call
+            //authenticate and authorize the user
+            _utilityMethods.SetDefaultHeadersForClient(true, authHttpClient, _configuration["AuthApiKey"]!, _configuration["AuthRateLimitingBypassCode"]!, HttpContext.Request);
+            HttpResponseMessage? response = await authHttpClient.GetAsync("Authentication/GetCurrentUserAndValidateThatTheyHaveGivenClaimsByToken/claimType/Permission/claimValue/CanManageUsers");
+
+            //validate that the authentication and authorization has worked
+            int retries = 3;
+            while ((int)response.StatusCode >= 500)
+            {
+                if (retries == 0)
+                    return StatusCode(500, "Internal Server Error");
+
+                response = await authHttpClient.GetAsync("Authentication/GetCurrentUserAndValidateThatTheyHaveGivenClaimsByToken/claimType/Permission/claimValue/CanManageUsers");
+                retries--;
+            }
+
+            if ((int)response.StatusCode >= 400 && (int)response.StatusCode < 500)
+                return await _utilityMethods.CommonValidationForRequestClientErrorCodesAsync(response);
+
+            //remove the coupon from the user
+            _utilityMethods.SetDefaultHeadersForClient(false, dataHttpClient, _configuration["DataApiKey"]!, _configuration["DataRateLimitingBypassCode"]!);
+            response = await dataHttpClient.DeleteAsync($"Coupon/RemoveCouponFromUser/userCouponId/{userCouponId}");
+
+            //validate that removing the coupon from the user worked
+            retries = 3;
+            while ((int)response.StatusCode >= 500)
+            {
+                if (retries == 0)
+                    return StatusCode(500, "Internal Server Error");
+
+                response = await dataHttpClient.DeleteAsync($"Coupon/RemoveCouponFromUser/userCouponId/{userCouponId}");
+                retries--;
+            }
+
+            if ((int)response.StatusCode >= 400 && (int)response.StatusCode < 500)
+                return await _utilityMethods.CommonValidationForRequestClientErrorCodesAsync(response);
+
+            if (response.StatusCode == HttpStatusCode.OK) //this can happen if the user coupon exists in an order and thus it only becomes deactivated/soft deleted
+                return Ok(new { WarningMessage = "NoErrorButNotFullyDeleted" });
+
+            return NoContent();
+        }
+        catch (Exception)
+        {
+            return StatusCode(500);
+        }
+    }
+}

--- a/EshopApp.GatewayAPI/DataMicroService/Coupon/Models/RequestModels/GatewayAddCouponToUserRequestModel.cs
+++ b/EshopApp.GatewayAPI/DataMicroService/Coupon/Models/RequestModels/GatewayAddCouponToUserRequestModel.cs
@@ -1,0 +1,21 @@
+﻿using System.ComponentModel.DataAnnotations;
+
+namespace EshopApp.GatewayAPI.DataMicroService.Coupon.Models.RequestModels;
+
+public class GatewayAddCouponToUserRequestModel
+{
+    [MaxLength(50)]
+    public string? Code { get; set; }
+    [Range(0, int.MaxValue, ErrorMessage = "The times used property must be a non-negative integer.")]
+    public int? TimesUsed { get; set; }
+    public bool? IsDeactivated { get; set; }
+    public bool? ExistInOrder { get; set; }
+    public DateTime? StartDate { get; set; }
+    public DateTime? ExpirationDate { get; set; }
+    [Required]
+    [MaxLength(50)]
+    public string? UserId { get; set; }
+    [Required]
+    [MaxLength(50)]
+    public string? CouponId { get; set; }
+}

--- a/EshopApp.GatewayAPI/DataMicroService/Coupon/Models/RequestModels/GatewayCreateCouponRequestModel.cs
+++ b/EshopApp.GatewayAPI/DataMicroService/Coupon/Models/RequestModels/GatewayCreateCouponRequestModel.cs
@@ -1,0 +1,25 @@
+﻿using System.ComponentModel.DataAnnotations;
+
+namespace EshopApp.GatewayAPI.DataMicroService.Coupon.Models.RequestModels;
+
+public class GatewayCreateCouponRequestModel
+{
+    [MaxLength(50)]
+    public string? Code { get; set; }
+    public string? Description { get; set; }
+    [Required]
+    [Range(0, 99, ErrorMessage = "The discount percentage must be an integer value between 0 and 99.")]
+    public int? DiscountPercentage { get; set; }
+    [Required]
+    [Range(0, int.MaxValue, ErrorMessage = "The usage limit must be a non-negative integer.")]
+    public int? UsageLimit { get; set; }
+    [Range(0, int.MaxValue, ErrorMessage = "The default date interval in days must be a non-negative integer.")]
+    public int? DefaultDateIntervalInDays { get; set; }
+    public bool? IsUserSpecific { get; set; }
+    public bool? IsDeactivated { get; set; }
+    [RegularExpression("OnSignUp|OnFirstOrder|OnEveryFiveOrders|OnEveryTenOrders|NoTrigger",
+    ErrorMessage = "The trigger event must have one of the following values: OnSignUp, OnFirstOrder, OnEveryFiveOrders, OnEveryTenOrders, NoTrigger.")]
+    public string? TriggerEvent { get; set; } //OnSignUp - OnFirstOrder - OnEveryFiveOrders - OnEveryTenOrders - NoTrigger
+    public DateTime? StartDate { get; set; }
+    public DateTime? ExpirationDate { get; set; }
+}

--- a/EshopApp.GatewayAPI/DataMicroService/Coupon/Models/RequestModels/GatewayUpdateCouponRequestModel.cs
+++ b/EshopApp.GatewayAPI/DataMicroService/Coupon/Models/RequestModels/GatewayUpdateCouponRequestModel.cs
@@ -1,0 +1,28 @@
+﻿using System.ComponentModel.DataAnnotations;
+
+namespace EshopApp.GatewayAPI.DataMicroService.Coupon.Models.RequestModels;
+
+public class GatewayUpdateCouponRequestModel
+{
+    [Required]
+    [MaxLength(50)]
+    public string? Id { get; set; }
+    [MaxLength(50)]
+    public string? Code { get; set; }
+    public string? Description { get; set; }
+    [Required]
+    [Range(0, 99, ErrorMessage = "The discount percentage must be an integer value between 0 and 99.")]
+    public int? DiscountPercentage { get; set; }
+    [Required]
+    [Range(0, int.MaxValue, ErrorMessage = "The usage limit must be a non-negative integer.")]
+    public int? UsageLimit { get; set; }
+    [Range(0, int.MaxValue, ErrorMessage = "The default date interval in days must be a non-negative integer.")]
+    public int? DefaultDateIntervalInDays { get; set; }
+    public bool? IsDeactivated { get; set; }
+    [RegularExpression("OnSignUp|OnFirstOrder|OnEveryFiveOrders|OnEveryTenOrders|NoTrigger",
+    ErrorMessage = "The trigger event must have one of the following values: OnSignUp, OnFirstOrder, OnEveryFiveOrders, OnEveryTenOrders, NoTrigger.")]
+    public string? TriggerEvent { get; set; } //OnSignUp - OnFirstOrder - OnEveryFiveOrders - OnEveryTenOrders - NoTrigger
+    public DateTime? StartDate { get; set; }
+    public DateTime? ExpirationDate { get; set; }
+    public List<string>? UserCouponIds { get; set; }
+}

--- a/EshopApp.GatewayAPI/DataMicroService/Coupon/Models/RequestModels/GatewayUpdateUserCouponRequestModel.cs
+++ b/EshopApp.GatewayAPI/DataMicroService/Coupon/Models/RequestModels/GatewayUpdateUserCouponRequestModel.cs
@@ -1,0 +1,18 @@
+﻿using System.ComponentModel.DataAnnotations;
+
+namespace EshopApp.GatewayAPI.DataMicroService.Coupon.Models.RequestModels;
+
+public class GatewayUpdateUserCouponRequestModel
+{
+    [Required]
+    [MaxLength(50)]
+    public string? Id { get; set; }
+    [MaxLength(50)]
+    public string? Code { get; set; }
+    [Range(0, int.MaxValue, ErrorMessage = "The times used property must be a non-negative integer.")]
+    public int? TimesUsed { get; set; }
+    public bool? IsDeactivated { get; set; }
+    public bool? ExistInOrder { get; set; }
+    public DateTime? StartDate { get; set; }
+    public DateTime? ExpirationDate { get; set; }
+}

--- a/EshopApp.GatewayAPI/DataMicroService/Discount/GatewayDiscountController.cs
+++ b/EshopApp.GatewayAPI/DataMicroService/Discount/GatewayDiscountController.cs
@@ -1,0 +1,268 @@
+﻿using EshopApp.GatewayAPI.DataMicroService.Discount.Models.RequestModels;
+using EshopApp.GatewayAPI.DataMicroService.SharedModels;
+using EshopApp.GatewayAPI.HelperMethods;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.RateLimiting;
+using System.Net;
+using System.Text.Json;
+
+namespace EshopApp.GatewayAPI.DataMicroService.Discount;
+
+[ApiController]
+[EnableRateLimiting("DefaultWindowLimiter")]
+[Route("api/[controller]")]
+public class GatewayDiscountController : ControllerBase
+{
+    private readonly HttpClient authHttpClient;
+    private readonly HttpClient dataHttpClient;
+    private readonly IConfiguration _configuration;
+    private readonly IUtilityMethods _utilityMethods;
+
+    public GatewayDiscountController(IConfiguration configuration, IHttpClientFactory httpClientFactory, IUtilityMethods utilityMethods)
+    {
+        _configuration = configuration;
+        _utilityMethods = utilityMethods;
+        authHttpClient = httpClientFactory.CreateClient("AuthApiClient");
+        dataHttpClient = httpClientFactory.CreateClient("DataApiClient");
+    }
+
+    [HttpGet("Amount/{amount}/includeDeactivated/{includeDeactivated}")]
+    public async Task<IActionResult> GetDiscounts(int amount, bool includeDeactivated)
+    {
+        try
+        {
+            //get the discounts
+            _utilityMethods.SetDefaultHeadersForClient(false, dataHttpClient, _configuration["DataApiKey"]!, _configuration["DataRateLimitingBypassCode"]!);
+            HttpResponseMessage? response = await dataHttpClient.GetAsync($"Discount/Amount/{amount}/includeDeactivated/{includeDeactivated}");
+
+
+            //validate that getting the discounts has worked
+            int retries = 3;
+            while ((int)response.StatusCode >= 500)
+            {
+                if (retries == 0)
+                    return StatusCode(500, "Internal Server Error");
+
+                response = await dataHttpClient.GetAsync($"Discount/Amount/{amount}/includeDeactivated/{includeDeactivated}");
+                retries--;
+            }
+
+            if ((int)response.StatusCode >= 400 && (int)response.StatusCode < 500)
+                return await _utilityMethods.CommonValidationForRequestClientErrorCodesAsync(response);
+
+            string? responseBody = await response.Content.ReadAsStringAsync();
+            List<GatewayDiscount>? discounts = JsonSerializer.Deserialize<List<GatewayDiscount>>(responseBody, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+
+            return Ok(discounts);
+        }
+        catch (Exception)
+        {
+            return StatusCode(500);
+        }
+    }
+
+    [HttpGet("{id}/includeDeactivated/{includeDeactivated}")]
+    public async Task<IActionResult> GetDiscountById(string id, bool includeDeactivated)
+    {
+        try
+        {
+            //get the discount
+            _utilityMethods.SetDefaultHeadersForClient(false, dataHttpClient, _configuration["DataApiKey"]!, _configuration["DataRateLimitingBypassCode"]!);
+            HttpResponseMessage? response = await dataHttpClient.GetAsync($"Discount/{id}/includeDeactivated/{includeDeactivated}");
+
+            //validate that getting the discount has worked
+            int retries = 3;
+            while ((int)response.StatusCode >= 500)
+            {
+                if (retries == 0)
+                    return StatusCode(500, "Internal Server Error");
+
+                response = await dataHttpClient.GetAsync($"Discount/{id}/includeDeactivated/{includeDeactivated}");
+                retries--;
+            }
+
+            if ((int)response.StatusCode >= 400 && (int)response.StatusCode < 500)
+                return await _utilityMethods.CommonValidationForRequestClientErrorCodesAsync(response);
+
+            string? responseBody = await response.Content.ReadAsStringAsync();
+            GatewayDiscount? discount = JsonSerializer.Deserialize<GatewayDiscount>(responseBody, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+
+            return Ok(discount);
+        }
+        catch (Exception)
+        {
+            return StatusCode(500);
+        }
+    }
+
+    [HttpPost]
+    public async Task<IActionResult> CreateDiscount(GatewayCreateDiscountRequestModel gatewayCreateDiscountRequestModel)
+    {
+        try
+        {
+            //check that an access token has been supplied, this check is made to avoid unnecessary requests
+            if (HttpContext?.Request == null || !HttpContext.Request.Headers.ContainsKey("Authorization") || string.IsNullOrEmpty(HttpContext.Request.Headers["Authorization"]) ||
+                !HttpContext.Request.Headers["Authorization"].ToString().StartsWith("Bearer ", StringComparison.OrdinalIgnoreCase))
+                return Unauthorized(new { ErrorMessage = "NoValidAccessTokenWasProvided" });
+
+            //here there is no reason to check if both microservices are fully online since changes can only occur in the second and final call
+            //authenticate and authorize the user
+            _utilityMethods.SetDefaultHeadersForClient(true, authHttpClient, _configuration["AuthApiKey"]!, _configuration["AuthRateLimitingBypassCode"]!, HttpContext.Request);
+            HttpResponseMessage? response = await authHttpClient.GetAsync("Authentication/GetCurrentUserAndValidateThatTheyHaveGivenClaimsByToken/claimType/Permission/claimValue/CanManageProducts");
+
+            //validate that the authentication and authorization has worked
+            int retries = 3;
+            while ((int)response.StatusCode >= 500)
+            {
+                if (retries == 0)
+                    return StatusCode(500, "Internal Server Error");
+
+                response = await authHttpClient.GetAsync("Authentication/GetCurrentUserAndValidateThatTheyHaveGivenClaimsByToken/claimType/Permission/claimValue/CanManageProducts");
+                retries--;
+            }
+
+            if ((int)response.StatusCode >= 400 && (int)response.StatusCode < 500)
+                return await _utilityMethods.CommonValidationForRequestClientErrorCodesAsync(response);
+
+            //create the discount
+            _utilityMethods.SetDefaultHeadersForClient(false, dataHttpClient, _configuration["DataApiKey"]!, _configuration["DataRateLimitingBypassCode"]!);
+            response = await dataHttpClient.PostAsJsonAsync("Discount", gatewayCreateDiscountRequestModel);
+
+            //validate that creating the discount has worked
+            retries = 3;
+            while ((int)response.StatusCode >= 500)
+            {
+                if (retries == 0)
+                    return StatusCode(500, "Internal Server Error");
+
+                response = await dataHttpClient.PostAsJsonAsync("Discount", gatewayCreateDiscountRequestModel);
+                retries--;
+            }
+
+            if ((int)response.StatusCode >= 400 && (int)response.StatusCode < 500)
+                return await _utilityMethods.CommonValidationForRequestClientErrorCodesAsync(response);
+
+            string? responseBody = await response.Content.ReadAsStringAsync();
+            GatewayDiscount? discount = JsonSerializer.Deserialize<GatewayDiscount>(responseBody, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+
+            return CreatedAtAction(nameof(GetDiscountById), new { id = discount!.Id, includeDeactivated = true }, discount);
+        }
+        catch (Exception)
+        {
+            return StatusCode(500);
+        }
+    }
+
+    [HttpPut]
+    public async Task<IActionResult> UpdateDiscount(GatewayUpdateDiscountRequestModel gatewayUpdateDiscountRequestModel)
+    {
+        try
+        {
+            //check that an access token has been supplied, this check is made to avoid unnecessary requests
+            if (HttpContext?.Request == null || !HttpContext.Request.Headers.ContainsKey("Authorization") || string.IsNullOrEmpty(HttpContext.Request.Headers["Authorization"]) ||
+                !HttpContext.Request.Headers["Authorization"].ToString().StartsWith("Bearer ", StringComparison.OrdinalIgnoreCase))
+                return Unauthorized(new { ErrorMessage = "NoValidAccessTokenWasProvided" });
+
+            //here there is no reason to check if both microservices are fully online since changes can only occur in the second and final call
+            //authenticate and authorize the user
+            _utilityMethods.SetDefaultHeadersForClient(true, authHttpClient, _configuration["AuthApiKey"]!, _configuration["AuthRateLimitingBypassCode"]!, HttpContext.Request);
+            HttpResponseMessage? response = await authHttpClient.GetAsync("Authentication/GetCurrentUserAndValidateThatTheyHaveGivenClaimsByToken/claimType/Permission/claimValue/CanManageProducts");
+
+            //validate that the authentication and authorization has worked
+            int retries = 3;
+            while ((int)response.StatusCode >= 500)
+            {
+                if (retries == 0)
+                    return StatusCode(500, "Internal Server Error");
+
+                response = await authHttpClient.GetAsync("Authentication/GetCurrentUserAndValidateThatTheyHaveGivenClaimsByToken/claimType/Permission/claimValue/CanManageProducts");
+                retries--;
+            }
+
+            if ((int)response.StatusCode >= 400 && (int)response.StatusCode < 500)
+                return await _utilityMethods.CommonValidationForRequestClientErrorCodesAsync(response);
+
+            //update the discount
+            _utilityMethods.SetDefaultHeadersForClient(false, dataHttpClient, _configuration["DataApiKey"]!, _configuration["DataRateLimitingBypassCode"]!);
+            response = await dataHttpClient.PutAsJsonAsync("Discount", gatewayUpdateDiscountRequestModel);
+
+            //validate that updating the discount has worked
+            retries = 3;
+            while ((int)response.StatusCode >= 500)
+            {
+                if (retries == 0)
+                    return StatusCode(500, "Internal Server Error");
+
+                response = await dataHttpClient.PutAsJsonAsync("Discount", gatewayUpdateDiscountRequestModel);
+                retries--;
+            }
+
+            if ((int)response.StatusCode >= 400 && (int)response.StatusCode < 500)
+                return await _utilityMethods.CommonValidationForRequestClientErrorCodesAsync(response);
+
+            return NoContent();
+        }
+        catch (Exception)
+        {
+            return StatusCode(500);
+        }
+    }
+
+    [HttpDelete("{id}")]
+    public async Task<IActionResult> DeleteDiscount(string id)
+    {
+        try
+        {
+            //check that an access token has been supplied, this check is made to avoid unnecessary requests
+            if (HttpContext?.Request == null || !HttpContext.Request.Headers.ContainsKey("Authorization") || string.IsNullOrEmpty(HttpContext.Request.Headers["Authorization"]) ||
+                !HttpContext.Request.Headers["Authorization"].ToString().StartsWith("Bearer ", StringComparison.OrdinalIgnoreCase))
+                return Unauthorized(new { ErrorMessage = "NoValidAccessTokenWasProvided" });
+
+            //here there is no reason to check if both microservices are fully online since changes can only occur in the second and final call
+            //authenticate and authorize the user
+            _utilityMethods.SetDefaultHeadersForClient(true, authHttpClient, _configuration["AuthApiKey"]!, _configuration["AuthRateLimitingBypassCode"]!, HttpContext.Request);
+            HttpResponseMessage? response = await authHttpClient.GetAsync("Authentication/GetCurrentUserAndValidateThatTheyHaveGivenClaimsByToken/claimType/Permission/claimValue/CanManageProducts");
+
+            //validate that the authentication and authorization has worked
+            int retries = 3;
+            while ((int)response.StatusCode >= 500)
+            {
+                if (retries == 0)
+                    return StatusCode(500, "Internal Server Error");
+
+                response = await authHttpClient.GetAsync("Authentication/GetCurrentUserAndValidateThatTheyHaveGivenClaimsByToken/claimType/Permission/claimValue/CanManageProducts");
+                retries--;
+            }
+
+            if ((int)response.StatusCode >= 400 && (int)response.StatusCode < 500)
+                return await _utilityMethods.CommonValidationForRequestClientErrorCodesAsync(response);
+
+            //delete the discount
+            _utilityMethods.SetDefaultHeadersForClient(false, dataHttpClient, _configuration["DataApiKey"]!, _configuration["DataRateLimitingBypassCode"]!);
+            response = await dataHttpClient.DeleteAsync($"Discount/{id}");
+
+            //validate that deleting the discount has worked
+            retries = 3;
+            while ((int)response.StatusCode >= 500)
+            {
+                if (retries == 0)
+                    return StatusCode(500, "Internal Server Error");
+
+                response = await dataHttpClient.DeleteAsync($"Discount/{id}");
+                retries--;
+            }
+
+            if ((int)response.StatusCode >= 400 && (int)response.StatusCode < 500)
+                return await _utilityMethods.CommonValidationForRequestClientErrorCodesAsync(response);
+
+            if (response.StatusCode == HttpStatusCode.OK) //this can happen if the discount exists in an order and thus it only becomes deactivated/soft deleted
+                return Ok(new { WarningMessage = "NoErrorButNotFullyDeleted" });
+
+            return NoContent();
+        }
+        catch (Exception)
+        {
+            return StatusCode(500);
+        }
+    }
+}

--- a/EshopApp.GatewayAPI/DataMicroService/Discount/Models/RequestModels/GatewayCreateDiscountRequestModel.cs
+++ b/EshopApp.GatewayAPI/DataMicroService/Discount/Models/RequestModels/GatewayCreateDiscountRequestModel.cs
@@ -1,0 +1,14 @@
+﻿using System.ComponentModel.DataAnnotations;
+
+namespace EshopApp.GatewayAPI.DataMicroService.Discount.Models.RequestModels;
+
+public class GatewayCreateDiscountRequestModel
+{
+    [Required]
+    [MaxLength(50)]
+    public string? Name { get; set; }
+    [Required]
+    [Range(1, 99, ErrorMessage = "Percentage must be between 1 and 99")]
+    public int? Percentage { get; set; }
+    public bool? IsDeactivated { get; set; }
+}

--- a/EshopApp.GatewayAPI/DataMicroService/Discount/Models/RequestModels/GatewayUpdateDiscountRequestModel.cs
+++ b/EshopApp.GatewayAPI/DataMicroService/Discount/Models/RequestModels/GatewayUpdateDiscountRequestModel.cs
@@ -1,0 +1,16 @@
+﻿using System.ComponentModel.DataAnnotations;
+
+namespace EshopApp.GatewayAPI.DataMicroService.Discount.Models.RequestModels;
+
+public class GatewayUpdateDiscountRequestModel
+{
+    [Required]
+    [MaxLength(50)]
+    public string? Id { get; set; }
+    [MaxLength(50)]
+    public string? Name { get; set; }
+    [Range(1, 99, ErrorMessage = "Percentage must be between 1 and 99")]
+    public int? Percentage { get; set; }
+    public bool? IsDeactivated { get; set; }
+    public List<string>? VariantIds { get; set; }
+}

--- a/EshopApp.GatewayAPI/DataMicroService/SharedModels/GatewayCoupon.cs
+++ b/EshopApp.GatewayAPI/DataMicroService/SharedModels/GatewayCoupon.cs
@@ -1,0 +1,19 @@
+﻿namespace EshopApp.GatewayAPI.DataMicroService.SharedModels;
+
+public class GatewayCoupon
+{
+    public string? Id { get; set; }
+    public string? Code { get; set; }
+    public string? Description { get; set; }
+    public int? DiscountPercentage { get; set; }
+    public int? UsageLimit { get; set; }
+    public int? DefaultDateIntervalInDays { get; set; }
+    public bool? IsUserSpecific { get; set; }
+    public bool? IsDeactivated { get; set; }
+    public string? TriggerEvent { get; set; } //OnSignUp - OnFirstOrder - OnEveryFiveOrders - OnEveryTenOrders - NoTrigger
+    public DateTime? StartDate { get; set; }
+    public DateTime? ExpirationDate { get; set; }
+    public DateTime CreatedAt { get; set; }
+    public DateTime ModifiedAt { get; set; }
+    public List<GatewayUserCoupon> UserCoupons { get; set; } = new List<GatewayUserCoupon>();
+}

--- a/EshopApp.GatewayAPI/DataMicroService/SharedModels/GatewayDiscount.cs
+++ b/EshopApp.GatewayAPI/DataMicroService/SharedModels/GatewayDiscount.cs
@@ -1,0 +1,14 @@
+﻿namespace EshopApp.GatewayAPI.DataMicroService.SharedModels;
+
+public class GatewayDiscount
+{
+    public string? Id { get; set; }
+    public string? Name { get; set; }
+    public int? Percentage { get; set; }
+    public string? Description { get; set; }
+    public bool? IsDeactivated { get; set; }
+    public DateTime CreatedAt { get; set; }
+    public DateTime ModifiedAt { get; set; }
+    public List<GatewayVariant> Variants { get; set; } = new List<GatewayVariant>();
+    //public List<OrderItem> OrderItems { get; set; } = new List<OrderItem>(); TODO add this later
+}

--- a/EshopApp.GatewayAPI/DataMicroService/SharedModels/GatewayUserCoupon.cs
+++ b/EshopApp.GatewayAPI/DataMicroService/SharedModels/GatewayUserCoupon.cs
@@ -1,0 +1,18 @@
+﻿namespace EshopApp.GatewayAPI.DataMicroService.SharedModels;
+
+public class GatewayUserCoupon
+{
+    public string? Id { get; set; }
+    public string? Code { get; set; }
+    public int? TimesUsed { get; set; }
+    public bool? IsDeactivated { get; set; }
+    public bool? ExistsInOrder { get; set; }
+    public DateTime? StartDate { get; set; } //nullable for implementation StartDate & ExpirationDate will always be filled
+    public DateTime? ExpirationDate { get; set; }
+    public DateTime CreatedAt { get; set; }
+    public DateTime ModifiedAt { get; set; }
+    public string? UserId { get; set; }
+    public string? CouponId { get; set; }
+    public GatewayCoupon? Coupon { get; set; }
+    //public List<Order> Orders { get; set; } = new List<Order>(); will be added later
+}

--- a/EshopApp.GatewayAPI/DataMicroService/SharedModels/GatewayVariant.cs
+++ b/EshopApp.GatewayAPI/DataMicroService/SharedModels/GatewayVariant.cs
@@ -13,8 +13,8 @@ public class GatewayVariant
     public DateTime ModifiedAt { get; set; }
     public string? ProductId { get; set; }
     public GatewayProduct? Product { get; set; }
-    //public string? DiscountId { get; set; }
-    //public Discount? Discount { get; set; }
+    public string? DiscountId { get; set; }
+    public GatewayDiscount? Discount { get; set; }
     public List<GatewayAppAttribute> Attributes { get; set; } = new List<GatewayAppAttribute>();
     public List<GatewayVariantImage> VariantImages { get; set; } = new List<GatewayVariantImage>();
     //public List<OrderItem> OrderItems { get; set; } = new List<OrderItem>();


### PR DESCRIPTION
I added coupon and discount related endpoints in the gateway api, which can be used to access the corresponding discount and coupon endpoints of the data microservice. In general it was mostly calling those endpoints, but in most endpoints there is also added authentication and authorization. An important difference with previous authorization is that for the usercoupons instead of checking for CanManageProducts claim the endpoint checks for the CanManageUsers claim. The admin endpoints GetUserById, GetUserByEmail, and the authentication endpoint GetUserByAccessToken of the gateway api have also been updated and now they also retrieve the user coupons(maybe I should make this optional). Other than there is not much to add, but it should be noted that the endpoints will be tested in the next update, so certain things might change.